### PR TITLE
Update store and store test tracing to use current trace methods

### DIFF
--- a/internal/clients/store/cloudchamber.yaml
+++ b/internal/clients/store/cloudchamber.yaml
@@ -25,7 +25,7 @@ simSupport:
 store:
   # trace level to use for insteractions with the store and
   # etcd
-  traceLevel: 1
+  traceLevel: 15
 
   # timeout in seconds to allow when attempting to establish
   # a connection to the etcd instance

--- a/internal/clients/store/errors.go
+++ b/internal/clients/store/errors.go
@@ -1,0 +1,57 @@
+// Package store - Errors contains the store package specific errors.
+//
+package store
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+
+	// ErrStoreUnableToCreateClient indicates that it is not currently possible
+	// to create a client.
+	//
+	ErrStoreUnableToCreateClient = errors.New("CloudChamber: unable to create a new client")
+
+	// ErrStoreNotConnected indicates the store instance does not have a
+	// currently active client. The Connect() method can be used to establist a client.
+	//
+	ErrStoreNotConnected = errors.New("CloudChamber: client not currently connected")
+
+	// ErrStoreConnected indicates the request failed as the store is currently
+	// connected and the request is not possible in that condition.
+	//
+	ErrStoreConnected = errors.New("CloudChamber: client currently connected")
+)
+
+// ErrStoreBadResultSize indicates the size of the result set does not match
+// expectations. There may be either too many, or too few. Typically a single
+// result way anticipated and more that that was received.
+//
+type ErrStoreBadResultSize struct {
+	expected int
+	actual   int
+}
+
+func (esbrs ErrStoreBadResultSize) Error() string {
+	return fmt.Sprintf("CloudChamber: unexpected size for result set - got %v expected %v", esbrs.actual, esbrs.expected)
+}
+
+// ErrStoreKeyNotFound indicates the request key was not found when the store
+// lookup/fetch was attempted.
+//
+type ErrStoreKeyNotFound string
+
+func (esknf ErrStoreKeyNotFound) Error() string {
+	return fmt.Sprintf("CloudChamber: key %q not found", string(esknf))
+}
+
+// ErrStoreNotImplemented indicated the called method does not yet have an
+// implementation
+//
+type ErrStoreNotImplemented string
+
+func (esni ErrStoreNotImplemented) Error() string {
+	return fmt.Sprintf("CloudChamber: method %v not currently implemented", string(esni))
+}


### PR DESCRIPTION
Update store and store test tracing to use current trace methods to avoid special handling during test initialization when calling tracing routines from TestMain() (specifically ReadGlobalConfig())

Also cleans up some trace message to remove spurious "\n" characters, attempts to cleanup processing tracing of store call responses containing multiple values and a few other cleanup issues
