### PR TITLE
Get Store to use standard config files

### DIFF
--- a/configs/cloudchamber.yaml
+++ b/configs/cloudchamber.yaml
@@ -21,7 +21,42 @@ simSupport:
     port: 8083
     hostname: localhost
 
-# TODO: etcd settings
+# store interactions and etcd instance connection parameters
+store:
+  # trace level to use for insteractions with the store and
+  # etcd
+  traceLevel: 1
+
+  # timeout in seconds to allow when attempting to establish
+  # a connection to the etcd instance
+  connectTimeout: 5
+
+  # timeout in seconds to allow when sending a request to
+  # etcd instance
+  requestTimeout: 5
+
+  # Client and peer endpoint addresses and ports for an external
+  # instance of etcd.
+  #
+  # Currently the use of an etcd cluster is not supported. When
+  # they are, this will become a list/array of endpoints.
+  etcdService:
+    hostname: localhost
+    port: 2379
+
+  # Client and peer ports for the etcd instance to be created
+  # when running the local tests. These values are ignored
+  # for production use.
+  #
+  # If testEmbedded is set to 0, the standard Etcd instance will
+  # be used for tests rather than a local embedded instance.
+  Test:
+    EmbeddedInstance: 0
+    EmbeddedHostname: localhost
+    EmbeddedHostAddr: 127.0.0.1
+    EmbeddedPortClient: 9379
+    EmbeddedPortPeer: 9380
+    EmbeddedPath: C:\CloudChamber\EtcdStore
 
 # front end service, client web server
 webServer:
@@ -36,7 +71,7 @@ webServer:
     hostname: localhost
 
   # file system path to the static files and scripts
-  rootFilePath: c:\CloudChamber
+  rootFilePath: c:\CloudChamber\Files
 
   # pre-defined account
   systemAccount: admin

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -7,187 +7,273 @@
 package config
 
 import (
-    "context"
-    "fmt"
+	"context"
+	"fmt"
 
-    "github.com/spf13/viper"
-    "go.opentelemetry.io/otel/api/global"
+	"github.com/spf13/viper"
+	"go.opentelemetry.io/otel/api/global"
 )
 
 const (
-    DefaultGlobalConfigFile = "cloudchamber.yaml"
-    DefaultConfigType = "yaml"
-    ControllerDefaultPort = 8081
-    InventoryDefaultPort = 8082
-    SimSupportDefaultPort = 8083
-    WebServerDefaultPort = 8084
-    WebServerFEDefaultPort = 8080
-    DefaultHost = ""
-    DefaultRootFilePath = "."
-    DefaultSystemAccount = "Admin"
-    DefaultSystemPassword = "SystemPassword"
+	DefaultGlobalConfigFile     = "cloudchamber.yaml"
+	DefaultConfigType           = "yaml"
+	ControllerDefaultPort       = 8081
+	InventoryDefaultPort        = 8082
+	SimSupportDefaultPort       = 8083
+	WebServerDefaultPort        = 8084
+	WebServerFEDefaultPort      = 8080
+	DefaultHost                 = ""
+	DefaultRootFilePath         = "."
+	DefaultSystemAccount        = "Admin"
+	DefaultSystemPassword       = "SystemPassword"
+	StoreDefaultTraceLevel      = 1
+	StoreDefaultConnectTimeout  = 5
+	StoreDefaultRequestTimeout  = 5
+	StoreDefaultEtcdSvcHostname = "localhost"
+	StoreDefaultEtcdSvcPort     = 2379
+
+	StoreDefaultTestEmbeddedInstance   = true
+	StoreDefaultTestEmbeddedHostname   = "localhost"
+	StoreDefaultTestEmbeddedHostAddr   = "127.0.0.1"
+	StoreDefaultTestEmbeddedPortClient = 9379
+	StoreDefaultTestEmbeddedPortPeer   = 9380
+	StoreDefaultTestEmbeddedPath       = "store"
 )
 
-// Define the global configuration structure produced from reading the config
-// files.  It is structured by the internal services, with each internal service
-// having room for the specific settings that it needs.
+// GlobalConfig defines the global configuration structure produced from reading
+// the config files.  It is structured by the internal services, with each
+// internal service having room for the specific settings that it needs.
 //
 type GlobalConfig struct {
-    Controller ControllerType
-    Inventory InventoryType
-    SimSupport SimSupportType
-    WebServer WebServerType
+	Controller ControllerType
+	Inventory  InventoryType
+	SimSupport SimSupportType
+	WebServer  WebServerType
+	Store      StoreType
 }
 
