### PR TITLE
Tools 20200420

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /pkg/protos/**/*.go
 /.idea/
 *~
+/**/#*#

--- a/build/buildall.cmd
+++ b/build/buildall.cmd
@@ -6,35 +6,42 @@
 
 @rem @if /i "%DbgScript%" == "" @echo off
 
-rem Generate a usable timestamp that we can use to generate a readme file containing
-rem the build time along with anything else we believe to be useful.
-rem
-rem Note - expects source date format to be US style MONTH/DAY/YEAR
-rem 
-setlocal
+@rem Generate a usable timestamp that we can use to generate a readme file containing
+@rem the build time along with anything else we believe to be useful.
+@rem
+@rem Note - expects source date format to be US style MONTH/DAY/YEAR
+@rem 
+@setlocal
 
-set UpdateDate=%date%
-set UpdateTime=%time%
+@set UpdateDate=%date%
+@set UpdateTime=%time%
 
-set UpdateYear=%UpdateDate:~10,4%
-set UpdateDay=%UpdateDate:~7,2%
-set UpdateMonth=%UpdateDate:~4,2%
+@set UpdateYear=%UpdateDate:~10,4%
+@set UpdateDay=%UpdateDate:~7,2%
+@set UpdateMonth=%UpdateDate:~4,2%
 
-set UpdateHour=%UpdateTime:~0,2%
-set UpdateMinute=%UpdateTime:~3,2%
-set UpdateSecond=%UpdateTime:~6,2%
+@set UpdateHour=%UpdateTime:~0,2%
+@set UpdateMinute=%UpdateTime:~3,2%
+@set UpdateSecond=%UpdateTime:~6,2%
 
-rem Allow for some variants dumping the time var with a leading space rather than a leading zero.
-rem
-if " " == "%UpdateHour:~0,1%" set UpdateHour=0%UpdateHour:~1,1%
+@rem Allow for some variants dumping the time var with a leading space rather than a leading zero.
+@rem
+@if " " == "%UpdateHour:~0,1%" set UpdateHour=0%UpdateHour:~1,1%
 
-set UpdateDateTime=%UpdateYear%%UpdateMonth%%UpdateDay%-%UpdateHour%%UpdateMinute%%UpdateSecond%
+@set UpdateDateTime=%UpdateYear%%UpdateMonth%%UpdateDay%-%UpdateHour%%UpdateMinute%%UpdateSecond%
+
+
+@rem Update PATH to include the tools from the local Go environment. This is a temporary update
+@rem due to the SETLOCAL above, and the PATH will return to its earlier value following the
+@rem ENDLOCAL below
+@rem 
+@set PATH=%PATH%;%GOPATH%\bin
+
+@set CCRoot=github.com\Jim3Things\CloudChamber
+@set CCDeployments=%CCRoot%\deployments
 
 
 pushd %gopath%\src
-
-set CCRoot=github.com\Jim3Things\CloudChamber
-set CCDeployments=%CCRoot%\deployments
 
 protoc --go_out=. --validate_out=lang=go:. github.com\Jim3Things\CloudChamber\pkg\protos\admin\users.proto
 protoc --go_out=. --validate_out=lang=go:. github.com\Jim3Things\CloudChamber\pkg\protos\common\capacity.proto
@@ -67,6 +74,6 @@ echo rem >> %CCDeployments%\readme.md
 echo rem >> %CCDeployments%\readme.md
 echo BuildTimeStamp %UpdateDateTime% >> %CCDeployments%\readme.md
 
-endlocal
 popd
 
+@endlocal

--- a/build/dev_tools/fetchall.cmd
+++ b/build/dev_tools/fetchall.cmd
@@ -6,7 +6,14 @@ if /i "%GOPATH%" == "" (
 pushd %GOPATH%\src
 
 go get github.com/golang/protobuf
+
+
+rem fetch & install the protobuf compiler for Go
+rem
 go get github.com/golang/protobuf/protoc-gen-go
+pushd %GOPATH%\src\github.com\golang\protobuf\protoc-gen-go
+go install .
+popd
 
 
 rem fetch & install the protobuf validation plugin
@@ -17,23 +24,22 @@ go install .
 popd
 
 
-go get go.etcd.io/etcd
-
 go get github.com/gorilla/mux
 go get github.com/gorilla/securecookie
 go get github.com/gorilla/sessions
 
 go get github.com/davecgh/go-spew/spew
 go get github.com/pmezard/go-difflib/difflib
+go get github.com/spf13/viper
 go get github.com/stretchr/testify/assert
+
+go get go.etcd.io/etcd
 
 go get go.opentelemetry.io/otel
 
 go get google.golang.org/grpc
 
 go get golang.org/x/crypto/...
-
-go get github.com/spf13/viper
 
 go get github.com/Jim3Things/CloudChamber
 

--- a/build/dev_tools/updateall.cmd
+++ b/build/dev_tools/updateall.cmd
@@ -2,16 +2,7 @@ pushd %GOPATH%\src
 
 go get -u github.com/golang/protobuf
 go get -u github.com/golang/protobuf/protoc-gen-go
-
-
-rem fetch & install the protobuf validation plugin
-rem
-go get -d github.com/envoyproxy/protoc-gen-validate
-pushd %GOPATH%\src\github.com\envoyproxy\protoc-gen-validate
-go install .
-popd
-
-go get -u go.etcd.io/etcd
+go get -u github.com/envoyproxy/protoc-gen-validate
 
 go get -u github.com/gorilla/mux
 go get -u github.com/gorilla/securecookie
@@ -19,14 +10,15 @@ go get -u github.com/gorilla/sessions
 
 go get -u github.com/davecgh/go-spew/spew
 go get -u github.com/pmezard/go-difflib/difflib
+go get -u github.com/spf13/viper
 go get -u github.com/stretchr/testify/assert
+
+go get -u go.etcd.io/etcd
 
 go get -u go.opentelemetry.io/otel
 
 go get -u google.golang.org/grpc
 
 go get -u golang.org/x/crypto/...
-
-go get -u github.com/spf13/viper
 
 popd

--- a/internal/tracing/exporters/common/common.go
+++ b/internal/tracing/exporters/common/common.go
@@ -11,13 +11,13 @@ import (
 )
 
 func ExtractEntry(_ context.Context, data *trace.SpanData) log.Entry {
-	spanId := data.SpanContext.SpanIDString()
-	parentId := fmt.Sprintf("%x", data.ParentSpanID)
+	spanID := data.SpanContext.SpanID.String()
+	parentID := fmt.Sprintf("%x", data.ParentSpanID)
 
 	entry := log.Entry{
 		Name:     data.Name,
-		SpanID:   spanId,
-		ParentID: parentId,
+		SpanID:   spanID,
+		ParentID: parentID,
 		Status:   fmt.Sprintf("%v: %v", data.StatusCode, data.StatusMessage),
 	}
 


### PR DESCRIPTION
Fix a build break (related to OpenTelemetry update?)
Reduce the chattiness of some of the build tools
Consolidate protoc extensions compile/separate install into single operation (like everything else)

Update buildall.cmd to use the locally built protoc extensions (compiler and validator). Give we fetch, build and install the protoc-gen-go.exe and protoc-gen-validate.exe extension, we probably should use them. 
