### PR TITLE
Simplify the context tracking in the actors

### DIFF
--- a/internal/services/frontend/users.go
+++ b/internal/services/frontend/users.go
@@ -20,7 +20,7 @@ import (
     "golang.org/x/crypto/bcrypt"
 
     "github.com/Jim3Things/CloudChamber/internal/config"
-    st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+    "github.com/Jim3Things/CloudChamber/internal/tracing"
     pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
 )
 
@@ -215,7 +215,7 @@ func usersAddRoutes(routeBase *mux.Router) {
 // Process an http request for the list of users.  Response should contain a document of links to the
 // details URI for each known user.
 func handlerUsersList(w http.ResponseWriter, r *http.Request) {
-    _ = tr.WithSpan(context.Background(), st.MethodName(1), func(ctx context.Context) (err error) {
+    _ = tr.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
         err = doSessionHeader(
             ctx, w, r,
             func(ctx context.Context, span trace.Span, session *sessions.Session) error {
@@ -253,7 +253,7 @@ func handlerUsersList(w http.ResponseWriter, r *http.Request) {
 }
 
 func handlerUsersCreate(w http.ResponseWriter, r *http.Request) {
-    _ = tr.WithSpan(context.Background(), st.MethodName(1), func(ctx context.Context) (err error) {
+    _ = tr.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
         vars := mux.Vars(r)
         username := vars["username"]
 
@@ -293,7 +293,7 @@ func handlerUsersCreate(w http.ResponseWriter, r *http.Request) {
 }
 
 func handlerUsersRead(w http.ResponseWriter, r *http.Request) {
-    _ = tr.WithSpan(context.Background(), st.MethodName(1), func(ctx context.Context) (err error) {
+    _ = tr.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
         vars := mux.Vars(r)
         username := vars["username"]
 
@@ -334,7 +334,7 @@ func handlerUsersRead(w http.ResponseWriter, r *http.Request) {
 
 // Update the user entry
 func handlerUsersUpdate(w http.ResponseWriter, r *http.Request) {
-    _ = tr.WithSpan(context.Background(), st.MethodName(1), func(ctx context.Context) (err error) {
+    _ = tr.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
         vars := mux.Vars(r)
         username := vars["username"]
 
@@ -402,7 +402,7 @@ func handlerUsersUpdate(w http.ResponseWriter, r *http.Request) {
 
 // Delete the user entry
 func handlerUsersDelete(w http.ResponseWriter, r *http.Request) {
-    _ = tr.WithSpan(context.Background(), st.MethodName(1), func(ctx context.Context) (err error) {
+    _ = tr.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
         vars := mux.Vars(r)
         username := vars["username"]
 
@@ -430,7 +430,7 @@ func handlerUsersDelete(w http.ResponseWriter, r *http.Request) {
 
 // Perform an admin operation (login, logout, enable, disable) on an account
 func handlerUsersOperation(w http.ResponseWriter, r *http.Request) {
-    _ = tr.WithSpan(context.Background(), st.MethodName(1), func(ctx context.Context) (err error) {
+    _ = tr.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
         var s string
 
         err = doSessionHeader(ctx, w, r, func(ctx context.Context, span trace.Span, session *sessions.Session) (err error) {

--- a/internal/tracing/server/actor_interceptor.go
+++ b/internal/tracing/server/actor_interceptor.go
@@ -50,9 +50,10 @@ func ReceiveLogger(next actor.ReceiverFunc) actor.ReceiverFunc {
 // actor's instance
 func SendLogger(next actor.SenderFunc) actor.SenderFunc {
     return func (c actor.SenderContext, target *actor.PID, envelope *actor.MessageEnvelope) {
+        ctx := trc.ContextWithSpan(context.Background(), GetSpan(c.Self()))
         hdr, msg, pid := actor.UnwrapEnvelope(envelope)
 
-        Info(context.Background(), -1, fmt.Sprintf("Sending pid: %v, hdr: %v, msg: %v", pid, hdr, dumpMessage(msg)))
+        Info(ctx, -1, fmt.Sprintf("Sending pid: %v, hdr: %v, msg: %v", pid, hdr, dumpMessage(msg)))
 
         next(c, target, envelope)
     }

--- a/internal/tracing/server/actor_interceptor.go
+++ b/internal/tracing/server/actor_interceptor.go
@@ -40,7 +40,7 @@ func ReceiveLogger(next actor.ReceiverFunc) actor.ReceiverFunc {
 
         hdr, msg, pid := actor.UnwrapEnvelope(envelope)
 
-        Info(ctx, span, -1, fmt.Sprintf("Receive pid: %v, hdr: %v, msg: %v", pid, hdr, dumpMessage(msg)))
+        Info(ctx, -1, fmt.Sprintf("Receive pid: %v, hdr: %v, msg: %v", pid, hdr, dumpMessage(msg)))
 
         next(c, envelope)
     }
@@ -52,7 +52,7 @@ func SendLogger(next actor.SenderFunc) actor.SenderFunc {
     return func (c actor.SenderContext, target *actor.PID, envelope *actor.MessageEnvelope) {
         hdr, msg, pid := actor.UnwrapEnvelope(envelope)
 
-        Info(context.Background(), GetSpan(c.Self()), -1, fmt.Sprintf("Sending pid: %v, hdr: %v, msg: %v", pid, hdr, dumpMessage(msg)))
+        Info(context.Background(), -1, fmt.Sprintf("Sending pid: %v, hdr: %v, msg: %v", pid, hdr, dumpMessage(msg)))
 
         next(c, target, envelope)
     }


### PR DESCRIPTION
Move all context state extensions to attributes on context.Context, and track appropriately.
Remove duplication MethodName implementation.