-// Helper type that defines a simple endpoint
+// Endpoint is a helper type that defines a simple endpoint
 type Endpoint struct {
-    Hostname string
-    Port int
+	Hostname string
+	Port     int
 }
 
-// controllerd configuration settings
+// ControllerType is a helper type describes the controllerd configuration settings
 type ControllerType struct {
-    // Exposed GRPC endpoint
-    EP Endpoint
+	// Exposed GRPC endpoint
+	EP Endpoint
 }
 
-// inventoryd configuration settings
+// InventoryType is a helper type that describes the inventoryd configuration settings
 type InventoryType struct {
-    // Exposed GRPC endpoint
-    EP Endpoint
+	// Exposed GRPC endpoint
+	EP Endpoint
 }
 
-// sim_supportd configuration settings
+// SimSupportType is a helper type that describes the sim_supportd configuration settings
 type SimSupportType struct {
-    // Exposed GRPC endpoint
-    EP Endpoint
+	// Exposed GRPC endpoint
+	EP Endpoint
 }
 
-// web_server configuration settings
+// WebServerType is a helper type that describes the web_server configuration settings
 type WebServerType struct {
-    // Filesystem path to the static files and scripts
-    RootFilePath string
+	// Filesystem path to the static files and scripts
+	RootFilePath string
 
-    // Predefined starting account
-    SystemAccount string
+	// Predefined starting account
+	SystemAccount string
 
-    // .. and that account's password
-    SystemAccountPassword string
+	// .. and that account's password
+	SystemAccountPassword string
 
-    // External http endpoint
-    FE Endpoint
+	// External http endpoint
+	FE Endpoint
 
-    // GPRC endpoint, used for internal notifications
-    BE Endpoint
+	// GPRC endpoint, used for internal notifications
+	BE Endpoint
+}
+
+// StoreTypeTestEmbedded describes the specific configured elements for
+// an embedded store InstanceType
+//
+type StoreTypeTestEmbedded struct {
+	EmbeddedInstance   bool
+	EmbeddedHostname   string
+	EmbeddedHostAddr   string
+	EmbeddedPortClient uint16
+	EmbeddedPortPeer   uint16
+	EmbeddedPath       string
+}
+
+// StoreType is a structure used to return the configurable elements
+// for the Store section of the global configuration file.
+//
+type StoreType struct {
+	ConnectTimeout int
+	RequestTimeout int
+	TraceLevel     int
+	EtcdService    Endpoint
+	Test           StoreTypeTestEmbedded
 }
 
 // Create a new global configuration object, preset with defaults
 func newGlobalConfig() *GlobalConfig {
-    return &GlobalConfig{
-        Controller: ControllerType{
-            EP: Endpoint{
-                Hostname: DefaultHost,
-                Port: ControllerDefaultPort,
-            }},
-        Inventory: InventoryType{
-            EP: Endpoint{
-                Hostname: DefaultHost,
-                Port: InventoryDefaultPort,
-            }},
-        SimSupport: SimSupportType{
-            EP: Endpoint{
-                Hostname: DefaultHost,
-                Port: SimSupportDefaultPort,
-            }},
-        WebServer: WebServerType{
-            RootFilePath: DefaultRootFilePath,
-            SystemAccount: DefaultSystemAccount,
-            SystemAccountPassword: DefaultSystemPassword,
-            FE: Endpoint{
-                Hostname: DefaultHost,
-                Port:     WebServerFEDefaultPort,
-            },
-            BE: Endpoint{
-                Hostname: DefaultHost,
-                Port:     WebServerDefaultPort,
-            }},
-    }
+	return &GlobalConfig{
+		Controller: ControllerType{
+			EP: Endpoint{
+				Hostname: DefaultHost,
+				Port:     ControllerDefaultPort,
+			}},
+		Inventory: InventoryType{
+			EP: Endpoint{
+				Hostname: DefaultHost,
+				Port:     InventoryDefaultPort,
+			}},
+		SimSupport: SimSupportType{
+			EP: Endpoint{
+				Hostname: DefaultHost,
+				Port:     SimSupportDefaultPort,
+			}},
+		WebServer: WebServerType{
+			RootFilePath:          DefaultRootFilePath,
+			SystemAccount:         DefaultSystemAccount,
+			SystemAccountPassword: DefaultSystemPassword,
+			FE: Endpoint{
+				Hostname: DefaultHost,
+				Port:     WebServerFEDefaultPort,
+			},
+			BE: Endpoint{
+				Hostname: DefaultHost,
+				Port:     WebServerDefaultPort,
+			}},
+		Store: StoreType{
+			ConnectTimeout: StoreDefaultConnectTimeout,
+			RequestTimeout: StoreDefaultRequestTimeout,
+			TraceLevel:     StoreDefaultTraceLevel,
+			EtcdService: Endpoint{
+				Hostname: StoreDefaultEtcdSvcHostname,
+				Port:     StoreDefaultEtcdSvcPort,
+			},
+			Test: StoreTypeTestEmbedded{
+				EmbeddedInstance:   StoreDefaultTestEmbeddedInstance,
+				EmbeddedHostname:   StoreDefaultTestEmbeddedHostname,
+				EmbeddedHostAddr:   StoreDefaultTestEmbeddedHostAddr,
+				EmbeddedPortClient: StoreDefaultTestEmbeddedPortClient,
+				EmbeddedPortPeer:   StoreDefaultTestEmbeddedPortPeer,
+				EmbeddedPath:       StoreDefaultTestEmbeddedPath,
+			},
+		},
+	}
 }
 
