### PR TITLE
Fix store problem with conflicting ports when using embedded etcd

### DIFF
--- a/internal/clients/store/store_test.go
+++ b/internal/clients/store/store_test.go
@@ -66,6 +66,8 @@ func etcdStart() {
 	etcdConfig.APUrls = []url.URL{*apurl}
 	etcdConfig.ACUrls = []url.URL{*acurl}
 
+	etcdConfig.InitialCluster = etcdConfig.InitialClusterFromName("")
+
 	// Override the default log level "info" which is very noisy
 	//
 	etcdConfig.LogLevel = "warn"

--- a/pkg/version/generator/generate.go
+++ b/pkg/version/generator/generate.go
@@ -7,8 +7,10 @@
 // not form part of the version package itself, but is a standalone file used to generate
 // part of the package.
 //
-// +build ignore
+// Note: the VsCode linter requires a blank line after the ignore directive
 //
+// +build ignore
+
 package main
 
 import (


### PR DESCRIPTION
Responding to what appears to be an etcd change, when using an embedded configuration, ensure the cluster connection path (even if not being used) is compatible with the other ports.


Also attend to a minor issue where the VsCode IDE lint-er complains about a missing blank line after a build directive.
