### PR TITLE
Add version flag to executables

### DIFF
--- a/build/buildall.cmd
+++ b/build/buildall.cmd
@@ -28,7 +28,7 @@
 @rem
 @if " " == "%UpdateHour:~0,1%" set UpdateHour=0%UpdateHour:~1,1%
 
-@set UpdateDateTime=%UpdateYear%%UpdateMonth%%UpdateDay%-%UpdateHour%%UpdateMinute%%UpdateSecond%
+@set BuildDateTime=%UpdateYear%%UpdateMonth%%UpdateDay%-%UpdateHour%%UpdateMinute%%UpdateSecond%
 
 
 @rem Update PATH to include the tools from the local Go environment. This is a temporary update
@@ -41,7 +41,15 @@
 @set CCDeployments=%CCRoot%\deployments
 
 
-pushd %gopath%\src
+@set BUILD_VERSION=v0.0.1
+
+@for /F "usebackq delims=" %%i in (`git symbolic-ref --short HEAD`)        do @set BUILD_BRANCH=%%i
+@for /F "usebackq delims=" %%i in (`git log -n 1 --pretty^=format:"%%cI"`) do @set BUILD_BRANCH_DATE=%%i
+@for /F "usebackq delims=" %%i in (`git log -n 1 --pretty^=format:"%%H"`)  do @set BUILD_BRANCH_HASH=%%i
+
+@set LD_FLAGS="-X 'main.version=%BUILD_VERSION%' -X 'main.buildDate=%BuildDateTime%' -X 'main.buildBranch=%BUILD_BRANCH%' -X 'main.buildBranchDate=%BUILD_BRANCH_DATE%' -X 'main.buildBranchHash=%BUILD_BRANCH_HASH%'"
+
+@pushd %gopath%\src
 
 protoc --go_out=. --validate_out=lang=go:. github.com\Jim3Things\CloudChamber\pkg\protos\admin\users.proto
 protoc --go_out=. --validate_out=lang=go:. github.com\Jim3Things\CloudChamber\pkg\protos\common\capacity.proto
@@ -59,21 +67,21 @@ protoc --go_out=. --validate_out=lang=go:. github.com\Jim3Things\CloudChamber\pk
 protoc --go_out=plugins=grpc:. --validate_out=lang=go:. github.com\Jim3Things\CloudChamber\pkg\protos\monitor\monitor.proto
 protoc --go_out=plugins=grpc:. --validate_out=lang=go:. github.com\Jim3Things\CloudChamber\pkg\protos\Stepper\stepper.proto
 
-go build -o github.com\Jim3Things\CloudChamber\deployments\controllerd.exe github.com\Jim3Things\CloudChamber\cmd\controllerd\main.go
-go build -o github.com\Jim3Things\CloudChamber\deployments\inventoryd.exe github.com\Jim3Things\CloudChamber\cmd\inventoryd\main.go
-go build -o github.com\Jim3Things\CloudChamber\deployments\sim_supportd.exe github.com\Jim3Things\CloudChamber\cmd\sim_supportd\main.go
-go build -o github.com\Jim3Things\CloudChamber\deployments\web_server.exe github.com\Jim3Things\CloudChamber\cmd\web_server\main.go
+go build -ldflags=%LD_FLAGS% -o github.com\Jim3Things\CloudChamber\deployments\controllerd.exe github.com\Jim3Things\CloudChamber\cmd\controllerd\main.go
+go build -ldflags=%LD_FLAGS% -o github.com\Jim3Things\CloudChamber\deployments\inventoryd.exe github.com\Jim3Things\CloudChamber\cmd\inventoryd\main.go
+go build -ldflags=%LD_FLAGS% -o github.com\Jim3Things\CloudChamber\deployments\sim_supportd.exe github.com\Jim3Things\CloudChamber\cmd\sim_supportd\main.go
+go build -ldflags=%LD_FLAGS% -o github.com\Jim3Things\CloudChamber\deployments\web_server.exe github.com\Jim3Things\CloudChamber\cmd\web_server\main.go
 
 copy github.com\Jim3Things\CloudChamber\Configs\cloudchamber.yaml github.com\Jim3Things\CloudChamber\deployments\cloudchamber.yaml
 copy github.com\Jim3Things\CloudChamber\scripts\start_cloud_chamber.cmd github.com\Jim3Things\CloudChamber\deployments\start_cloud_chamber.cmd
 copy github.com\Jim3Things\CloudChamber\scripts\startetcd.cmd github.com\Jim3Things\CloudChamber\deployments\startetcd.cmd
 