-// Read the configuration file at the specified path.
+// ReadGlobalConfig is a routine to read the configuration file at the specified path.
 //
 // The configuration file is parsed, and the result returned as a typed object
 func ReadGlobalConfig(path string) (*GlobalConfig, error) {
-    viper.SetConfigName(DefaultGlobalConfigFile)
-    viper.AddConfigPath(path)
-    viper.SetConfigType(DefaultConfigType)
+	viper.SetConfigName(DefaultGlobalConfigFile)
+	viper.AddConfigPath(path)
+	viper.SetConfigType(DefaultConfigType)
 
-    cfg := newGlobalConfig()
+	cfg := newGlobalConfig()
 
-    tr := global.TraceProvider().Tracer("")
+	tr := global.TraceProvider().Tracer("")
 
-    ctx, span := tr.Start(
-        context.Background(),
-        "ReadGlobalConfig")
-    defer span.End()
+	ctx, span := tr.Start(
+		context.Background(),
+		"ReadGlobalConfig")
+	defer span.End()
 
-    if err := viper.ReadInConfig(); err != nil {
-        if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-            // Config file not found; we'll just use the default values
-            span.AddEvent(
-                ctx,
-                fmt.Sprintf(
-                    "No config file found at %s/%s (%s), applying defaults.",
-                    path,
-                    DefaultGlobalConfigFile,
-                    DefaultConfigType))
-        } else {
-            // Config file was found but another error was produced
-            err = fmt.Errorf("Fatal error reading config file: %s \n", err)
-            span.AddEvent(ctx, err.Error())
-            return nil, err
-        }
-    } else {
-        // Fill in the global configuration object from the configuration file
-        if err = viper.UnmarshalExact(cfg); err != nil {
-            err = fmt.Errorf("unable to decode into struct, %v", err)
-            span.AddEvent(ctx, err.Error())
-            return nil, err
-        }
-    }
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			// Config file not found; we'll just use the default values
+			span.AddEvent(
+				ctx,
+				fmt.Sprintf(
+					"No config file found at %s/%s (%s), applying defaults.",
+					path,
+					DefaultGlobalConfigFile,
+					DefaultConfigType))
+		} else {
+			// Config file was found but another error was produced
+			err = fmt.Errorf("fatal error reading config file: %s", err)
+			span.AddEvent(ctx, err.Error())
+			return nil, err
+		}
+	} else {
+		// Fill in the global configuration object from the configuration file
+		if err = viper.UnmarshalExact(cfg); err != nil {
+			err = fmt.Errorf("unable to decode into struct, %v", err)
+			span.AddEvent(ctx, err.Error())
+			return nil, err
+		}
+	}
 
-    span.AddEvent(ctx,
-        fmt.Sprintf("Configuration Read: \n%v", ToString(cfg)))
+	span.AddEvent(ctx,
+		fmt.Sprintf("Configuration Read: \n%v", ToString(cfg)))
 
-    return cfg, nil
+	return cfg, nil
 }
 
