### PR TITLE
Rename inventory test file

### DIFF
--- a/internal/clients/timestamp/timestamp_test.go
+++ b/internal/clients/timestamp/timestamp_test.go
@@ -63,7 +63,7 @@ func TestNow(t *testing.T) {
 	defer unit_test.SetTesting(nil)
 
 	commonSetup(t)
-	assert.Nil(t, SetPolicy(pb.StepperPolicy_Manual, &duration.Duration{Seconds: 0}))
+	assert.Nil(t, SetPolicy(pb.StepperPolicy_Manual, &duration.Duration{Seconds: 0}, -1))
 
 	now, err := Now()
 	assert.Nil(t, err)
@@ -88,7 +88,7 @@ func TestTimestamp_After(t *testing.T) {
 	defer unit_test.SetTesting(nil)
 
 	commonSetup(t)
-	assert.Nil(t, SetPolicy(pb.StepperPolicy_Manual, &duration.Duration{Seconds: 0}))
+	assert.Nil(t, SetPolicy(pb.StepperPolicy_Manual, &duration.Duration{Seconds: 0}, -1))
 
 	now, err := Now()
 	assert.Nil(t, err)

--- a/internal/services/frontend/common_test.go
+++ b/internal/services/frontend/common_test.go
@@ -65,7 +65,6 @@ func TestMain(m *testing.M) {
 // Establish the test environment, including starting a test frontend service
 // over a faked http connection.
 func commonSetup() {
-
     if initialized {
         log.Fatalf("Error initializing service for second or subsequent time")
     }

--- a/internal/services/frontend/errors.go
+++ b/internal/services/frontend/errors.go
@@ -155,4 +155,32 @@ func NewErrUserProtected(name string) *HTTPError {
     }
 }
 
+func NewErrInvalidStepperMode(mode string) *HTTPError {
+    return &HTTPError{
+        SC:   http.StatusBadRequest,
+        Base: fmt.Errorf("CloudChamber: mode %q is invalid.  Supported modes are 'manual' and 'automatic'", mode),
+    }
+}
+
+func NewErrInvalidRateRequest() *HTTPError {
+    return &HTTPError{
+        SC:   http.StatusBadRequest,
+        Base: errors.New("CloudChamber: manual mode does not accept additional arguments"),
+    }
+}
+
+func NewErrInvalidStepperRate(rate string) *HTTPError {
+    return &HTTPError{
+        SC:   http.StatusBadRequest,
+        Base: fmt.Errorf("CloudChamber: requested rate %q could not be parsed as a positive decimal number", rate),
+    }
+}
+
+func NewErrStepperFailedToSetPolicy() *HTTPError {
+    return &HTTPError{
+        SC:   http.StatusBadRequest,
+        Base: errors.New("CloudChamber: Set simulated time policy operation failed"),
+    }
+}
+
 // --- HTTPError specializations

--- a/internal/services/frontend/errors.go
+++ b/internal/services/frontend/errors.go
@@ -155,8 +155,9 @@ func NewErrUserProtected(name string) *HTTPError {
 	}
 }
 
-// ErrRackNotFound indicates the specified rack do not exist and the http request (http.statusNotFound) determines to be
-// the request was made against a non-existing rack.
+// ErrRackNotFound indicates the specified rack do not exist and the http
+// request (http.statusNotFound) determines to be the request was made against
+// a non-existing rack.
 func NewErrRackNotFound(name string) *HTTPError {
 	return &HTTPError{
 		SC:   http.StatusNotFound,

--- a/internal/services/frontend/inventory_test.go
+++ b/internal/services/frontend/inventory_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// // First DBInventory unit test
+// First DBInventory unit test
 func TestInventoryListRacks(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
@@ -27,7 +27,7 @@ func TestInventoryListRacks(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, response.StatusCode, "Handler returned unexpected error: %v", response.StatusCode)
 	assert.Equal(t, "text/plain; charset=utf-8", strings.ToLower(response.Header.Get("Content-Type")))
-	s := string(body)                   // Converted into a string
+	s := string(body)                        // Converted into a string
 	var splits = strings.Split(s, "\n") // Created an array per line
 
 	expected := []string{"/api/racks/rack1", "/api/racks/rack2", ""}

--- a/internal/services/frontend/stepper.go
+++ b/internal/services/frontend/stepper.go
@@ -2,14 +2,19 @@ package frontend
 
 import (
     "context"
+    "fmt"
     "net/http"
+    "strconv"
+    "strings"
 
     "github.com/golang/protobuf/jsonpb"
+    "github.com/golang/protobuf/ptypes/duration"
     "github.com/gorilla/mux"
 
     clients "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
     "github.com/Jim3Things/CloudChamber/internal/tracing"
     st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+    pb "github.com/Jim3Things/CloudChamber/pkg/protos/Stepper"
 )
 
 func stepperAddRoutes(routeBase *mux.Router) {
@@ -23,31 +28,132 @@ func stepperAddRoutes(routeBase *mux.Router) {
     routeStepper.HandleFunc("/now", handleGetNow).Methods("GET")
 }
 
-func handleGetStatus(w http.ResponseWriter, r *http.Request) {
-    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-        return nil
+func handleGetStatus(w http.ResponseWriter, _ *http.Request) {
+    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
+        stat, err := clients.Status()
+        if err != nil {
+            httpError(ctx, w, err)
+            return err
+        }
+
+        w.Header().Set("Content-Type", "application/json")
+        w.Header().Set("ETag", fmt.Sprintf("%v", stat.Epoch))
+
+        p := jsonpb.Marshaler{}
+        return p.Marshal(w, stat)
     })
 }
 
 func handleAdvance(w http.ResponseWriter, r *http.Request) {
     _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-        return nil
-    })
-}
+        var count int
 
-func handleSetMode(w http.ResponseWriter, r *http.Request) {
-    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-        return nil
-    })
-}
+        vars := mux.Vars(r)
+        arg, ok := vars["num"]
+        if !ok || len(arg) == 0 {
+            count = 1
+        } else {
+            count, err = strconv.Atoi(arg)
+            if err != nil || count <= 0 {
+                err = NewErrInvalidStepperRate(arg)
+                httpError(ctx, w, err)
+                return err
+            }
+        }
 
-func handleGetNow(w http.ResponseWriter, _ *http.Request) {
-    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        for i := 0; i < count; i++ {
+            if err := clients.Advance(); err != nil {
+                httpError(ctx, w, err)
+                return err
+            }
+        }
+
         now, err := clients.Now()
         if err != nil {
             httpError(ctx, w, err)
             return err
         }
+
+        w.Header().Set("Content-Type", "application/json")
+
+        p := jsonpb.Marshaler{}
+        return p.Marshal(w, now)
+    })
+}
+
+func handleSetMode(w http.ResponseWriter, r *http.Request) {
+    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        vars := mux.Vars(r)
+        args := strings.Split(strings.Replace(vars["type"], "=", ":", 1), ":")
+
+        var delay *duration.Duration
+        var policy pb.StepperPolicy
+
+        var match int64
+
+        matchString := r.Header.Get("If-Match")
+        match, err = strconv.ParseInt(matchString, 10, 64)
+        if err != nil {
+            httpError(ctx, w, NewErrBadMatchType(matchString))
+            return err
+        }
+
+        switch args[0] {
+        case "manual":
+            if len(args) != 1 {
+                err := NewErrInvalidRateRequest()
+                httpError(ctx, w, err)
+                return err
+            }
+
+            delay = &duration.Duration{Seconds: 0, Nanos: 0}
+            policy = pb.StepperPolicy_Manual
+
+        case "automatic":
+            delay = &duration.Duration{Seconds: 1, Nanos: 0}
+            if len(args) == 2 {
+                tps, err := strconv.Atoi(args[1])
+                if err != nil {
+                    err = NewErrInvalidStepperRate(args[1])
+                    httpError(ctx, w, err)
+                    return err
+                }
+
+                if tps > 1 {
+                    delay.Seconds = 0
+                    delay.Nanos = int32(1_000_000_000 / tps)
+                }
+            }
+
+            policy = pb.StepperPolicy_Measured
+
+        default:
+            err := NewErrInvalidStepperMode(args[0])
+            httpError(ctx, w, err)
+            return err
+        }
+
+        if err := clients.SetPolicy(policy, delay, match); err != nil {
+            err = NewErrStepperFailedToSetPolicy()
+            httpError(ctx, w, err)
+            return err
+        }
+
+        w.Header().Set("ETag", fmt.Sprintf("%v", match + 1))
+
+        return nil
+    })
+}
+
+func handleGetNow(w http.ResponseWriter, _ *http.Request) {
+    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
+        now, err := clients.Now()
+        if err != nil {
+            httpError(ctx, w, err)
+            return err
+        }
+
+        w.Header().Set("Content-Type", "application/json")
 
         p := jsonpb.Marshaler{}
         return p.Marshal(w, now)

--- a/internal/services/frontend/stepper_test.go
+++ b/internal/services/frontend/stepper_test.go
@@ -8,15 +8,35 @@ import (
 
     "github.com/stretchr/testify/assert"
 
+    ts "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
     "github.com/Jim3Things/CloudChamber/internal/tracing/exporters/unit_test"
+    pb "github.com/Jim3Things/CloudChamber/pkg/protos/Stepper"
     "github.com/Jim3Things/CloudChamber/pkg/protos/common"
 )
 
-func TestStepperGetNow(t *testing.T) {
-    unit_test.SetTesting(t)
-    defer unit_test.SetTesting(nil)
+const (
+	stepperURI    = "/api/stepper"
+)
 
-    request := httptest.NewRequest("GET", fmt.Sprintf("%s%s", baseURI, "/api/stepper/now"), nil)
+func testStepperPath() string { return baseURI + stepperURI }
+
+func testStepperReset(t *testing.T) {
+    err := ts.Reset()
+    assert.Nilf(t, err, "Unexpected error when resetting the stepper service)")
+}
+
+func testStepperSetManual(t *testing.T, match int64) {
+    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?mode=manual"), nil)
+    request.Header.Set("If-Match", fmt.Sprintf("%v", match))
+
+    response := doHTTP(request, nil)
+
+    assert.Equal(t, http.StatusOK, response.StatusCode)
+    assert.Equal(t, fmt.Sprintf("%v", match + 1), response.Header.Get("ETag"))
+}
+
+func testStepperGetNow(t *testing.T) *common.Timestamp {
+    request := httptest.NewRequest("GET", fmt.Sprintf("%s%s", testStepperPath(), "/now"), nil)
     response := doHTTP(request, nil)
 
     assert.Equal(t, http.StatusOK, response.StatusCode)
@@ -25,16 +45,196 @@ func TestStepperGetNow(t *testing.T) {
     err := getJsonBody(response, res)
 
     assert.Nilf(t, err, "Unexpected error, err: %v", err)
-    t.Log(res.Ticks)
 
-    request = httptest.NewRequest("GET", fmt.Sprintf("%s%s", baseURI, "/api/stepper/now"), nil)
-    response = doHTTP(request, nil)
+    return res
+}
+
+func testStepperGetStatus(t *testing.T) *pb.StatusResponse {
+    request := httptest.NewRequest("GET", testStepperPath(), nil)
+    response := doHTTP(request, nil)
 
     assert.Equal(t, http.StatusOK, response.StatusCode)
 
-    res2 := &common.Timestamp{}
-    err = getJsonBody(response, res2)
+    res := &pb.StatusResponse{}
+    err := getJsonBody(response, res)
 
     assert.Nilf(t, err, "Unexpected error, err: %v", err)
+
+    return res
+}
+
+func TestStepperGetStatus(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
+    res := testStepperGetStatus(t)
+    t.Log(res)
+}
+
+func TestStepperSetManual(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
+    testStepperReset(t)
+    stat := testStepperGetStatus(t)
+    testStepperSetManual(t, stat.Epoch)
+
+    res := testStepperGetStatus(t)
+    assert.Equal(t, pb.StepperPolicy_Manual, res.Policy, "Unexpected policy")
+    assert.Equal(t, int64(0), res.MeasuredDelay.Seconds, "Unexpected delay")
+    assert.Equal(t, int32(0), res.MeasuredDelay.Nanos, "Unexpected delay")
+    assert.Equal(t, int64(0), res.Now.Ticks, "Unexpected current time")
+    assert.Equal(t, int64(0), res.WaiterCount, "Unexpected active waiter count")
+    assert.Equal(t, stat.Epoch + 1, res.Epoch, "Unexpected epoch value")
+}
+
+func TestStepperSetModeInvalid(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
+    testStepperReset(t)
+    res := testStepperGetStatus(t)
+    testStepperSetManual(t, res.Epoch)
+
+    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?mode=badChoice"), nil)
+    request.Header.Set("If-Match", "-1")
+
+    response := doHTTP(request, nil)
+
+    assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+
+    body, err := getBody(response)
+    assert.Nil(t, err)
+    assert.Equal(t, "CloudChamber: mode \"badChoice\" is invalid.  Supported modes are 'manual' and 'automatic'\n", string(body))
+
+    res = testStepperGetStatus(t)
+    assert.Equal(t, pb.StepperPolicy_Manual, res.Policy, "Unexpected policy")
+    assert.Equal(t, int64(0), res.MeasuredDelay.Seconds, "Unexpected delay")
+    assert.Equal(t, int32(0), res.MeasuredDelay.Nanos, "Unexpected delay")
+    assert.Equal(t, int64(0), res.Now.Ticks, "Unexpected current time")
+    assert.Equal(t, int64(0), res.WaiterCount, "Unexpected active waiter count")
+}
+
+func TestStepperSetModeBadEpoch(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
+    testStepperReset(t)
+    stat := testStepperGetStatus(t)
+    testStepperSetManual(t, stat.Epoch)
+
+    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?mode=manual"), nil)
+    request.Header.Set("If-Match", fmt.Sprintf("%v", stat.Epoch))
+
+    response := doHTTP(request, nil)
+
+    assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+
+    body, err := getBody(response)
+    assert.Nil(t, err)
+    assert.Equal(t, "CloudChamber: Set simulated time policy operation failed\n", string(body))
+
+    res := testStepperGetStatus(t)
+    assert.Equal(t, pb.StepperPolicy_Manual, res.Policy, "Unexpected policy")
+    assert.Equal(t, int64(0), res.MeasuredDelay.Seconds, "Unexpected delay")
+    assert.Equal(t, int32(0), res.MeasuredDelay.Nanos, "Unexpected delay")
+    assert.Equal(t, int64(0), res.Now.Ticks, "Unexpected current time")
+    assert.Equal(t, int64(0), res.WaiterCount, "Unexpected active waiter count")
+    assert.Equal(t, stat.Epoch + 1, res.Epoch, "Unexpected epoch")
+}
+
+func TestStepperAdvanceOne(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
+    testStepperReset(t)
+    stat := testStepperGetStatus(t)
+    testStepperSetManual(t, stat.Epoch)
+
+    res := testStepperGetNow(t)
+    assert.Equal(t, int64(0), res.Ticks, "Time expected to be reset, was %d", res.Ticks)
+
+    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?advance"), nil)
+    response := doHTTP(request, nil)
+    assert.Equal(t, http.StatusOK, response.StatusCode)
+
+    res2 := &common.Timestamp{}
+    err := getJsonBody(response, res2)
+
+    assert.Nilf(t, err, "Unexpected error, err: %v", err)
+
+    assert.Equal(t, int64(1), res2.Ticks - res.Ticks, "time expected to advance by 1, old: %d, new: %d", res.Ticks, res2.Ticks)
+}
+
+func TestStepperAdvanceTwo(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
+    status := testStepperGetStatus(t)
+
+    testStepperSetManual(t, status.Epoch)
+    res := testStepperGetNow(t)
+
+    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?advance=2"), nil)
+    response := doHTTP(request, nil)
+    assert.Equal(t, http.StatusOK, response.StatusCode)
+
+    res2 := &common.Timestamp{}
+    err := getJsonBody(response, res2)
+
+    assert.Nilf(t, err, "Unexpected error, err: %v", err)
+
+    assert.Equal(t, int64(2), res2.Ticks - res.Ticks, "time expected to advance by 1, old: %d, new: %d", res.Ticks, res2.Ticks)
+}
+
+func TestStepperAdvanceNotANumber(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
+    stat := testStepperGetStatus(t)
+    testStepperSetManual(t, stat.Epoch)
+
+    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?advance=two"), nil)
+    response := doHTTP(request, nil)
+    assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+    body, err := getBody(response)
+    assert.Nil(t, err)
+    assert.Equal(t, "CloudChamber: requested rate \"two\" could not be parsed as a positive decimal number\n", string(body))
+}
+
+func TestStepperAdvanceMinusOne(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
+    stat := testStepperGetStatus(t)
+    testStepperSetManual(t, stat.Epoch)
+
+    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?advance=-1"), nil)
+    response := doHTTP(request, nil)
+    assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+    body, err := getBody(response)
+    assert.Nil(t, err)
+    assert.Equal(t, "CloudChamber: requested rate \"-1\" could not be parsed as a positive decimal number\n", string(body))
+}
+
+func TestStepperSetManualBadRate(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
+    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?mode=manual=10"), nil)
+    response := doHTTP(request, nil)
+
+    assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+}
+
+func TestStepperGetNow(t *testing.T) {
+    unit_test.SetTesting(t)
+    defer unit_test.SetTesting(nil)
+
+    res := testStepperGetNow(t)
+    t.Log(res.Ticks)
+
+    res2 := testStepperGetNow(t)
+
     assert.Equal(t, res.Ticks, res2.Ticks, "times with no advance do not match, %v != %v", res.Ticks, res2.Ticks)
 }

--- a/internal/services/stepper_actor/actor.go
+++ b/internal/services/stepper_actor/actor.go
@@ -30,6 +30,8 @@ type Actor struct {
 
     latest int64                // current simulate time, in ticks
     waiters *treemap.Map        // waiting delay operations
+
+    epoch  int64                // Epoch counter (policy changes)
 }
 
 // Register the stepper actor with the supplied grpc server (via the adapter

--- a/internal/services/stepper_actor/adapter.go
+++ b/internal/services/stepper_actor/adapter.go
@@ -110,6 +110,15 @@ func (s *server) Reset(_ context.Context, in *pb.ResetRequest) (*empty.Empty, er
     return asEmpty(msgToError(c.RequestFuture(s.pid, in, ActorTimeout).Result()))
 }
 
+func (s *server) GetStatus(_ context.Context, in *pb.GetStatusRequest) (*pb.StatusResponse, error) {
+    if err := in.Validate(); err != nil {
+        return nil, err
+    }
+
+    c := actor.EmptyRootContext
+    return asStatusResponse(msgToError(c.RequestFuture(s.pid, in, ActorTimeout).Result()))
+}
+
 // --- GRPC Methods
 
 // +++ Helper functions
@@ -127,6 +136,15 @@ func asTimestamp(res interface{}, err error) (*common.Timestamp, error) {
 func asEmpty(res interface{}, err error) (*empty.Empty, error) {
     if err == nil {
         return res.(*empty.Empty), err
+    }
+
+    return nil, err
+}
+
+// Convert the return pair into (StatusResposne, error) types
+func asStatusResponse(res interface{}, err error) (*pb.StatusResponse, error) {
+    if err == nil {
+        return res.(*pb.StatusResponse), err
     }
 
     return nil, err

--- a/internal/tracing/server/actor_interceptor.go
+++ b/internal/tracing/server/actor_interceptor.go
@@ -101,13 +101,15 @@ func dumpMessage(msg interface{}) string {
         return fmt.Sprintf("common.Completion error: %q", msg.Error)
 
     case *common.Timestamp:
-        return "common.Timestamp"
+        return fmt.Sprintf("common.Timestamp: Ticks: %d", msg.Ticks)
 
     case *pb.AutoStepRequest:
         return "AutoStepRequest"
 
     case *pb.PolicyRequest:
-        return fmt.Sprintf("PolicyRequest: policy: %v, delay: %ds", msg.Policy, msg.MeasuredDelay.Seconds)
+        return fmt.Sprintf(
+            "PolicyRequest: policy: %v, delay: %ds.%dn, match: %d",
+            msg.Policy, msg.MeasuredDelay.Seconds, msg.MeasuredDelay.Nanos, msg.MatchEpoch)
 
     case *pb.ResetRequest:
         return "ResetRequest"
@@ -120,6 +122,14 @@ func dumpMessage(msg interface{}) string {
 
     case *pb.DelayRequest:
         return fmt.Sprintf("DelayRequest: atLeast to %d, jitter %d", msg.AtLeast.Ticks, msg.Jitter)
+
+    case *pb.GetStatusRequest:
+        return "GetStatusRequest"
+
+    case *pb.StatusResponse:
+        return fmt.Sprintf(
+            "StatusResponse: mode: %v, measured delay: %ds.%dn, current time: %d, number of waiters: %d, epoch: %d",
+            msg.Policy, msg.MeasuredDelay.Seconds, msg.MeasuredDelay.Nanos, msg.Now.Ticks, msg.WaiterCount, msg.Epoch)
 
     case *empty.Empty:
         return "<empty>"

--- a/pkg/protos/Stepper/Stepper.Validate.go
+++ b/pkg/protos/Stepper/Stepper.Validate.go
@@ -62,3 +62,7 @@ func (x *DelayRequest) Validate() error {
 func (x *ResetRequest) Validate() error {
     return nil
 }
+
+func (x *GetStatusRequest) Validate() error {
+    return nil
+}

--- a/pkg/protos/Stepper/stepper.proto
+++ b/pkg/protos/Stepper/stepper.proto
@@ -35,6 +35,9 @@ service Stepper {
     // Forcibly reset the stepper's internal state back to its starting
     // point.
     rpc Reset(ResetRequest) returns (google.protobuf.Empty);
+
+    // Get the current status for the stepper service
+    rpc GetStatus(GetStatusRequest) returns (StatusResponse);
 }
 
 // Define the various simulated time stepping policies
@@ -66,6 +69,11 @@ message PolicyRequest {
 
     // Number of seconds between ticks.  Only valid for the "Measured" policy.
     google.protobuf.Duration measuredDelay = 2;
+
+    // If non-negative, require that the current policy revision number match
+    // Negative values do not require a match, and force an unconditional
+    // application of the new policy
+    int64 matchEpoch = 3;
 }
 
 // Define the request associated with a Step operation
@@ -89,10 +97,31 @@ message DelayRequest {
 // Define the request associated with a forcible reset
 message ResetRequest { }
 
+// Define the request associated with a status request
+message GetStatusRequest { }
+
 // Internally used message to cause a simulate time advance based on timer
 // expiry
 message AutoStepRequest {
     // The epoch number associated with the repeating timer call.  Ignore
     // this message if this value does not match the last timer's epoch.
     int64 epoch = 1;
+}
+
+// Define the current status response message
+message StatusResponse {
+    // Current stepper policy
+    StepperPolicy policy = 1;
+
+    // Current measured delay - should be zero if the policy is not "Measured"
+    google.protobuf.Duration measuredDelay = 2;
+
+    // Current simulated time
+    common.Timestamp now = 3;
+
+    // Number of active waiters (number of outstanding delay calls)
+    int64 waiter_count = 4;
+
+    // Current policy version number
+    int64 epoch = 5;
 }


### PR DESCRIPTION
In one of our discussions I agreed to rename the inventory test tile to better match what it was testing.  This seemed like an opportune time to do that.

Also include two minor comment formatting cleanups.