### PR TITLE
Add a script to allow testing of arbitrary single subjects

### DIFF
--- a/build/test.cmd
+++ b/build/test.cmd
@@ -1,0 +1,74 @@
+@rem
+@rem
+@rem T E S T . C M D
+@rem
+@rem Allows one or more individually selected tests to be run, one at a time
+@rem
+
+@if /i "%DbgScript%" == "" @echo off
+
+setlocal
+
+if "%1" == "" goto :TestHelp
+
+
+:TestParseLoop
+
+if "%1" == "" goto :TestExit
+
+for %%j in (store timestamp) do (
+  if "%1" == "%%j" (call :TestRunClient %1)
+)
+
+for %%j in (frontend stepper) do (
+  if "%1" == "%%j" (call :TestRunService %1)
+)
+
+shift
+goto :TestParseLoop
+
+
+rem Protective EXIT
+rem 
+goto :TestExit
+
+
+:TestRunClient %1
+call :TestRun %1 %GOPATH%\src\github.com\Jim3Things\CloudChamber\internal\clients
+goto :EOF
+
+
+:TestRunService %1
+call :TestRun %1 %GOPATH%\src\github.com\Jim3Things\CloudChamber\internal\services
+goto :EOF
+
+
+
+:TestRun %1 %2
+pushd %2\%1
+go test -v
+popd
+goto :EOF
+
+
+
+:TestHelp
+
+echo.
+echo Test ^<test-subject^>
+echo.
+echo provides for the running of a single set of tests
+echo only for one of the following subjects
+echo.
+echo   frontend
+echo   stepper
+echo   store
+echo   timestamp
+echo.
+goto :TestExit
+
+
+:TestExit
+
+endlocal
+

--- a/internal/clients/store/store_test.go
+++ b/internal/clients/store/store_test.go
@@ -66,6 +66,12 @@ func etcdStart() {
 	etcdConfig.APUrls = []url.URL{*apurl}
 	etcdConfig.ACUrls = []url.URL{*acurl}
 
+	// Force a new derivation of the initial cluster name from the just initialized A*Urls.
+	// This is particularly relevant when using an embedded setup for test as a non-default
+	// IP port is being used to avoid collisions with a standard ETCD installation.
+	//
+	etcdConfig.InitialCluster = etcdConfig.InitialClusterFromName("")
+
 	// Override the default log level "info" which is very noisy
 	//
 	etcdConfig.LogLevel = "warn"


### PR DESCRIPTION
Basically I got fed up of cutting and pasting a single line from the testall.cmd file when I was concentrating on a single component. 

Enter test.cmd which allows one to run just the tests for a single subject component, e.g.

test store

It also takes multiple subject to run the tests of more than a single subject, or repeating subjects, but that's strictly a bonus.