-// Format the configuration data.
+// ToString is a function to format the configuration data as a returned string.
 func ToString(data *GlobalConfig) string {
-    return fmt.Sprintf(
-        "Controller:\n" +
-            "  EP:\n" +
-            "    port: %v\n    hostname: %v\n" +
-            "Inventory:\n" +
-            "  EP:\n" +
-            "    port: %v\n    hostname: %v\n" +
-            "SimSupport:\n" +
-            "  EP:\n" +
-            "    port: %v\n    hostname: %v\n" +
-            "Webserver:\n" +
-            "  FE:\n" +
-            "    port: %v\n    hostname: %v\n" +
-            "  BE:\n" +
-            "    port: %v\n    hostname: %v\n" +
-            "  RootFilePath: %s\n" +
-            "  SystemAccount: %s\n" +
-            "  SystemAccountPassword: %s\n",
-        data.Controller.EP.Port, data.Controller.EP.Hostname,
-        data.Inventory.EP.Port, data.Inventory.EP.Hostname,
-        data.SimSupport.EP.Port, data.SimSupport.EP.Hostname,
-        data.WebServer.FE.Port, data.WebServer.FE.Hostname,
-        data.WebServer.BE.Port, data.WebServer.BE.Hostname,
-        data.WebServer.RootFilePath,
-        data.WebServer.SystemAccount,
-        data.WebServer.SystemAccountPassword)
+	var storeInstanceConfig string
+
+	switch data.Store.Test.EmbeddedInstance {
+	case true:
+		storeInstanceConfig = fmt.Sprintf(
+			"  Embed: Embedded\n"+
+				"    Hostname: %v\n"+
+				"    HostAddr: %v\n"+
+				"    ClientPort: %v\n"+
+				"    PeerPort: %v\n"+
+				"    Path: %v\n",
+			data.Store.Test.EmbeddedHostname,
+			data.Store.Test.EmbeddedHostAddr,
+			data.Store.Test.EmbeddedPortClient,
+			data.Store.Test.EmbeddedPortPeer,
+			data.Store.Test.EmbeddedPath)
+	case false:
+		storeInstanceConfig = fmt.Sprintf(
+			"  Embed: External\n"+
+				"    Hostname: %v\n"+
+				"    Port: %v\n",
+			data.Store.EtcdService.Hostname,
+			data.Store.EtcdService.Port)
+	}
+	return fmt.Sprintf(
+		"Controller:\n"+
+			"  EP:\n"+
+			"    port: %v\n    hostname: %v\n"+
+			"Inventory:\n"+
+			"  EP:\n"+
+			"    port: %v\n    hostname: %v\n"+
+			"SimSupport:\n"+
+			"  EP:\n"+
+			"    port: %v\n    hostname: %v\n"+
+			"Webserver:\n"+
+			"  FE:\n"+
+			"    port: %v\n    hostname: %v\n"+
+			"  BE:\n"+
+			"    port: %v\n    hostname: %v\n"+
+			"  RootFilePath: %s\n"+
+			"  SystemAccount: %s\n"+
+			"  SystemAccountPassword: %s\n"+
+			"Store:"+
+			"  ConnectTimeout: %v\n"+
+			"  RequestTimeout: %v\n"+
+			"  TraceLevel: %v\n"+
+			"%s\n",
+		data.Controller.EP.Port, data.Controller.EP.Hostname,
+		data.Inventory.EP.Port, data.Inventory.EP.Hostname,
+		data.SimSupport.EP.Port, data.SimSupport.EP.Hostname,
+		data.WebServer.FE.Port, data.WebServer.FE.Hostname,
+		data.WebServer.BE.Port, data.WebServer.BE.Hostname,
+		data.WebServer.RootFilePath,
+		data.WebServer.SystemAccount,
+		data.WebServer.SystemAccountPassword,
+		data.Store.ConnectTimeout,
+		data.Store.RequestTimeout,
+		data.Store.TraceLevel,
+		storeInstanceConfig)
 }


### PR DESCRIPTION
This is step one in a sequence of store related changes. 

This step is to make the store pay attention to the standard config file. At present it still refers to the embedded etcd instance but that will go away completely in step 2. (I wanted to get this checked in to unblock the tests)

1. The store (according to the config file) will now use an external etcd instance, so scripts\startetcd.cmd should be run prior to starting any store related tests.
2. The store tests place use a sub-tree namespace to the main CloudChamber store. This will prevent any interference between the main store and any test data. Given a single store, we may need to go further and have a specific namespace per test-instance if we want to allow multiple test to run simultaneously.
3. The store tests now run cleanly on the current etcd version.


Upcoming in future PRs
step 2 - remove embedded etcd altogether
step 3 - convert to standard tracing (currently blocked by embedding of etcd)
