### PR TITLE
Adjust for opentelemetry API change

### DIFF
--- a/internal/tracing/client/tracing.go
+++ b/internal/tracing/client/tracing.go
@@ -5,7 +5,7 @@ import (
 
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/trace"
-	"go.opentelemetry.io/otel/plugin/grpctrace"
+	"go.opentelemetry.io/otel/instrumentation/grpctrace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"

--- a/internal/tracing/server/tracing.go
+++ b/internal/tracing/server/tracing.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/kv"
 	"go.opentelemetry.io/otel/api/trace"
-	"go.opentelemetry.io/otel/plugin/grpctrace"
+	"go.opentelemetry.io/otel/instrumentation/grpctrace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 


### PR DESCRIPTION
I got a notification that protoactor was cleaning up its dependencies, so I updated all our dependencies and found that ... opentelemetry broke its api again.  The plugin directory was renamed to instrumentation...

This fixes that issue and does require an updateall to work.