-echo rem > %CCDeployments%\readme.md
-echo rem R E A D M E . m d >> %CCDeployments%\readme.md
-echo rem >> %CCDeployments%\readme.md
-echo rem >> %CCDeployments%\readme.md
-echo BuildTimeStamp %UpdateDateTime% >> %CCDeployments%\readme.md
+@echo rem > %CCDeployments%\readme.md
+@echo rem R E A D M E . m d >> %CCDeployments%\readme.md
+@echo rem >> %CCDeployments%\readme.md
+@echo rem >> %CCDeployments%\readme.md
+@echo BuildTimeStamp %BuildDateTime% >> %CCDeployments%\readme.md
 
-popd
+@popd
 
 @endlocal

--- a/cmd/controllerd/main.go
+++ b/cmd/controllerd/main.go
@@ -16,12 +16,30 @@ import (
 	"github.com/Jim3Things/CloudChamber/internal/tracing/setup"
 )
 
-func main() {
-	setup.Init(exporters.StdOut)
+var (
+	// declare a bunch of variables whose values given here will be replaced by some
+	// build-time defined values. If for some reason those build-time replacements
+	// do not take place then the -version flag will dump these values as-is.
+	//
+	version         = "development"
+	buildDate       = "buildDate"
+	buildBranch     = "branch"
+	buildBranchHash = "branch-hash"
+	buildBranchDate = "branch-date"
+)
 
+func main() {
 	cfgPath := flag.String("config", ".", "path to the configuration file")
 	showConfig := flag.Bool("showConfig", false, "display the current configuration settings")
+	showVersion := flag.Bool("version", false, "display the current version of the program")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("Version: %v\nBuildDate: %v\nBranch: %v (%v \\ %v)\n", version, buildDate, buildBranch, buildBranchDate, buildBranchHash)
+		os.Exit(0)
+	}
+
+	setup.Init(exporters.StdOut)
 
 	cfg, err := config.ReadGlobalConfig(*cfgPath)
 	if err != nil {

--- a/cmd/inventoryd/main.go
+++ b/cmd/inventoryd/main.go
@@ -1,31 +1,49 @@
 package main
 
 import (
-    "flag"
-    "fmt"
-    "log"
-    "os"
+	"flag"
+	"fmt"
+	"log"
+	"os"
 
-    "github.com/Jim3Things/CloudChamber/internal/config"
-    "github.com/Jim3Things/CloudChamber/internal/tracing/exporters"
-    "github.com/Jim3Things/CloudChamber/internal/tracing/setup"
+	"github.com/Jim3Things/CloudChamber/internal/config"
+	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters"
+	"github.com/Jim3Things/CloudChamber/internal/tracing/setup"
+)
+
+var (
+	// declare a bunch of variables whose values given here will be replaced by some
+	// build-time defined values. If for some reason those build-time replacements
+	// do not take place then the -version flag will dump these values as-is.
+	//
+	version         = "development"
+	buildDate       = "buildDate"
+	buildBranch     = "branch"
+	buildBranchHash = "branch-hash"
+	buildBranchDate = "branch-date"
 )
 
 func main() {
-    setup.Init(exporters.StdOut)
+	cfgPath := flag.String("config", ".", "path to the configuration file")
+	showConfig := flag.Bool("showConfig", false, "display the current configuration settings")
+	showVersion := flag.Bool("version", false, "display the current version of the program")
+	flag.Parse()
 
-    cfgPath := flag.String("config", ".", "path to the configuration file")
-    showConfig := flag.Bool("showConfig", false, "display the current configuration settings")
-    flag.Parse()
+	if *showVersion {
+		fmt.Printf("Version: %v\nBuildDate: %v\nBranch: %v (%v \\ %v)\n", version, buildDate, buildBranch, buildBranchDate, buildBranchHash)
+		os.Exit(0)
+	}
 
-    cfg, err := config.ReadGlobalConfig(*cfgPath)
-    if err != nil {
-        log.Fatalf("failed to process the global configuration: %v", err)
-    }
+	setup.Init(exporters.StdOut)
 
-    if *showConfig {
-        fmt.Println(config.ToString(cfg))
-        os.Exit(0)
-    }
+	cfg, err := config.ReadGlobalConfig(*cfgPath)
+	if err != nil {
+		log.Fatalf("failed to process the global configuration: %v", err)
+	}
+
+	if *showConfig {
+		fmt.Println(config.ToString(cfg))
+		os.Exit(0)
+	}
 
 }

--- a/cmd/sim_supportd/main.go
+++ b/cmd/sim_supportd/main.go
@@ -16,12 +16,30 @@ import (
 	"github.com/Jim3Things/CloudChamber/internal/tracing/setup"
 )
 
-func main() {
-	setup.Init(exporters.StdOut)
+var (
+	// declare a bunch of variables whose values given here will be replaced by some
+	// build-time defined values. If for some reason those build-time replacements
+	// do not take place then the -version flag will dump these values as-is.
+	//
+	version         = "development"
+	buildDate       = "buildDate"
+	buildBranch     = "branch"
+	buildBranchHash = "branch-hash"
+	buildBranchDate = "branch-date"
+)
 
+func main() {
 	cfgPath := flag.String("config", ".", "path to the configuration file")
 	showConfig := flag.Bool("showConfig", false, "display the current configuration settings")
+	showVersion := flag.Bool("version", false, "display the current version of the program")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("Version: %v\nBuildDate: %v\nBranch: %v (%v \\ %v)\n", version, buildDate, buildBranch, buildBranchDate, buildBranchHash)
+		os.Exit(0)
+	}
+
+	setup.Init(exporters.StdOut)
 
 	cfg, err := config.ReadGlobalConfig(*cfgPath)
 	if err != nil {

--- a/cmd/web_server/main.go
+++ b/cmd/web_server/main.go
@@ -12,12 +12,30 @@ import (
 	"github.com/Jim3Things/CloudChamber/internal/tracing/setup"
 )
 
-func main() {
-	setup.Init(exporters.StdOut)
+var (
+	// declare a bunch of variables whose values given here will be replaced by some
+	// build-time defined values. If for some reason those build-time replacements
+	// do not take place then the -version flag will dump these values as-is.
+	//
+	version         = "development"
+	buildDate       = "buildDate"
+	buildBranch     = "branch"
+	buildBranchHash = "branch-hash"
+	buildBranchDate = "branch-date"
+)
 
+func main() {
 	cfgPath := flag.String("config", ".", "path to the configuration file")
 	showConfig := flag.Bool("showConfig", false, "display the current configuration settings")
+	showVersion := flag.Bool("version", false, "display the current version of the program")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("Version: %v\nBuildDate: %v\nBranch: %v (%v \\ %v)\n", version, buildDate, buildBranch, buildBranchDate, buildBranchHash)
+		os.Exit(0)
+	}
+
+	setup.Init(exporters.StdOut)
 
 	cfg, err := config.ReadGlobalConfig(*cfgPath)
 	if err != nil {


### PR DESCRIPTION
Adds a -version flag to each of the executables in which the build script will place useful build-time defined/obtained information.

This works by using the ldflags -X option to replace the value of a variable at the moral equivalent of link time. The name of the symbol must be known and the names chosen ensure that this requirement holds true.

This looks a little hokey, but I've not so far found anything more robust. Oh, for compile time constants and/or resource files...