### PR TITLE
Add stepper REST head, UT, trace channel sync

### DIFF
--- a/cmd/sim_supportd/main.go
+++ b/cmd/sim_supportd/main.go
@@ -49,8 +49,11 @@ func main() {
 
 	s := grpc.NewServer(grpc.UnaryInterceptor(server.Interceptor))
 
-	if err := stepper.Register(s); err != nil {
-		log.Fatalf("failed to register the stepper actor: %v", err)
+	if err := stepper.Register(s, cfg.SimSupport.GetPolicyType()); err != nil {
+		log.Fatalf(
+			"failed to register the stepper actor.  default policy: %v, err: %v",
+			cfg.SimSupport.GetPolicyType(),
+			err)
 	}
 
 	if err := s.Serve(lis); err != nil {

--- a/configs/cloudchamber.yaml
+++ b/configs/cloudchamber.yaml
@@ -21,9 +21,14 @@ simSupport:
     port: 8083
     hostname: localhost
 
+  # Starting Stepper Policy Mode
+  # valid strings are 'manual' or 'automatic'.  The latter
+  # is preset to 1 tick / second
+  stepperPolicy: manual
+
 # store interactions and etcd instance connection parameters
 store:
-  # trace level to use for insteractions with the store and
+  # trace level to use for interactions with the store and
   # etcd
   traceLevel: 1
 

--- a/internal/clients/timestamp/timestamp_test.go
+++ b/internal/clients/timestamp/timestamp_test.go
@@ -33,7 +33,7 @@ func init() {
 	lis = bufconn.Listen(bufSize)
 	s := grpc.NewServer(grpc.UnaryInterceptor(strc.Interceptor))
 
-	if err := stepper.Register(s); err != nil {
+	if err := stepper.Register(s, pb.StepperPolicy_Invalid); err != nil {
 		log.Fatalf("Failed to register stepper actor: %v", err)
 	}
 
@@ -49,8 +49,6 @@ func bufDialer(_ context.Context, _ string) (net.Conn, error) {
 }
 
 func commonSetup(t *testing.T) {
-	unit_test.SetTesting(t)
-
 	InitTimestamp("bufnet",
 		grpc.WithContextDialer(bufDialer),
 		grpc.WithInsecure(),
@@ -61,6 +59,9 @@ func commonSetup(t *testing.T) {
 }
 
 func TestNow(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
 	commonSetup(t)
 	assert.Nil(t, SetPolicy(pb.StepperPolicy_Manual, &duration.Duration{Seconds: 0}))
 
@@ -83,6 +84,9 @@ func TestNow(t *testing.T) {
 }
 
 func TestTimestamp_After(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
 	commonSetup(t)
 	assert.Nil(t, SetPolicy(pb.StepperPolicy_Manual, &duration.Duration{Seconds: 0}))
 

--- a/internal/services/frontend/DBInventory_test.go
+++ b/internal/services/frontend/DBInventory_test.go
@@ -18,6 +18,7 @@ import (
 // // First DBInventory unit test
 func TestInventoryListRacks(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	request := httptest.NewRequest("GET", "/api/racks/", nil)
 	response := doHTTP(request, nil)

--- a/internal/services/frontend/doc.go
+++ b/internal/services/frontend/doc.go
@@ -118,6 +118,21 @@ GET - /api/racks/{rack-id}/TOR //To get details about a specific blade in a spec
 GET - /api/racks/rack-id/PDU //Gets Power distribution Unit details.
 
 
+/api/stepper
+
+GET - /api/stepper
+Returns the current simulated time, mode and advance rate
+
+GET - /api/stepper/now
+Returns the current simulated time
+
+PUT - /api/stepper?advance
+Moves simulated time forward, so long as the mode is manual
+This relies on an ETag returned by either of the two preceding GET operations
+
+PUT - /api/stepper?mode={manual|automatic[=rate]}
+Sets the new mode and advance rate
+This relies on an ETag returned by the first GET operation above
 
 TODO
 

--- a/internal/services/frontend/errors.go
+++ b/internal/services/frontend/errors.go
@@ -4,9 +4,12 @@
 package frontend
 
 import (
+    "context"
     "errors"
     "fmt"
     "net/http"
+
+    st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 )
 
 var (
@@ -54,6 +57,26 @@ func (he *HTTPError) StatusCode() int {
 
 func (he *HTTPError) Error() string {
     return he.Base.Error()
+}
+
+// Set an http error, and log it to the tracing system.
+func httpError(ctx context.Context, w http.ResponseWriter, err error) {
+    // We're hoping this is an HTTPError form of error, which would have the
+    // preferred HTTP status code included.
+    //
+    // If it isn't, then the error originated in some support or library logic,
+    // rather than the web server's business logic.  In that case we assume a
+    // status code of internal server error as the most likely correct value.
+    he, ok := err.(*HTTPError)
+    if !ok {
+        he = &HTTPError{
+            SC:   http.StatusInternalServerError,
+            Base: err,
+        }
+    }
+
+    _ = st.Errorf(ctx, -1, "http error %v: %s", he.StatusCode(), he.Error())
+    http.Error(w, he.Error(), he.StatusCode())
 }
 
 // +++ HTTPError specializations

--- a/internal/services/frontend/frontend.go
+++ b/internal/services/frontend/frontend.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/Jim3Things/CloudChamber/internal/config"
 	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+	pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
 )
 
 // Computer is a representation an individual Computer
@@ -120,6 +121,7 @@ func initHandlers() error {
 	usersAddRoutes(routeAPI)
 	workloadsAddRoutes(routeAPI)
 	inventoryAddRoutes(routeAPI)
+	stepperAddRoutes(routeAPI)
 
 	// TODO the following handler definitions are just temporary placeholders and
 	// should at some point be converted to follow the same pattern as for files,
@@ -127,7 +129,6 @@ func initHandlers() error {
 	// there.
 	//
 	routeAPI.HandleFunc("/logs", handlerLogsRoot).Methods("GET")
-	routeAPI.HandleFunc("/stepper", handlerStepperRoot).Methods("GET")
 	routeAPI.HandleFunc("/injector", handlerInjectorRoot).Methods("GET")
 
 	server.handler = normalizeURL(handler)
@@ -243,4 +244,18 @@ func doSessionHeader(
 	}
 
 	return err
+}
+
+
+func getLoggedInUser(session *sessions.Session) (*pb.User, error) {
+	key, ok := session.Values[UserNameKey].(string)
+	if !ok {
+		return nil, &HTTPError{
+			SC:   http.StatusBadRequest,
+			Base: http.ErrNoCookie,
+		}
+	}
+
+	user, _, err := dbUsers.Get(key)
+	return user, err
 }

--- a/internal/services/frontend/frontend.go
+++ b/internal/services/frontend/frontend.go
@@ -16,43 +16,20 @@
 package frontend
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"net/http"
 	"strings"
-	"sync"
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
+	"google.golang.org/grpc"
 
+	clients "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
 	"github.com/Jim3Things/CloudChamber/internal/config"
-	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
-	pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
+	ctrc "github.com/Jim3Things/CloudChamber/internal/tracing/client"
 )
-
-// Computer is a representation an individual Computer
-//
-// TODO This is just a placeholder until we have proper inventory items
-//     held in a persisted store (Etcd)
-//
-type Computer struct {
-	Name       string
-	Processors uint32
-	Memory     uint64
-}
-
-// DbComputers is a container used to established synchronized access to
-// the in-memory set of inventory records.
-//
-// TODO This is just a placeholder until we have proper inventory items
-//     held in the persisted store (Etcd)
-//
-type DbComputers struct {
-	Lock      sync.Mutex
-	Computers map[string]Computer
-}
 
 // Server is the context structure for the frontend web service. It is used to
 // provide a convenient place to store all the long-lived server/service global data fields.
@@ -69,8 +46,6 @@ var (
 	// key must be 16, 24 or 32 bytes long (AES-128, AES-192 or AES-256)
 	keyAuthentication = securecookie.GenerateRandomKey(32)
 	keyEncryption     = securecookie.GenerateRandomKey(32)
-
-	dbComputers DbComputers
 
 	server Server
 )
@@ -112,12 +87,12 @@ func normalizeURL(next http.Handler) http.Handler {
 func initHandlers() error {
 
 	handler := mux.NewRouter()
+	filesAddRoutes(server.rootFilePath, handler)
 
 	routeAPI := handler.PathPrefix("/api").Subrouter()
 
 	// Now add the routes for the API
 	//
-	filesAddRoutes(server.rootFilePath, handler)
 	usersAddRoutes(routeAPI)
 	workloadsAddRoutes(routeAPI)
 	inventoryAddRoutes(routeAPI)
@@ -160,6 +135,15 @@ func initService(cfg *config.GlobalConfig) error {
 	server.cookieStore.Options.Secure = false
 	server.cookieStore.Options.HttpOnly = false
 
+	// Initialize the simulated time (stepper) service client
+	clients.InitTimestamp(
+		fmt.Sprintf(
+			"%s:%d",
+			cfg.SimSupport.EP.Hostname,
+			cfg.SimSupport.EP.Port),
+		grpc.WithInsecure(),
+		grpc.WithUnaryInterceptor(ctrc.Interceptor))
+
 	if err := initHandlers(); err != nil {
 		return err
 	}
@@ -194,68 +178,7 @@ func handlerLogsRoot(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Logs (Root)")
 }
 
-func handlerStepperRoot(w http.ResponseWriter, r *http.Request) {
-
-	fmt.Fprintf(w, "Stepper (Root)")
-}
-
 func handlerInjectorRoot(w http.ResponseWriter, r *http.Request) {
 
 	fmt.Fprintf(w, "Injector (Root)")
-}
-
-// Set an http error, and log it to the tracing system.
-func httpError(ctx context.Context, w http.ResponseWriter, err error) {
-	// We're hoping this is an HTTPError form of error, which would have the
-	// preferred HTTP status code included.
-	//
-	// If it isn't, then the error originated in some support or library logic,
-	// rather than the web server's business logic.  In that case we assume a
-	// status code of internal server error as the most likely correct value.
-	he := err.(*HTTPError)
-	if he == nil {
-		he = &HTTPError{
-			SC:   http.StatusInternalServerError,
-			Base: err,
-		}
-	}
-
-	_ = st.Errorf(ctx, -1, "http error %v: %s", he.StatusCode(), he.Error())
-	http.Error(w, he.Error(), he.StatusCode())
-}
-
-// doSessionHeader wraps a handler action with the necessary code to retrieve any existing session state,
-// and to attach that state to the response prior to returning.
-//
-// The session object is passed out for reference use by any later body processing.
-func doSessionHeader(
-	ctx context.Context, w http.ResponseWriter, r *http.Request,
-	action func(ctx context.Context, session *sessions.Session) error) error {
-
-	session, _ := server.cookieStore.Get(r, SessionCookieName)
-
-	err := action(ctx, session)
-
-	if errx := session.Save(r, w); errx != nil {
-		return &HTTPError{
-			SC:   http.StatusInternalServerError,
-			Base: errx,
-		}
-	}
-
-	return err
-}
-
-
-func getLoggedInUser(session *sessions.Session) (*pb.User, error) {
-	key, ok := session.Values[UserNameKey].(string)
-	if !ok {
-		return nil, &HTTPError{
-			SC:   http.StatusBadRequest,
-			Base: http.ErrNoCookie,
-		}
-	}
-
-	user, _, err := dbUsers.Get(key)
-	return user, err
 }

--- a/internal/services/frontend/frontend.go
+++ b/internal/services/frontend/frontend.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gorilla/sessions"
 	"google.golang.org/grpc"
 
-	clients "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
+	ts "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
 	"github.com/Jim3Things/CloudChamber/internal/config"
 	ctrc "github.com/Jim3Things/CloudChamber/internal/tracing/client"
 )
@@ -136,7 +136,7 @@ func initService(cfg *config.GlobalConfig) error {
 	server.cookieStore.Options.HttpOnly = false
 
 	// Initialize the simulated time (stepper) service client
-	clients.InitTimestamp(
+	ts.InitTimestamp(
 		fmt.Sprintf(
 			"%s:%d",
 			cfg.SimSupport.EP.Hostname,

--- a/internal/services/frontend/session_manager.go
+++ b/internal/services/frontend/session_manager.go
@@ -1,0 +1,48 @@
+// This module contains the session management support methods
+package frontend
+
+import (
+    "context"
+    "net/http"
+
+    "github.com/gorilla/sessions"
+
+    pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
+)
+
+// getLoggedInUser returns the user definition for the current session,
+// or an error, if no user can be found.
+func getLoggedInUser(session *sessions.Session) (*pb.User, error) {
+    key, ok := session.Values[UserNameKey].(string)
+    if !ok {
+        return nil, &HTTPError{
+            SC:   http.StatusBadRequest,
+            Base: http.ErrNoCookie,
+        }
+    }
+
+    user, _, err := dbUsers.Get(key)
+    return user, err
+}
+
+// doSessionHeader wraps a handler action with the necessary code to retrieve any existing session state,
+// and to attach that state to the response prior to returning.
+//
+// The session object is passed out for reference use by any later body processing.
+func doSessionHeader(
+    ctx context.Context, w http.ResponseWriter, r *http.Request,
+    action func(ctx context.Context, session *sessions.Session) error) error {
+
+    session, _ := server.cookieStore.Get(r, SessionCookieName)
+
+    err := action(ctx, session)
+
+    if errx := session.Save(r, w); errx != nil {
+        return &HTTPError{
+            SC:   http.StatusInternalServerError,
+            Base: errx,
+        }
+    }
+
+    return err
+}

--- a/internal/services/frontend/stepper.go
+++ b/internal/services/frontend/stepper.go
@@ -1,0 +1,46 @@
+package frontend
+
+import (
+    "context"
+    "net/http"
+
+    "github.com/gorilla/mux"
+
+    "github.com/Jim3Things/CloudChamber/internal/tracing"
+    st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+)
+
+func stepperAddRoutes(routeBase *mux.Router) {
+    routeStepper := routeBase.PathPrefix("/stepper").Subrouter()
+
+    routeStepper.HandleFunc("", handleGetStatus).Methods("GET")
+    routeStepper.HandleFunc("/", handleGetStatus).Methods("GET")
+
+    routeStepper.HandleFunc("", handleAdvance).Queries("advance", "{num}").Methods("PUT")
+    routeStepper.HandleFunc("", handleSetMode).Queries("mode", "{type}").Methods("PUT")
+    routeStepper.HandleFunc("/now", handleGetNow).Methods("GET")
+}
+
+func handleGetStatus(w http.ResponseWriter, r *http.Request) {
+    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        return nil
+    })
+}
+
+func handleAdvance(w http.ResponseWriter, r *http.Request) {
+    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        return nil
+    })
+}
+
+func handleSetMode(w http.ResponseWriter, r *http.Request) {
+    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        return nil
+    })
+}
+
+func handleGetNow(w http.ResponseWriter, r *http.Request) {
+    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        return nil
+    })
+}

--- a/internal/services/frontend/stepper.go
+++ b/internal/services/frontend/stepper.go
@@ -4,8 +4,10 @@ import (
     "context"
     "net/http"
 
+    "github.com/golang/protobuf/jsonpb"
     "github.com/gorilla/mux"
 
+    clients "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
     "github.com/Jim3Things/CloudChamber/internal/tracing"
     st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 )
@@ -39,8 +41,15 @@ func handleSetMode(w http.ResponseWriter, r *http.Request) {
     })
 }
 
-func handleGetNow(w http.ResponseWriter, r *http.Request) {
+func handleGetNow(w http.ResponseWriter, _ *http.Request) {
     _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-        return nil
+        now, err := clients.Now()
+        if err != nil {
+            httpError(ctx, w, err)
+            return err
+        }
+
+        p := jsonpb.Marshaler{}
+        return p.Marshal(w, now)
     })
 }

--- a/internal/services/frontend/stepper_test.go
+++ b/internal/services/frontend/stepper_test.go
@@ -2,19 +2,39 @@ package frontend
 
 import (
     "fmt"
+    "net/http"
     "net/http/httptest"
     "testing"
 
+    "github.com/stretchr/testify/assert"
+
     "github.com/Jim3Things/CloudChamber/internal/tracing/exporters/unit_test"
+    "github.com/Jim3Things/CloudChamber/pkg/protos/common"
 )
 
 func TestStepperGetNow(t *testing.T) {
     unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
 
     request := httptest.NewRequest("GET", fmt.Sprintf("%s%s", baseURI, "/api/stepper/now"), nil)
     response := doHTTP(request, nil)
-    body, err := getBody(response)
 
-    t.Log(string(body))
-    t.Logf("Err=%v", err)
+    assert.Equal(t, http.StatusOK, response.StatusCode)
+
+    res := &common.Timestamp{}
+    err := getJsonBody(response, res)
+
+    assert.Nilf(t, err, "Unexpected error, err: %v", err)
+    t.Log(res.Ticks)
+
+    request = httptest.NewRequest("GET", fmt.Sprintf("%s%s", baseURI, "/api/stepper/now"), nil)
+    response = doHTTP(request, nil)
+
+    assert.Equal(t, http.StatusOK, response.StatusCode)
+
+    res2 := &common.Timestamp{}
+    err = getJsonBody(response, res2)
+
+    assert.Nilf(t, err, "Unexpected error, err: %v", err)
+    assert.Equal(t, res.Ticks, res2.Ticks, "times with no advance do not match, %v != %v", res.Ticks, res2.Ticks)
 }

--- a/internal/services/frontend/stepper_test.go
+++ b/internal/services/frontend/stepper_test.go
@@ -1,0 +1,20 @@
+package frontend
+
+import (
+    "fmt"
+    "net/http/httptest"
+    "testing"
+
+    "github.com/Jim3Things/CloudChamber/internal/tracing/exporters/unit_test"
+)
+
+func TestStepperGetNow(t *testing.T) {
+    unit_test.SetTesting(t)
+
+    request := httptest.NewRequest("GET", fmt.Sprintf("%s%s", baseURI, "/api/stepper/now"), nil)
+    response := doHTTP(request, nil)
+    body, err := getBody(response)
+
+    t.Log(string(body))
+    t.Logf("Err=%v", err)
+}

--- a/internal/services/frontend/users.go
+++ b/internal/services/frontend/users.go
@@ -455,15 +455,7 @@ func userVerifyPassword(name string, password []byte) error {
 // Determine if this session's active login has permission to change or
 // manage the targeted account.  Note that any account may manage itself.
 func canManageAccounts(session *sessions.Session, username string) error {
-    key, ok := session.Values[UserNameKey].(string)
-    if !ok {
-        return &HTTPError{
-            SC:   http.StatusBadRequest,
-            Base: http.ErrNoCookie,
-        }
-    }
-
-    user, _, err := dbUsers.Get(key)
+    user, err := getLoggedInUser(session)
     if err != nil {
         return NewErrUserPermissionDenied()
     }

--- a/internal/services/frontend/users_test.go
+++ b/internal/services/frontend/users_test.go
@@ -113,6 +113,7 @@ func ensureAccount(t *testing.T, user string, u *pb.UserDefinition, cookies []*h
 
 func TestUsersLoginSessionSimple(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	// login for the first time, should succeed
 	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s?op=login", baseURI, admin), strings.NewReader(adminPassword))
@@ -143,6 +144,7 @@ func TestUsersLoginSessionSimple(t *testing.T) {
 
 func TestUsersLoginSessionRepeat(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	// login for the first time, should succeed
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
@@ -173,6 +175,7 @@ func TestUsersLoginSessionRepeat(t *testing.T) {
 
 func TestUsersLoginDupLogins(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	// login for the first time, should succeed
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
@@ -219,6 +222,7 @@ func TestUsersLoginDupLogins(t *testing.T) {
 
 func TestUsersLoginLogoutDiffAccounts(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	// login for the first time, should succeed
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
@@ -252,6 +256,7 @@ func TestUsersLoginLogoutDiffAccounts(t *testing.T) {
 
 func TestUsersDoubleLogout(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	// login for the first time, should succeed
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
@@ -283,6 +288,7 @@ func TestUsersDoubleLogout(t *testing.T) {
 
 func TestUsersLoginSessionBadPassword(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	// login for the first time, should succeed
 	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s?op=login", baseURI, admin), strings.NewReader(adminPassword+"rubbish"))
@@ -305,6 +311,7 @@ func TestUsersLoginSessionBadPassword(t *testing.T) {
 
 func TestUsersLoginSessionNoUser(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	// login for the first time, should succeed
 	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s?op=login", baseURI, admin+"Bogus"), strings.NewReader(adminPassword))
@@ -331,6 +338,7 @@ func TestUsersLoginSessionNoUser(t *testing.T) {
 
 func TestUsersCreate(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	path := baseURI + alice + "2"
 
@@ -361,6 +369,7 @@ func TestUsersCreate(t *testing.T) {
 
 func TestUsersCreateDup(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	r, err := toJsonReader(aliceDef)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
@@ -390,6 +399,7 @@ func TestUsersCreateDup(t *testing.T) {
 
 func TestUsersCreateBadData(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
@@ -417,6 +427,7 @@ func TestUsersCreateBadData(t *testing.T) {
 
 func TestUsersCreateNoPriv(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	r, err := toJsonReader(bobDef)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
@@ -444,6 +455,7 @@ func TestUsersCreateNoPriv(t *testing.T) {
 
 func TestUsersCreateNoSession(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	path := baseURI + alice + "2"
 
@@ -461,9 +473,9 @@ func TestUsersCreateNoSession(t *testing.T) {
 	t.Logf("[%s]: SC=%v, Content-Type='%v'\n", path, response.StatusCode, response.Header.Get("Content-Type"))
 	t.Log(string(body))
 
-	assert.Equal(t, http.StatusBadRequest, response.StatusCode, "Handler returned unexpected error: %v", response.StatusCode)
+	assert.Equal(t, http.StatusForbidden, response.StatusCode, "Handler returned unexpected error: %v", response.StatusCode)
 	assert.Equal(t,
-		"http: named cookie not present\n", string(body),
+		"CloudChamber: permission denied\n", string(body),
 		"Handler returned unexpected response body: %v", string(body))
 }
 
@@ -473,6 +485,7 @@ func TestUsersCreateNoSession(t *testing.T) {
 
 func TestUsersList(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
@@ -509,6 +522,7 @@ func TestUsersList(t *testing.T) {
 
 func TestUsersListNoPriv(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 	_, cookies := ensureAccount(t, "Alice", aliceDef, response.Cookies())
@@ -533,6 +547,7 @@ func TestUsersListNoPriv(t *testing.T) {
 
 func TestUsersRead(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
@@ -558,6 +573,7 @@ func TestUsersRead(t *testing.T) {
 
 func TestUsersReadUnknownUser(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
@@ -578,6 +594,7 @@ func TestUsersReadUnknownUser(t *testing.T) {
 
 func TestUsersReadNoPriv(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 	_, cookies := ensureAccount(t, "Alice", aliceDef, response.Cookies())
@@ -606,6 +623,7 @@ func TestUsersReadNoPriv(t *testing.T) {
 
 func TestUsersOperationIllegal(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	// Verify a bunch of failure cases. Specifically,
 	// - that a naked op fails
@@ -658,6 +676,7 @@ func TestUsersUpdate(t *testing.T) {
 	}
 
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
@@ -688,6 +707,7 @@ func TestUsersUpdate(t *testing.T) {
 
 func TestUsersUpdateBadData(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
@@ -724,6 +744,7 @@ func TestUsersUpdateBadMatch(t *testing.T) {
 	}
 
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
@@ -758,6 +779,7 @@ func TestUsersUpdateBadMatchSyntax(t *testing.T) {
 	}
 
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
@@ -789,6 +811,7 @@ func TestUsersUpdateNoUser(t *testing.T) {
 	}
 
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
@@ -817,6 +840,7 @@ func TestUsersUpdateNoPriv(t *testing.T) {
 	}
 
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 	_, cookies := ensureAccount(t, "Alice", aliceDef, response.Cookies())
@@ -848,6 +872,7 @@ func TestUsersUpdateNoPriv(t *testing.T) {
 
 func TestUsersDelete(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	path := fmt.Sprintf("%s%s", baseURI, alice)
 
@@ -883,6 +908,7 @@ func TestUsersDelete(t *testing.T) {
 
 func TestUsersDeleteNoUser(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	path := fmt.Sprintf("%s%s", baseURI, alice+"Bogus")
 
@@ -904,6 +930,7 @@ func TestUsersDeleteNoUser(t *testing.T) {
 
 func TestUsersDeleteNoPriv(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 	_, cookies := ensureAccount(t, "Alice", aliceDef, response.Cookies())
@@ -927,6 +954,7 @@ func TestUsersDeleteNoPriv(t *testing.T) {
 
 func TestUsersDeleteProtected(t *testing.T) {
 	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 

--- a/internal/services/stepper_actor/actor.go
+++ b/internal/services/stepper_actor/actor.go
@@ -34,7 +34,7 @@ type Actor struct {
 
 // Register the stepper actor with the supplied grpc server (via the adapter
 // functions)
-func Register(svc *grpc.Server) (err error) {
+func Register(svc *grpc.Server, p pb.StepperPolicy) (err error) {
     // Create the base actor object
     act := &Actor{
         adapter: &server{},
@@ -54,9 +54,16 @@ func Register(svc *grpc.Server) (err error) {
         return err
     }
 
-    // .. and finally, connect it to the incoming grpc messages
+    // .. and then, connect it to the incoming grpc messages
     act.adapter.Attach(pid)
     pb.RegisterStepperServer(svc, act.adapter)
+
+    // Finally, if there is a default policy provided, set it now.
+    if p != pb.StepperPolicy_Invalid {
+        if err := act.adapter.SetDefaultPolicy(p); err != nil {
+            return err
+        }
+    }
 
     return nil
 }

--- a/internal/services/stepper_actor/stepper_test.go
+++ b/internal/services/stepper_actor/stepper_test.go
@@ -35,7 +35,7 @@ func init() {
 
     lis = bufconn.Listen(bufSize)
     s := grpc.NewServer(grpc.UnaryInterceptor(srvtrace.Interceptor))
-    if err := Register(s); err != nil {
+    if err := Register(s, pb.StepperPolicy_Invalid); err != nil {
         log.Fatalf("Failed to register wither error: %v", err)
     }
 
@@ -122,8 +122,6 @@ func testDelay(t *testing.T, ctx context.Context, atLeast int64, jitter int64) {
 }
 
 func commonSetup(t *testing.T) (context.Context, *grpc.ClientConn) {
-    unit_test.SetTesting(t)
-
     conn, err := grpc.Dial(
         "bufnet",
         grpc.WithContextDialer(bufDialer),
@@ -146,6 +144,9 @@ func commonSetup(t *testing.T) (context.Context, *grpc.ClientConn) {
 }
 
 func TestInvalidSetPolicyType(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
     ctx, conn := commonSetup(t)
     defer func() { _ = conn.Close() }()
 
@@ -156,6 +157,9 @@ func TestInvalidSetPolicyType(t *testing.T) {
 }
 
 func TestInvalidSetPolicyManual(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
     ctx, conn := commonSetup(t)
     defer func() { _ = conn.Close() }()
 
@@ -172,6 +176,9 @@ func TestInvalidSetPolicyManual(t *testing.T) {
 }
 
 func TestInvalidSetPolicyMeasured(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
     ctx, conn := commonSetup(t)
     defer func() { _ = conn.Close() }()
 
@@ -190,6 +197,9 @@ func TestInvalidSetPolicyMeasured(t *testing.T) {
 }
 
 func TestInvalidSetPolicyNoWait(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
     ctx, conn := commonSetup(t)
     defer func() { _ = conn.Close() }()
 
@@ -206,6 +216,9 @@ func TestInvalidSetPolicyNoWait(t *testing.T) {
 }
 
 func TestInvalidDelay(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
     ctx, conn := commonSetup(t)
     defer func() { _ = conn.Close() }()
 
@@ -222,6 +235,9 @@ func TestInvalidDelay(t *testing.T) {
 }
 
 func TestStepper_NoWait(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
     ctx, conn := commonSetup(t)
     defer func() { _ = conn.Close() }()
 
@@ -238,6 +254,9 @@ func TestStepper_NoWait(t *testing.T) {
 }
 
 func TestStepper_Measured(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
     ctx, conn := commonSetup(t)
     defer func() { _ = conn.Close() }()
 
@@ -259,6 +278,9 @@ func TestStepper_Measured(t *testing.T) {
 }
 
 func TestStepper_Manual(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
     ctx, conn := commonSetup(t)
     defer func() { _ = conn.Close() }()
 

--- a/internal/tracing/exporters/common/common.go
+++ b/internal/tracing/exporters/common/common.go
@@ -10,22 +10,16 @@ import (
 	"github.com/Jim3Things/CloudChamber/pkg/protos/log"
 )
 
-func ExtractEntry(_ context.Context, data *trace.SpanData) log.Entry {
+func ExtractEntry(_ context.Context, data *trace.SpanData) *log.Entry {
 	spanID := data.SpanContext.SpanID.String()
 	parentID := data.ParentSpanID.String()
 
-	entry := log.Entry{
+	entry := &log.Entry{
 		Name:     data.Name,
 		SpanID:   spanID,
 		ParentID: parentID,
 		Status:   fmt.Sprintf("%v: %v", data.StatusCode, data.StatusMessage),
 		StackTrace: "",
-	}
-
-	for _, attr := range data.Attributes {
-		if attr.Key == tracing.StackTraceKey {
-			entry.StackTrace = attr.Value.AsString()
-		}
 	}
 
 	for _, attr := range data.Attributes {

--- a/internal/tracing/exporters/unit_test/utIntegration.go
+++ b/internal/tracing/exporters/unit_test/utIntegration.go
@@ -20,17 +20,46 @@ type Exporter struct {
 
 var testContext *testing.T
 
+// Since the actor system can produce async activity that occurs outside of an
+// active test context, we have to be able to handle these events.  When they
+// happen we save them into this array and process them as soon as we see an
+// active test context.
+var savedEntries []*log.Entry
+
 func NewExporter(_ Options) (*Exporter, error) {
 	return &Exporter{}, nil
 }
 
+// Set the testing context hook, or clear it, if the reference is nil.
 func SetTesting(item *testing.T) {
 	testContext = item
+
+	if testContext != nil {
+		flushSaved()
+	}
 }
 
+// Export a span to the output channel
 func (e *Exporter) ExportSpan(ctx context.Context, data *export.SpanData) {
-	entry := common.ExtractEntry(ctx, data)
+	if testContext != nil {
+		flushSaved()
+		processOneEntry(common.ExtractEntry(ctx, data))
+	} else {
+		savedEntries = append(savedEntries, common.ExtractEntry(ctx, data))
+	}
+}
 
+// Flush all saved (out of band) entries into the trace log
+func flushSaved() {
+	for _, item := range savedEntries {
+		processOneEntry(item)
+	}
+
+	savedEntries = []*log.Entry{}
+}
+
+// Send one entry to the output channel
+func processOneEntry(entry *log.Entry) {
 	testContext.Logf("[%s:%s] %s %s:\n%s", entry.GetSpanID(), entry.GetParentID(), entry.GetStatus(), entry.GetName(), entry.GetStackTrace())
 
 	for _, event := range entry.Event {

--- a/pkg/protos/Stepper/stepper.proto
+++ b/pkg/protos/Stepper/stepper.proto
@@ -30,11 +30,11 @@ service Stepper {
 
     // Delay the simulated time by a specified amount +/- an allowed variance.
     // Do not return until that new time is current.
-    rpc Delay (DelayRequest) returns (common.Timestamp);
+    rpc Delay(DelayRequest) returns (common.Timestamp);
 
     // Forcibly reset the stepper's internal state back to its starting
     // point.
-    rpc Reset (ResetRequest) returns (google.protobuf.Empty);
+    rpc Reset(ResetRequest) returns (google.protobuf.Empty);
 }
 
 // Define the various simulated time stepping policies


### PR DESCRIPTION
This adds REST processing for GET /api/stepper/now, and a UT to verify
In turn, this caused:
- changes to timestamp setup,
- adding a default stepper policy to the config
- Tracking down and fixing a trace/test context sync issue