### PR TITLE
Fix inadvertent file deletion bug

### DIFF
--- a/build/cleanall.cmd
+++ b/build/cleanall.cmd
@@ -1,7 +1,22 @@
-pushd .
+@rem
+@rem
+@rem    C L E A N A L L . C M D
+@rem
+@rem
+@rem
 
-cd /d %GOPATH%\src\github.com\Jim3Things\CloudChamber\deployments
-del *.*
+@if /i "%DbgScript%" == "" @echo off
 
-popd
+if exist "%GOPATH%\src\github.com\Jim3Things\CloudChamber\deployments" (
 
+  pushd "%GOPATH%\src\github.com\Jim3Things\CloudChamber\deployments"
+
+  del *.*
+
+  popd
+
+) else (
+  echo.
+  echo Deployments directory not found. Check definition of GOPATH: %GOPATH%
+  echo.
+)

--- a/build/cleanall.cmd
+++ b/build/cleanall.cmd
@@ -11,7 +11,7 @@ if exist "%GOPATH%\src\github.com\Jim3Things\CloudChamber\deployments" (
 
   pushd "%GOPATH%\src\github.com\Jim3Things\CloudChamber\deployments"
 
-  del *.*
+  del /q *.*
 
   popd
 


### PR DESCRIPTION
If GOPATH is not defined, the cd /d fails but is then followed by a unilateral del *.* which can lead to the deletion of all files in the *current* directory, rather than the deployment directory.

Fix is to check that the deployments directory based on a GOPATH env var actually exists before trying to use it. It might be the wrong deployments directory if there are multiple copies of the repo, but at least it's not deleting a bunch of arbitrary files.