### PR TITLE
Update to reflect dependency changes

### DIFF
--- a/internal/tracing/client/tracing.go
+++ b/internal/tracing/client/tracing.go
@@ -32,8 +32,8 @@ func Interceptor(ctx context.Context, method string, req, reply interface{}, cc 
 func setTraceStatus(ctx context.Context, err error) {
 	if err != nil {
 		s, _ := status.FromError(err)
-		trace.SpanFromContext(ctx).SetStatus(s.Code())
+		trace.SpanFromContext(ctx).SetStatus(s.Code(), s.Message())
 	} else {
-		trace.SpanFromContext(ctx).SetStatus(codes.OK)
+		trace.SpanFromContext(ctx).SetStatus(codes.OK, "OK")
 	}
 }

--- a/internal/tracing/exporters/common/common.go
+++ b/internal/tracing/exporters/common/common.go
@@ -18,7 +18,7 @@ func ExtractEntry(_ context.Context, data *trace.SpanData) log.Entry {
 		Name:     data.Name,
 		SpanID:   spanId,
 		ParentID: parentId,
-		Status:   data.Status.String(),
+		Status:   fmt.Sprintf("%v: %v", data.StatusCode, data.StatusMessage),
 	}
 
 	for _, event := range data.MessageEvents {

--- a/pkg/protos/Stepper/stepper.pb.go
+++ b/pkg/protos/Stepper/stepper.pb.go
@@ -214,11 +214,11 @@ var fileDescriptor_fd4a41c05ff9560e = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // StepperClient is the client API for Stepper service.
 //
@@ -238,10 +238,10 @@ type StepperClient interface {
 }
 
 type stepperClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewStepperClient(cc *grpc.ClientConn) StepperClient {
+func NewStepperClient(cc grpc.ClientConnInterface) StepperClient {
 	return &stepperClient{cc}
 }
 

--- a/pkg/protos/monitor/monitor.pb.go
+++ b/pkg/protos/monitor/monitor.pb.go
@@ -795,11 +795,11 @@ var fileDescriptor_318189739c1c4c20 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // MonitorClient is the client API for Monitor service.
 //
@@ -810,10 +810,10 @@ type MonitorClient interface {
 }
 
 type monitorClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewMonitorClient(cc *grpc.ClientConn) MonitorClient {
+func NewMonitorClient(cc grpc.ClientConnInterface) MonitorClient {
 	return &monitorClient{cc}
 }
 
@@ -887,10 +887,10 @@ type InventoryClient interface {
 }
 
 type inventoryClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewInventoryClient(cc *grpc.ClientConn) InventoryClient {
+func NewInventoryClient(cc grpc.ClientConnInterface) InventoryClient {
 	return &inventoryClient{cc}
 }
 

--- a/tools/fetch_imports.cmd
+++ b/tools/fetch_imports.cmd
@@ -14,7 +14,7 @@ rem fetch & install the protobuf validation plugin
 rem
 go get -d github.com/envoyproxy/protoc-gen-validate
 pushd %GOPATH%\src\github.com\envoyproxy\protoc-gen-validate
-make build
+go install .
 popd
 
 
@@ -24,6 +24,8 @@ go get github.com/gorilla/mux
 go get github.com/gorilla/securecookie
 go get github.com/gorilla/sessions
 
+go get github.com/davecgh/go-spew/spew
+go get github.com/pmezard/go-difflib/difflib
 go get github.com/stretchr/testify/assert
 
 go get go.opentelemetry.io/otel

--- a/tools/fetchall.cmd
+++ b/tools/fetchall.cmd
@@ -13,7 +13,7 @@ rem fetch & install the protobuf validation plugin
 rem
 go get -d github.com/envoyproxy/protoc-gen-validate
 pushd %GOPATH%\src\github.com\envoyproxy\protoc-gen-validate
-make build
+go install .
 popd
 
 
@@ -23,6 +23,8 @@ go get github.com/gorilla/mux
 go get github.com/gorilla/securecookie
 go get github.com/gorilla/sessions
 
+go get github.com/davecgh/go-spew/spew
+go get github.com/pmezard/go-difflib/difflib
 go get github.com/stretchr/testify/assert
 
 go get go.opentelemetry.io/otel

--- a/tools/updateall.cmd
+++ b/tools/updateall.cmd
@@ -8,7 +8,7 @@ rem fetch & install the protobuf validation plugin
 rem
 go get -d github.com/envoyproxy/protoc-gen-validate
 pushd %GOPATH%\src\github.com\envoyproxy\protoc-gen-validate
-make build
+go install .
 popd
 
 
@@ -18,6 +18,8 @@ go get -u github.com/gorilla/mux
 go get -u github.com/gorilla/securecookie
 go get -u github.com/gorilla/sessions
 
+go get -u github.com/davecgh/go-spew/spew
+go get -u github.com/pmezard/go-difflib/difflib
 go get -u github.com/stretchr/testify/assert
 
 go get -u go.opentelemetry.io/otel


### PR DESCRIPTION
Incorporate changes in opentelemetry api changes, and in the latest grpc output.
Add cmd file updates to fetch the libraries.