### PR TITLE
Add transactional read and update support to the store layer and add user record CRUD operations

### DIFF
--- a/internal/clients/store/common_test.go
+++ b/internal/clients/store/common_test.go
@@ -69,7 +69,6 @@ func commonSetup() {
 	}
 
 	setDefaultNamespaceSuffix(testNamespace)
-	return
 }
 
 func cleanNamespace(testNamespace string) error {

--- a/internal/clients/store/common_test.go
+++ b/internal/clients/store/common_test.go
@@ -130,6 +130,26 @@ func testGenerateKeySetFromKeyValueSet(keyValueSet []KeyValueArg) []string {
 	return keySet
 }
 
+// Build a set of key,value pairs to be created unconditionally in the store.
+//
+func testGenerateRecordUpdateSetFromKeyValueSet(keyValueSet []KeyValueArg, label string, condition WriteCondition) RecordUpdateSet {
+
+	recordUpdateSet := RecordUpdateSet{Label: label, Records: make(map[string]RecordUpdate)}
+
+	for _, kv := range keyValueSet {
+		recordUpdateSet.Records[kv.key] =
+			RecordUpdate{
+				Condition: condition,
+				Record: Record{
+					Revision: RevisionInvalid,
+					Value:    kv.value,
+				},
+			}
+	}
+
+	return recordUpdateSet
+}
+
 // TestMain is the Common test startup method.  This is the _only_ Test* function in this
 // file.
 func TestMain(m *testing.M) {

--- a/internal/clients/store/common_test.go
+++ b/internal/clients/store/common_test.go
@@ -1,0 +1,138 @@
+package store
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Jim3Things/CloudChamber/internal/config"
+	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters"
+	"github.com/Jim3Things/CloudChamber/internal/tracing/setup"
+)
+
+// A number of tests use a pre-computed set of keys for the purposes of
+// the test. This constant determines the standard size of these sets.
+// The value chosen is largely arbitrary. Selecting a value that is too
+// large may lead to problems with values to /from the underlying store,
+// so be reasonable.
+//
+const keySetSize = 100
+
+var (
+	baseURI     string
+	initialized bool
+
+	testNamespaceSuffixRoot = "/Test"
+
+	configPath *string
+)
+
+func commonSetup() {
+	var testNamespace string
+
+	setup.Init(exporters.UnitTest)
+
+	configPath = flag.String("config", ".", "path to the configuration file")
+	flag.Parse()
+
+	cfg, err := config.ReadGlobalConfig(*configPath)
+	if err != nil {
+		log.Fatalf("failed to process the global configuration: %v", err)
+	}
+
+	Initialize(cfg)
+
+	// It is meaningless to have both a unique per-instance test namespace
+	// and to clean the store before the tests are run
+	//
+	if cfg.Store.Test.UseUniqueInstance && cfg.Store.Test.PreCleanStore {
+		log.Fatalf("invalid configuration: both UseUniqueInstance and PreCleanStore are enabled: %v", err)
+	}
+
+	// For test purposes, need to set an alternate namespace rather than
+	// rely on the standard. From the configuration, we can either use the
+	// standard, fixed, well-known prefix, or we can use a per-instance
+	// unique prefix derived from the current time
+	//
+	if cfg.Store.Test.UseUniqueInstance {
+		testNamespace = fmt.Sprintf("%s/%s/", testNamespaceSuffixRoot, time.Now().Format(time.RFC3339Nano))
+	} else {
+		testNamespace = testNamespaceSuffixRoot + "/Standard/"
+	}
+
+	if cfg.Store.Test.PreCleanStore {
+		if err := cleanNamespace(testNamespace); err != nil {
+			log.Fatalf("failed to pre-clean the store as requested - namespace: %s err: %v", testNamespace, err)
+		}
+	}
+
+	setDefaultNamespaceSuffix(testNamespace)
+	return
+}
+
+func cleanNamespace(testNamespace string) error {
+
+	store := NewStore()
+
+	if store == nil {
+		log.Fatalf("unable to allocate store context for pre-cleanup")
+	}
+
+	if err := store.SetNamespaceSuffix(""); err != nil {
+		return err
+	}
+	if err := store.Connect(); err != nil {
+		return err
+	}
+	if err := store.DeleteWithPrefix(testNamespace); err != nil {
+		return err
+	}
+
+	store.Disconnect()
+
+	return nil
+}
+
+func testGenerateKeyValueSet(setSize int, setName string) []KeyValueArg {
+
+	keyValueSet := make([]KeyValueArg, setSize)
+
+	for i := range keyValueSet {
+		keyValueSet[i].key = fmt.Sprintf("%s/Key%04d", setName, i)
+		keyValueSet[i].value = fmt.Sprintf("%s/Val%04d", setName, i)
+	}
+
+	return keyValueSet
+}
+
+func testGenerateKeyValueMapFromKeyValueSet(keyValueSet []KeyValueArg) map[string]string {
+
+	keyValueMap := make(map[string]string, len(keyValueSet))
+
+	for _, kv := range keyValueSet {
+		keyValueMap[kv.key] = kv.value
+	}
+
+	return keyValueMap
+}
+
+func testGenerateKeySetFromKeyValueSet(keyValueSet []KeyValueArg) []string {
+
+	keySet := make([]string, len(keyValueSet))
+
+	for i, kv := range keyValueSet {
+		keySet[i] = kv.key
+	}
+
+	return keySet
+}
+
+// TestMain is the Common test startup method.  This is the _only_ Test* function in this
+// file.
+func TestMain(m *testing.M) {
+	commonSetup()
+	os.Exit(m.Run())
+}

--- a/internal/clients/store/common_test.go
+++ b/internal/clients/store/common_test.go
@@ -22,7 +22,6 @@ import (
 const keySetSize = 100
 
 var (
-	baseURI     string
 	initialized bool
 
 	testNamespaceSuffixRoot = "/Test"
@@ -132,7 +131,7 @@ func testGenerateKeySetFromKeyValueSet(keyValueSet []KeyValueArg) []string {
 
 // Build a set of key,value pairs to be created unconditionally in the store.
 //
-func testGenerateRecordUpdateSetFromKeyValueSet(keyValueSet []KeyValueArg, label string, condition WriteCondition) RecordUpdateSet {
+func testGenerateRecordUpdateSetFromKeyValueSet(keyValueSet []KeyValueArg, label string, condition Condition) RecordUpdateSet {
 
 	recordUpdateSet := RecordUpdateSet{Label: label, Records: make(map[string]RecordUpdate)}
 

--- a/internal/clients/store/errors.go
+++ b/internal/clients/store/errors.go
@@ -25,19 +25,6 @@ var (
 	ErrStoreConnected = errors.New("CloudChamber: client currently connected")
 )
 
-// ErrStoreBadResultSize indicates the size of the result set does not match
-// expectations. There may be either too many, or too few. Typically a single
-// result way anticipated and more that that was received.
-//
-type ErrStoreBadResultSize struct {
-	expected int
-	actual   int
-}
-
-func (esbrs ErrStoreBadResultSize) Error() string {
-	return fmt.Sprintf("CloudChamber: unexpected size for result set - got %v expected %v", esbrs.actual, esbrs.expected)
-}
-
 // ErrStoreKeyNotFound indicates the request key was not found when the store
 // lookup/fetch was attempted.
 //
@@ -65,12 +52,12 @@ func (esni ErrStoreNotImplemented) Error() string {
 	return fmt.Sprintf("CloudChamber: method %v not currently implemented", string(esni))
 }
 
-// ErrStoreKeyFetchFailure indicates the read transaction failed.
+// ErrStoreKeyReadFailure indicates the read transaction failed.
 //
-type ErrStoreKeyFetchFailure string
+type ErrStoreKeyReadFailure string
 
-func (eskff ErrStoreKeyFetchFailure) Error() string {
-	return fmt.Sprintf("CloudChamber: fetch txn failed reading key %q", string(eskff))
+func (eskff ErrStoreKeyReadFailure) Error() string {
+	return fmt.Sprintf("CloudChamber: transaction failed reading key %q", string(eskff))
 }
 
 // ErrStoreKeyWriteFailure indicates the read transaction failed.
@@ -78,7 +65,7 @@ func (eskff ErrStoreKeyFetchFailure) Error() string {
 type ErrStoreKeyWriteFailure string
 
 func (eskwf ErrStoreKeyWriteFailure) Error() string {
-	return fmt.Sprintf("CloudChamber: fetch txn failed deleting key %q", string(eskwf))
+	return fmt.Sprintf("CloudChamber: transaction failed deleting key %q", string(eskwf))
 }
 
 // ErrStoreKeyDeleteFailure indicates the read transaction failed.
@@ -86,40 +73,7 @@ func (eskwf ErrStoreKeyWriteFailure) Error() string {
 type ErrStoreKeyDeleteFailure string
 
 func (eskdf ErrStoreKeyDeleteFailure) Error() string {
-	return fmt.Sprintf("CloudChamber: fetch txn failed deleting key %q", string(eskdf))
-}
-
-// ErrStoreWriteConditionFail indicates the update transaction failed due to a revision mismatch.
-//
-type ErrStoreWriteConditionFail string
-
-func (eswcf ErrStoreWriteConditionFail) Error() string {
-	return fmt.Sprintf("CloudChamber: condition fail/mismatch on update for key %q", string(eswcf))
-}
-
-// ErrStoreBadArgRevision indicates the supplied revision argument was invalid.
-//
-type ErrStoreBadArgRevision string
-
-func (esbar ErrStoreBadArgRevision) Error() string {
-	return fmt.Sprintf("CloudChamber: invalid revision argument supplied on update for key %q", string(esbar))
-}
-
-// ErrStoreBadArgCompare indicates the compare argument for the update was not valid.
-//
-type ErrStoreBadArgCompare string
-
-func (esbac ErrStoreBadArgCompare) Error() string {
-	return fmt.Sprintf("CloudChamber: compare operator not valid for key %q", string(esbac))
-}
-
-// ErrStoreBadRecordCount indicates the record count for the operation was not valid.
-// This might mean that the store found more, or less, than the number of records expected.
-//
-type ErrStoreBadRecordCount string
-
-func (esbrc ErrStoreBadRecordCount) Error() string {
-	return fmt.Sprintf("CloudChamber: did not get the number of records expected %q", string(esbrc))
+	return fmt.Sprintf("CloudChamber: transaction failed deleting key %q", string(eskdf))
 }
 
 // ErrStoreBadRecordKey indicates the store has found a record with an unrecognized
@@ -144,4 +98,55 @@ type ErrStoreBadRecordContent string
 
 func (esbrk ErrStoreBadRecordContent) Error() string {
 	return fmt.Sprintf("CloudChamber: discovered found record where content does not match key %q", string(esbrk))
+}
+
+// ErrStoreBadRecordCount indicates the record count for the operation was not valid.
+// This might mean that the store found more, or less, than the number of records expected.
+//
+type ErrStoreBadRecordCount struct {
+	key      string
+	expected int
+	actual   int
+}
+
+func (esbrc ErrStoreBadRecordCount) Error() string {
+	return fmt.Sprintf("CloudChamber: unexpected record count for key %q - expected: %v actual %v", esbrc.key, esbrc.expected, esbrc.actual)
+}
+
+// ErrStoreBadArgCondition indicates the condition argument specified for the update was not valid.
+//
+type ErrStoreBadArgCondition struct {
+	key       string
+	condition Condition
+}
+
+func (esbac ErrStoreBadArgCondition) Error() string {
+	return fmt.Sprintf("CloudChamber: compare operator %q not valid for key %q", esbac.condition, esbac.key)
+}
+
+// ErrStoreBadArgRevision indicates the supplied revision argument was invalid.
+//
+type ErrStoreBadArgRevision struct {
+	key       string
+	requested int64
+	actual    int64
+}
+
+func (esbar ErrStoreBadArgRevision) Error() string {
+	return fmt.Sprintf("CloudChamber: invalid revision argument supplied on update for key %q - requested: %v actual: %v", esbar.key, esbar.requested, esbar.actual)
+}
+
+// ErrStoreConditionFail indicates the update transaction failed due to a
+// failure in the requested condition. This is like a revision mismatch
+// but other conditions may apply.
+//
+type ErrStoreConditionFail struct {
+	key       string
+	requested int64
+	condition Condition
+	actual    int64
+}
+
+func (esucf ErrStoreConditionFail) Error() string {
+	return fmt.Sprintf("CloudChamber: condition failure on update for key %q - requested: %v condition: %v actual: %v", esucf.key, esucf.requested, esucf.condition, esucf.actual)
 }

--- a/internal/clients/store/errors.go
+++ b/internal/clients/store/errors.go
@@ -47,6 +47,15 @@ func (esknf ErrStoreKeyNotFound) Error() string {
 	return fmt.Sprintf("CloudChamber: key %q not found", string(esknf))
 }
 
+// ErrStoreKeyTypeMismatch indicates the request key was not found when the store
+// lookup/fetch was attempted.
+//
+type ErrStoreKeyTypeMismatch string
+
+func (esktm ErrStoreKeyTypeMismatch) Error() string {
+	return fmt.Sprintf("CloudChamber: key %q not the requested type", string(esktm))
+}
+
 // ErrStoreNotImplemented indicated the called method does not yet have an
 // implementation
 //
@@ -54,4 +63,36 @@ type ErrStoreNotImplemented string
 
 func (esni ErrStoreNotImplemented) Error() string {
 	return fmt.Sprintf("CloudChamber: method %v not currently implemented", string(esni))
+}
+
+// ErrStoreKeyFetchFailure indicates the read transaction failed.
+//
+type ErrStoreKeyFetchFailure string
+
+func (eskff ErrStoreKeyFetchFailure) Error() string {
+	return fmt.Sprintf("CloudChamber: fetch txn failed reading keys %q", string(eskff))
+}
+
+// ErrStoreRevisionMismatch indicates the update transaction failed due to a revision mismatch.
+//
+type ErrStoreRevisionMismatch string
+
+func (esrm ErrStoreRevisionMismatch) Error() string {
+	return fmt.Sprintf("CloudChamber: revision mismatch on update for key %q", string(esrm))
+}
+
+// ErrStoreBadArgRevision indicates the supplied revision argument was invalid.
+//
+type ErrStoreBadArgRevision string
+
+func (esbar ErrStoreBadArgRevision) Error() string {
+	return fmt.Sprintf("CloudChamber: invalid revision argument supplied on update for key %q", string(esbar))
+}
+
+// ErrStoreBadArgCompare indicates the compare argument for the update was not valid.
+//
+type ErrStoreBadArgCompare string
+
+func (esbac ErrStoreBadArgCompare) Error() string {
+	return fmt.Sprintf("CloudChamber: compare operator not valid for key %q", string(esbac))
 }

--- a/internal/clients/store/errors.go
+++ b/internal/clients/store/errors.go
@@ -112,3 +112,19 @@ type ErrStoreBadRecordCount string
 func (esbrc ErrStoreBadRecordCount) Error() string {
 	return fmt.Sprintf("CloudChamber: did not get the number of records expected %q", string(esbrc))
 }
+
+// ErrStoreBadRecordKey indicates the store has found a record with an unrecognized format
+//
+type ErrStoreBadRecordKey string
+
+func (esbrk ErrStoreBadRecordKey) Error() string {
+	return fmt.Sprintf("CloudChamber: discovered key with an unrecognized format %q", string(esbrk))
+}
+
+// ErrStoreBadRecordContent indicates the store has found a record with some content that does not match the key
+//
+type ErrStoreBadRecordContent string
+
+func (esbrk ErrStoreBadRecordContent) Error() string {
+	return fmt.Sprintf("CloudChamber: discovered found record where content does not match key %q", string(esbrk))
+}

--- a/internal/clients/store/errors.go
+++ b/internal/clients/store/errors.go
@@ -73,6 +73,14 @@ func (eskff ErrStoreKeyFetchFailure) Error() string {
 	return fmt.Sprintf("CloudChamber: fetch txn failed reading key %q", string(eskff))
 }
 
+// ErrStoreKeyWriteFailure indicates the read transaction failed.
+//
+type ErrStoreKeyWriteFailure string
+
+func (eskwf ErrStoreKeyWriteFailure) Error() string {
+	return fmt.Sprintf("CloudChamber: fetch txn failed deleting key %q", string(eskwf))
+}
+
 // ErrStoreKeyDeleteFailure indicates the read transaction failed.
 //
 type ErrStoreKeyDeleteFailure string
@@ -105,7 +113,8 @@ func (esbac ErrStoreBadArgCompare) Error() string {
 	return fmt.Sprintf("CloudChamber: compare operator not valid for key %q", string(esbac))
 }
 
-// ErrStoreBadRecordCount indicates the record count for the update was not valid.
+// ErrStoreBadRecordCount indicates the record count for the operation was not valid.
+// This might mean that the store found more, or less, than the number of records expected.
 //
 type ErrStoreBadRecordCount string
 
@@ -113,7 +122,8 @@ func (esbrc ErrStoreBadRecordCount) Error() string {
 	return fmt.Sprintf("CloudChamber: did not get the number of records expected %q", string(esbrc))
 }
 
-// ErrStoreBadRecordKey indicates the store has found a record with an unrecognized format
+// ErrStoreBadRecordKey indicates the store has found a record with an unrecognized
+// format. This generally means the key itself is not properly constructed.
 //
 type ErrStoreBadRecordKey string
 
@@ -121,7 +131,14 @@ func (esbrk ErrStoreBadRecordKey) Error() string {
 	return fmt.Sprintf("CloudChamber: discovered key with an unrecognized format %q", string(esbrk))
 }
 
-// ErrStoreBadRecordContent indicates the store has found a record with some content that does not match the key
+// ErrStoreBadRecordContent indicates the store has found a record with some content
+// that does not match the key. An example might be that the user name used for a key
+// does not match the user name field in the record.
+//
+// There is little consistency checking of this nature in the store itself due to the
+// limited knowledge the store component has about the content of records. There
+// should be no expectation that the store is taking on the responsibility of any
+// consistency checking and any that does occur should be treated as advisory.
 //
 type ErrStoreBadRecordContent string
 

--- a/internal/clients/store/errors.go
+++ b/internal/clients/store/errors.go
@@ -73,12 +73,12 @@ func (eskff ErrStoreKeyFetchFailure) Error() string {
 	return fmt.Sprintf("CloudChamber: fetch txn failed reading keys %q", string(eskff))
 }
 
-// ErrStoreRevisionMismatch indicates the update transaction failed due to a revision mismatch.
+// ErrStoreWriteConditionFail indicates the update transaction failed due to a revision mismatch.
 //
-type ErrStoreRevisionMismatch string
+type ErrStoreWriteConditionFail string
 
-func (esrm ErrStoreRevisionMismatch) Error() string {
-	return fmt.Sprintf("CloudChamber: revision mismatch on update for key %q", string(esrm))
+func (esrm ErrStoreWriteConditionFail) Error() string {
+	return fmt.Sprintf("CloudChamber: condition fail/mismatch on update for key %q", string(esrm))
 }
 
 // ErrStoreBadArgRevision indicates the supplied revision argument was invalid.

--- a/internal/clients/store/errors.go
+++ b/internal/clients/store/errors.go
@@ -65,7 +65,7 @@ func (eskff ErrStoreKeyReadFailure) Error() string {
 type ErrStoreKeyWriteFailure string
 
 func (eskwf ErrStoreKeyWriteFailure) Error() string {
-	return fmt.Sprintf("CloudChamber: transaction failed deleting key %q", string(eskwf))
+	return fmt.Sprintf("CloudChamber: transaction failed writing key %q", string(eskwf))
 }
 
 // ErrStoreKeyDeleteFailure indicates the read transaction failed.

--- a/internal/clients/store/errors.go
+++ b/internal/clients/store/errors.go
@@ -70,15 +70,23 @@ func (esni ErrStoreNotImplemented) Error() string {
 type ErrStoreKeyFetchFailure string
 
 func (eskff ErrStoreKeyFetchFailure) Error() string {
-	return fmt.Sprintf("CloudChamber: fetch txn failed reading keys %q", string(eskff))
+	return fmt.Sprintf("CloudChamber: fetch txn failed reading key %q", string(eskff))
+}
+
+// ErrStoreKeyDeleteFailure indicates the read transaction failed.
+//
+type ErrStoreKeyDeleteFailure string
+
+func (eskdf ErrStoreKeyDeleteFailure) Error() string {
+	return fmt.Sprintf("CloudChamber: fetch txn failed deleting key %q", string(eskdf))
 }
 
 // ErrStoreWriteConditionFail indicates the update transaction failed due to a revision mismatch.
 //
 type ErrStoreWriteConditionFail string
 
-func (esrm ErrStoreWriteConditionFail) Error() string {
-	return fmt.Sprintf("CloudChamber: condition fail/mismatch on update for key %q", string(esrm))
+func (eswcf ErrStoreWriteConditionFail) Error() string {
+	return fmt.Sprintf("CloudChamber: condition fail/mismatch on update for key %q", string(eswcf))
 }
 
 // ErrStoreBadArgRevision indicates the supplied revision argument was invalid.
@@ -95,4 +103,12 @@ type ErrStoreBadArgCompare string
 
 func (esbac ErrStoreBadArgCompare) Error() string {
 	return fmt.Sprintf("CloudChamber: compare operator not valid for key %q", string(esbac))
+}
+
+// ErrStoreBadRecordCount indicates the record count for the update was not valid.
+//
+type ErrStoreBadRecordCount string
+
+func (esbrc ErrStoreBadRecordCount) Error() string {
+	return fmt.Sprintf("CloudChamber: did not get the number of records expected %q", string(esbrc))
 }

--- a/internal/clients/store/store.go
+++ b/internal/clients/store/store.go
@@ -961,22 +961,6 @@ func (store *Store) SetWatchWithPrefix(keyPrefix string) error {
 	})
 }
 
-/*
-// RecordType is used to describe the type of the record value associated with a specific record key
-//
-type RecordType int64
-
-const (
-	RecordTypeInvalid RecordType = iota
-	RecordTypeUser
-	RecordTypeWorkload
-	RecordTypeRack
-	RecordTypeBlade
-	RecordTypeTOR
-	RecordTypePDU
-)
-*/
-
 // RevisionInvalid is returned from certain operations if
 // failure cases and is also used when defining
 // unconditional write to the store.
@@ -1003,36 +987,6 @@ const (
 	WriteConditionRevisionEqualOrGreater
 	WriteConditionRevisionGreater
 )
-
-/*
-type record struct {
-	checksum       int64      `json:"Checksum"`
-	recordType     RecordType `json:"Type"`
-	timeLastUpdate time.Time  `json:"LastUpdate"`
-	timeCreation   time.Time  `json:"Creation"`
-
-	etag  int64  `json:"ETag"`
-	value []byte `json:"Value"`
-}
-
-type readResult struct {
-	key string
-}
-
-type readResponse struct {
-	key   string
-	value []byte
-	err   error
-}
-*/
-
-/*
-// RecordKey is a
-//
-type RecordKey2 struct {
-	Key string
-}
-*/
 
 // RecordKeySet is a struct defining the set of keys to be read along with an arbitrary
 // label to tag the transaction.
@@ -1078,11 +1032,11 @@ type RecordUpdateSet struct {
 // ReadMultipleTxn is a method to fetch a set of arbitrary keys within a
 // single txn so they form a (self-)consistent set.
 //
-func (store *Store) ReadMultipleTxn(keySet RecordKeySet) (*RecordSet, error) {
+func (store *Store) ReadMultipleTxn(ctx context.Context, keySet RecordKeySet) (*RecordSet, error) {
 
 	resultSet := RecordSet{0, make(map[string]Record)}
 
-	err := st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+	err := st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
 
 		if err := store.disconnected(ctx); err != nil {
 			return err
@@ -1146,11 +1100,11 @@ func (store *Store) ReadMultipleTxn(keySet RecordKeySet) (*RecordSet, error) {
 // WriteMultipleTxn is a method to write/update a set of arbitrary keys within a
 // single txn so they form a (self-)consistent set.
 //
-func (store *Store) WriteMultipleTxn(recordSet *RecordUpdateSet) (int64, error) {
+func (store *Store) WriteMultipleTxn(ctx context.Context, recordSet *RecordUpdateSet) (int64, error) {
 
 	revision := RevisionInvalid
 
-	err := st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+	err := st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
 
 		prefetchKeys := make([]string, 0, len(recordSet.Records))
 
@@ -1280,11 +1234,11 @@ func (store *Store) WriteMultipleTxn(recordSet *RecordUpdateSet) (int64, error) 
 // DeleteMultipleTxn is a method to delete a set of arbitrary keys within a
 // single txn so they form a (self-)consistent operation.
 //
-func (store *Store) DeleteMultipleTxn(recordSet *RecordUpdateSet) (int64, error) {
+func (store *Store) DeleteMultipleTxn(ctx context.Context, recordSet *RecordUpdateSet) (int64, error) {
 
 	revision := RevisionInvalid
 
-	err := st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+	err := st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
 
 		prefetchKeys := make([]string, 0, len(recordSet.Records))
 

--- a/internal/clients/store/store.go
+++ b/internal/clients/store/store.go
@@ -77,8 +77,6 @@ import (
 	"github.com/Jim3Things/CloudChamber/internal/tracing"
 	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 
-	//	"github.com/golang/protobuf/jsonpb"
-
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/concurrency"
 	"go.etcd.io/etcd/clientv3/namespace"
@@ -1089,6 +1087,9 @@ func (store *Store) WriteMultipleTxn(recordSet *RecordUpdateSet) (int64, error) 
 			} else if ru.Record.Revision != RevisionUnconditional {
 
 				switch ru.Compare {
+				case RevisionCompareNotEqual:
+					fallthrough
+
 				case RevisionCompareLess:
 					fallthrough
 

--- a/internal/clients/store/store_test.go
+++ b/internal/clients/store/store_test.go
@@ -734,7 +734,7 @@ func TestStoreWriteMultipleTxn(t *testing.T) {
 
 	keyValueSet := testGenerateKeyValueSet(keySetSize, testName)
 	keySet := testGenerateKeySetFromKeyValueSet(keyValueSet)
-	recordUpdateSet := testGenerateRecordUpdateSetFromKeyValueSet(keyValueSet, testName, WriteConditionUnconditional)
+	recordUpdateSet := testGenerateRecordUpdateSetFromKeyValueSet(keyValueSet, testName, ConditionUnconditional)
 	recordReadSet := RecordKeySet{Label: testName, Keys: keySet}
 
 	store := NewStore()
@@ -780,7 +780,7 @@ func TestStoreWriteMultipleTxnCreate(t *testing.T) {
 
 	keyValueSet := testGenerateKeyValueSet(keySetSize, testName)
 	keySet := testGenerateKeySetFromKeyValueSet(keyValueSet)
-	recordUpdateSet := testGenerateRecordUpdateSetFromKeyValueSet(keyValueSet, testName, WriteConditionCreate)
+	recordUpdateSet := testGenerateRecordUpdateSetFromKeyValueSet(keyValueSet, testName, ConditionCreate)
 	recordReadSet := RecordKeySet{Label: testName, Keys: keySet}
 
 	store := NewStore()
@@ -816,8 +816,7 @@ func TestStoreWriteMultipleTxnCreate(t *testing.T) {
 	// Try to re-create the same keys. These should fail and the original values and revisions should survive.
 	//
 	revStoreRecreate, err := store.WriteMultipleTxn(context.Background(), &recordUpdateSet)
-	assert.NotNilf(t, err, "Succeeded where we expected to get a failed to write to store - error: %v", err)
-	// assert.Equalf(t, ErrStoreWriteConditionFail(keyFail), err, "Failed to get the expected error value")
+	assert.NotNilf(t, err, "Succeeded where we expected to get a failed store write - error: %v", err)
 	assert.Equalf(t, RevisionInvalid, revStoreRecreate, "Unexpected value for store revision on write(re-create) completion")
 
 	readResponseRecreate, err := store.ReadMultipleTxn(context.Background(), recordReadSet)
@@ -846,7 +845,7 @@ func TestStoreWriteMultipleTxnOverwrite(t *testing.T) {
 
 	keyValueSet := testGenerateKeyValueSet(keySetSize, testName)
 	keySet := testGenerateKeySetFromKeyValueSet(keyValueSet)
-	recordCreateSet := testGenerateRecordUpdateSetFromKeyValueSet(keyValueSet, testName, WriteConditionCreate)
+	recordCreateSet := testGenerateRecordUpdateSetFromKeyValueSet(keyValueSet, testName, ConditionCreate)
 	recordReadSet := RecordKeySet{Label: testName, Keys: keySet}
 
 	store := NewStore()
@@ -886,7 +885,7 @@ func TestStoreWriteMultipleTxnOverwrite(t *testing.T) {
 
 	for k, r := range recordCreateSet.Records {
 		recordUpdateSet.Records[k] = RecordUpdate{
-			Condition: WriteConditionUnconditional,
+			Condition: ConditionUnconditional,
 			Record: Record{
 				Revision: RevisionInvalid,
 				Value:    r.Record.Value + "+ConditionOverwrite",
@@ -924,7 +923,7 @@ func TestStoreWriteMultipleTxnCompareEqual(t *testing.T) {
 
 	keyValueSet := testGenerateKeyValueSet(keySetSize, testName)
 	keySet := testGenerateKeySetFromKeyValueSet(keyValueSet)
-	recordCreateSet := testGenerateRecordUpdateSetFromKeyValueSet(keyValueSet, testName, WriteConditionCreate)
+	recordCreateSet := testGenerateRecordUpdateSetFromKeyValueSet(keyValueSet, testName, ConditionCreate)
 	recordReadSet := RecordKeySet{Label: testName, Keys: keySet}
 
 	store := NewStore()
@@ -957,7 +956,7 @@ func TestStoreWriteMultipleTxnCompareEqual(t *testing.T) {
 		assert.Equalf(t, recordCreateSet.Records[k].Record.Value, r.Value, "read value does not match earlier write value")
 	}
 
-	// We verified the write worked, so try an conditional update when the revisions
+	// We verified the write worked, so try a conditional update when the revisions
 	// are equal. Set the required condition and change the value so we can verify
 	// after the update.
 	//
@@ -965,7 +964,7 @@ func TestStoreWriteMultipleTxnCompareEqual(t *testing.T) {
 
 	for k, r := range readResponse.Records {
 		recordUpdateSet.Records[k] = RecordUpdate{
-			Condition: WriteConditionRevisionEqual,
+			Condition: ConditionRevisionEqual,
 			Record: Record{
 				Revision: r.Revision,
 				Value:    r.Value + "+ConditionEqual",

--- a/internal/clients/store/store_test.go
+++ b/internal/clients/store/store_test.go
@@ -716,7 +716,7 @@ func TestStoreWriteMultipleTxn(t *testing.T) {
 
 	keyValueSet := testGenerateKeyValueSet(keySetSize, testName)
 	keySet := testGenerateKeySetFromKeyValueSet(keyValueSet)
-	recordUpdateSet := testGenerateRecordUpdateSetFromKeyValueSet(keyValueSet, testName, WriteConditionOverwrite)
+	recordUpdateSet := testGenerateRecordUpdateSetFromKeyValueSet(keyValueSet, testName, WriteConditionUnconditional)
 	recordReadSet := RecordKeySet{Label: testName, Keys: keySet}
 
 	store := NewStore()
@@ -868,7 +868,7 @@ func TestStoreWriteMultipleTxnOverwrite(t *testing.T) {
 
 	for k, r := range recordCreateSet.Records {
 		recordUpdateSet.Records[k] = RecordUpdate{
-			Condition: WriteConditionOverwrite,
+			Condition: WriteConditionUnconditional,
 			Record: Record{
 				Revision: RevisionInvalid,
 				Value:    r.Record.Value + "+ConditionOverwrite",

--- a/internal/clients/store/store_test.go
+++ b/internal/clients/store/store_test.go
@@ -3,142 +3,12 @@
 package store
 
 import (
-	"flag"
 	"fmt"
-	"log"
-	"os"
 	"testing"
-	"time"
 
-	"github.com/Jim3Things/CloudChamber/internal/config"
-	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters"
 	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters/unit_test"
-	"github.com/Jim3Things/CloudChamber/internal/tracing/setup"
 	"github.com/stretchr/testify/assert"
-	//	"go.opentelemetry.io/otel/api/kv"
 )
-
-// A number of tests use a pre-computed set of keys for the purposes of
-// the test. This constant determines the standard size of these sets.
-// The value chosen is largely arbitrary. Selecting a value that is too
-// large may lead to problems with values to /from the underlying store,
-// so be reasonable.
-//
-const keySetSize = 100
-
-var (
-	baseURI     string
-	initialized bool
-
-	testNamespaceSuffixRoot = "/Test"
-
-	configPath *string
-)
-
-func commonSetup() {
-	var testNamespace string
-
-	setup.Init(exporters.UnitTest)
-
-	configPath = flag.String("config", ".", "path to the configuration file")
-	flag.Parse()
-
-	cfg, err := config.ReadGlobalConfig(*configPath)
-	if err != nil {
-		log.Fatalf("failed to process the global configuration: %v", err)
-	}
-
-	Initialize(cfg)
-
-	// It is meaningless to have both a unique per-instance test namespace
-	// and to clean the store before the tests are run
-	//
-	if cfg.Store.Test.UseUniqueInstance && cfg.Store.Test.PreCleanStore {
-		log.Fatalf("invalid configuration: both UseUniqueInstance and PreCleanStore are enabled: %v", err)
-	}
-
-	// For test purposes, need to set an alternate namespace rather than
-	// rely on the standard. From the configuration, we can either use the
-	// standard, fixed, well-known prefix, or we can use a per-instance
-	// unique prefix derived from the current time
-	//
-	if cfg.Store.Test.UseUniqueInstance {
-		testNamespace = fmt.Sprintf("%s/%s/", testNamespaceSuffixRoot, time.Now().Format(time.RFC3339Nano))
-	} else {
-		testNamespace = testNamespaceSuffixRoot + "/Standard/"
-	}
-
-	if cfg.Store.Test.PreCleanStore {
-		if err := cleanNamespace(testNamespace); err != nil {
-			log.Fatalf("failed to pre-clean the store as requested - namespace: %s err: %v", testNamespace, err)
-		}
-	}
-
-	setDefaultNamespaceSuffix(testNamespace)
-	return
-}
-
-func cleanNamespace(testNamespace string) error {
-
-	store := NewStore()
-
-	if store == nil {
-		log.Fatalf("unable to allocate store context for pre-cleanup")
-	}
-
-	if err := store.SetNamespaceSuffix(""); err != nil {
-		return err
-	}
-	if err := store.Connect(); err != nil {
-		return err
-	}
-	if err := store.DeleteWithPrefix(testNamespace); err != nil {
-		return err
-	}
-
-	store.Disconnect()
-
-	return nil
-}
-
-func testGenerateKeyValueSet(setSize int, setName string) []KeyValueArg {
-
-	keyValueSet := make([]KeyValueArg, setSize)
-
-	for i := range keyValueSet {
-		keyValueSet[i].key = fmt.Sprintf("%s/Key%04d", setName, i)
-		keyValueSet[i].value = fmt.Sprintf("%s/Val%04d", setName, i)
-	}
-
-	return keyValueSet
-}
-
-func testGenerateKeyValueMapFromKeyValueSet(keyValueSet []KeyValueArg) map[string]string {
-
-	keyValueMap := make(map[string]string, len(keyValueSet))
-
-	for _, kv := range keyValueSet {
-		keyValueMap[kv.key] = kv.value
-	}
-
-	return keyValueMap
-}
-
-func testGenerateKeySetFromKeyValueSet(keyValueSet []KeyValueArg) []string {
-
-	keySet := make([]string, len(keyValueSet))
-
-	for i, kv := range keyValueSet {
-		keySet[i] = kv.key
-	}
-
-	return keySet
-}
-
-func TestMain(m *testing.M) {
-	commonSetup()
-	os.Exit(m.Run())
-}
 
 func TestNew(t *testing.T) {
 	unit_test.SetTesting(t)
@@ -933,7 +803,7 @@ func TestStoreWriteMultipleTxn(t *testing.T) {
 
 	revStoreCurrent = revStoreNew
 
-	readResponseUpdate, err := store.ReadMultipleTxn(recordKeySetUpdate)
+	readResponseUpdate, err = store.ReadMultipleTxn(recordKeySetUpdate)
 	assert.Nilf(t, err, "Failed to read from store - error: %v", err)
 	assert.Equalf(t, len(recordKeySet.Keys), len(readResponseUpdate.Records), "Unexpected numbers of records returned")
 	assert.Equalf(t, revStoreCurrent, readResponseUpdate.Revision, "Unexpected value for store revision given no updates")

--- a/internal/clients/store/storeapi.go
+++ b/internal/clients/store/storeapi.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"bytes"
 	"context"
 	"strings"
 
@@ -10,19 +11,21 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 )
 
-// UserList is a method
-//
-func (store *Store) UserList() error {
-	methodName := tracing.MethodName(1)
-	return st.WithSpan(context.Background(), methodName, func(ctx context.Context) (err error) {
-		return ErrStoreNotImplemented(methodName)
-	})
-}
+const (
+	storeRootUsers     = "users/"
+	storeRootRacks     = "racks/"
+	storeRootBlades    = "blades/"
+	storeRootWorkloads = "workloads/"
+)
 
-// UserCreate is a method called by the user management
-// routines to create a persistent user record in the store.
+// UserCreate is a method called by the user management routines to create
+// a persistent user record in the store.
+//
+// No consistency check is performed on the content of the user record itself
 //
 func (store *Store) UserCreate(u *pb.User) (rev int64, err error) {
+
+	key := storeRootUsers + u.Name
 
 	methodName := tracing.MethodName(1)
 
@@ -41,7 +44,7 @@ func (store *Store) UserCreate(u *pb.User) (rev int64, err error) {
 
 		recordSet := RecordUpdateSet{Label: methodName, Records: make(map[string]RecordUpdate)}
 
-		recordSet.Records[u.Name] =
+		recordSet.Records[key] =
 			RecordUpdate{
 				Condition: WriteConditionCreate,
 				Record: Record{
@@ -66,9 +69,13 @@ func (store *Store) UserCreate(u *pb.User) (rev int64, err error) {
 	return rev, err
 }
 
-// UserUpdate is a method
+// UserUpdate is a method used to update the user record for the sepcified user.
+//
+// No validation is performed on the content of the user record itself
 //
 func (store *Store) UserUpdate(u *pb.User, revision int64) (rev int64, err error) {
+
+	key := storeRootUsers + u.Name
 
 	methodName := tracing.MethodName(1)
 
@@ -87,7 +94,7 @@ func (store *Store) UserUpdate(u *pb.User, revision int64) (rev int64, err error
 
 		recordSet := RecordUpdateSet{Label: methodName, Records: make(map[string]RecordUpdate)}
 
-		recordSet.Records[u.Name] =
+		recordSet.Records[key] =
 			RecordUpdate{
 				Condition: WriteConditionRevisionEqual,
 				Record: Record{
@@ -112,60 +119,11 @@ func (store *Store) UserUpdate(u *pb.User, revision int64) (rev int64, err error
 	return rev, err
 }
 
-// UserRead is a method
-//
-// What about InvalidRev, NewErrUserNotFound(name)
-//
-func (store *Store) UserRead(name string) (user *pb.User, rev int64, err error) {
-
-	rev = RevisionInvalid
-
-	methodName := tracing.MethodName(1)
-
-	err = st.WithSpan(context.Background(), methodName, func(ctx context.Context) (err error) {
-
-		if err := store.disconnected(ctx); err != nil {
-			return err
-		}
-
-		// If we need to do the read to get the revision, we will need an array of the keys
-		//
-		recordKeySet := RecordKeySet{Label: methodName, Keys: []string{name}}
-
-		readResponse, err := store.ReadMultipleTxn(recordKeySet)
-
-		if err != nil {
-			return err
-		}
-
-		recordCount := len(readResponse.Records)
-
-		if recordCount != 1 {
-			return ErrStoreBadRecordCount(recordCount)
-		}
-
-		u := &pb.User{}
-
-		err = jsonpb.Unmarshal(strings.NewReader(readResponse.Records[name].Value), u)
-
-		if err != nil {
-			return err
-		}
-
-		user = u
-		rev = readResponse.Records[name].Revision
-
-		st.Infof(ctx, -1, "Read User %q with revision %v", name, rev)
-
-		return nil
-	})
-
-	return user, rev, err
-}
-
-// UserDelete is a method
+// UserDelete is a method used to delete the user record for the specified user
 //
 func (store *Store) UserDelete(u *pb.User, revision int64) (rev int64, err error) {
+
+	key := storeRootUsers + u.Name
 
 	methodName := tracing.MethodName(1)
 
@@ -177,7 +135,7 @@ func (store *Store) UserDelete(u *pb.User, revision int64) (rev int64, err error
 
 		recordSet := RecordUpdateSet{Label: methodName, Records: make(map[string]RecordUpdate)}
 
-		recordSet.Records[u.Name] =
+		recordSet.Records[key] =
 			RecordUpdate{
 				Condition: WriteConditionRevisionEqual,
 				Record: Record{
@@ -200,4 +158,134 @@ func (store *Store) UserDelete(u *pb.User, revision int64) (rev int64, err error
 	})
 
 	return rev, err
+}
+
+// UserRead is a method to retrieve the user record associated with the
+// supplied name, deal with any store related key prefixes, and decore
+// the json encoded record into something the caller understands.
+//
+// NOTE: A future enhancement may occur where the caller supplies an action
+//       routine to take care of the decoding of the record itself allowing
+//       this layer to only have to deal with the manipulation of the store,
+//       the keys used to persist the callers records but not have to worry
+//       about the encode/decode formats or indeed the target record itself.
+//
+func (store *Store) UserRead(name string) (user *pb.User, rev int64, err error) {
+
+	rev = RevisionInvalid
+	key := storeRootUsers + name
+
+	methodName := tracing.MethodName(1)
+
+	err = st.WithSpan(context.Background(), methodName, func(ctx context.Context) (err error) {
+
+		if err := store.disconnected(ctx); err != nil {
+			return err
+		}
+
+		// If we need to do the read to get the revision, we will need an array of the keys
+		//
+		recordKeySet := RecordKeySet{Label: methodName, Keys: []string{key}}
+
+		readResponse, err := store.ReadMultipleTxn(recordKeySet)
+
+		if err != nil {
+			return err
+		}
+
+		recordCount := len(readResponse.Records)
+
+		if recordCount != 1 {
+			return ErrStoreBadRecordCount(recordCount)
+		}
+
+		u := &pb.User{}
+
+		err = jsonpb.Unmarshal(strings.NewReader(readResponse.Records[key].Value), u)
+
+		if err != nil {
+			return err
+		}
+
+		user = u
+		rev = readResponse.Records[key].Revision
+
+		st.Infof(ctx, -1, "Read User %q with revision %v", name, rev)
+
+		return nil
+	})
+
+	return user, rev, err
+}
+
+// UserRecord represents the revision, user struct pair for a given user
+//
+type UserRecord struct {
+	Revision int64
+	User     *pb.User
+}
+
+// UserRecordSet is a collection of UserRecord structs used to describe
+// a set of users all with a common store revision.
+//
+type UserRecordSet struct {
+	StoreRevision int64
+	Records       map[string]UserRecord
+}
+
+// UserList is a method to return all the user records using a single call.
+//
+// NOTE: This should only be used at present if the number of user records
+//       is limited as there is a limit to the number of records that can
+//       be fetched from the store in a single shot. Eventually this will
+//       be updated to user an "interupted" enum style call to allow for
+//		 an essentially infinite number of records.
+//
+func (store *Store) UserList() (recordSet *UserRecordSet, err error) {
+	methodName := tracing.MethodName(1)
+
+	err = st.WithSpan(context.Background(), methodName, func(ctx context.Context) (err error) {
+
+		if err := store.disconnected(ctx); err != nil {
+			return err
+		}
+
+		readResponse, err := store.ReadWithPrefix(storeRootUsers)
+
+		if err != nil {
+			return err
+		}
+
+		rs := &UserRecordSet{StoreRevision: RevisionInvalid, Records: make(map[string]UserRecord, len(readResponse))}
+
+		for _, kv := range readResponse {
+			u := &pb.User{}
+
+			err = jsonpb.Unmarshal(bytes.NewBuffer(kv.value), u)
+
+			if err != nil {
+				return err
+			}
+
+			if !strings.HasPrefix(kv.key, storeRootUsers) {
+				return ErrStoreBadRecordKey(kv.key)
+			}
+
+			userName := strings.TrimPrefix(kv.key, storeRootUsers)
+
+			if userName != u.Name {
+				return ErrStoreBadRecordContent(kv.key)
+			}
+
+			rs.Records[userName] = UserRecord{Revision: RevisionInvalid, User: u}
+		}
+
+		rs.StoreRevision = RevisionInvalid
+
+		recordSet = rs
+
+		return nil
+	})
+
+	return recordSet, err
 }

--- a/internal/clients/store/storeapi.go
+++ b/internal/clients/store/storeapi.go
@@ -51,7 +51,7 @@ func (store *Store) UserCreate(ctx context.Context, u *pb.User) (revision int64,
 
 		recordSet.Records[getKeyFromUsername(u.Name)] =
 			RecordUpdate{
-				Condition: WriteConditionCreate,
+				Condition: ConditionCreate,
 				Record: Record{
 					Revision: RevisionInvalid,
 					Value:    val,
@@ -89,15 +89,15 @@ func (store *Store) UserUpdate(ctx context.Context, u *pb.User, revCond int64) (
 		var (
 			rev       int64
 			val       string
-			condition WriteCondition
+			condition Condition
 		)
 
 		switch {
 		case revCond == RevisionInvalid:
-			condition = WriteConditionUnconditional
+			condition = ConditionUnconditional
 
 		default:
-			condition = WriteConditionRevisionEqual
+			condition = ConditionRevisionEqual
 		}
 
 		key := getKeyFromUsername(u.Name)
@@ -151,7 +151,7 @@ func (store *Store) UserDelete(ctx context.Context, u *pb.User, revision int64) 
 
 		recordSet.Records[key] =
 			RecordUpdate{
-				Condition: WriteConditionRevisionEqual,
+				Condition: ConditionRevisionEqual,
 				Record: Record{
 					Revision: revision,
 					Value:    "",
@@ -216,8 +216,7 @@ func (store *Store) UserRead(ctx context.Context, name string) (user *pb.User, r
 
 		switch recordCount {
 		default:
-			st.Errorf(ctx, -1, "searching for user %q found %v records when expecting just one", name, recordCount)
-			return ErrStoreBadRecordCount(name)
+			return ErrStoreBadRecordCount{name, 1, recordCount}
 
 		case 0:
 			return ErrStoreKeyNotFound(name)
@@ -308,7 +307,7 @@ func (store *Store) UserList(ctx context.Context) (recordSet *UserRecordSet, err
 
 			rs.Records[userName] = UserRecord{Revision: r.Revision, User: u}
 
-			st.Infof(ctx, -1, "found record for user %q eith revision %v", u.Name, r.Revision)
+			st.Infof(ctx, -1, "found record for user %q either revision %v", u.Name, r.Revision)
 		}
 
 		rs.StoreRevision = readResponse.Revision

--- a/internal/clients/store/storeapi.go
+++ b/internal/clients/store/storeapi.go
@@ -1,0 +1,146 @@
+package store
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Jim3Things/CloudChamber/internal/tracing"
+	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+	pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
+	"github.com/golang/protobuf/jsonpb"
+)
+
+// UserList is a method
+//
+func (store *Store) UserList() error {
+	methodName := tracing.MethodName(1)
+	return st.WithSpan(context.Background(), methodName, func(ctx context.Context) (err error) {
+		return ErrStoreNotImplemented(methodName)
+	})
+}
+
+// UserCreate is a method called by the user management
+// routines to create a persistent user record in the store.
+//
+func (store *Store) UserCreate(u *pb.User) (rev int64, err error) {
+
+	methodName := tracing.MethodName(1)
+
+	err = st.WithSpan(context.Background(), methodName, func(ctx context.Context) (err error) {
+
+		if err := store.disconnected(ctx); err != nil {
+			return err
+		}
+
+		// If we need to do the read to get the revision, we will need an array of the keys
+		//
+		users := []string{u.Name}
+
+		p := jsonpb.Marshaler{}
+		value, err := p.MarshalToString(u)
+
+		if err != nil {
+			return err
+		}
+
+		// We should probably add a "Create" condition
+		//
+		recordUpdateSet := RecordUpdateSet{Label: methodName, Records: make(map[string]RecordUpdate)}
+
+		recordUpdateSet.Records[users[0]] =
+			RecordUpdate{
+				Compare: RevisionCompareUnconditional,
+				Record: Record{
+					Revision: RevisionUnconditional,
+					Value:    value,
+				},
+			}
+
+		revStore, err := store.WriteMultipleTxn(&recordUpdateSet)
+
+		if err != nil {
+			return err
+		}
+
+		recordKeySet := RecordKeySet{Label: methodName, Keys: users}
+
+		readResponse, err := store.ReadMultipleTxn(recordKeySet)
+
+		if err != nil {
+			return err
+		}
+
+		rev = readResponse.Records[users[0]].Revision
+
+		st.Infof(ctx, -1, "Write user record with store revision %v and record revision %v", revStore, rev)
+
+		st.Infof(ctx, -1, "Created User %q with revision %v", users[0], rev)
+
+		return nil
+	})
+
+	return rev, err
+}
+
+// UserRead is a method
+//
+// What about InvalidRev, NewErrUserNotFound(name)
+//
+func (store *Store) UserRead(name string) (user *pb.User, rev int64, err error) {
+
+	rev = RevisionInvalid
+
+	methodName := tracing.MethodName(1)
+
+	err = st.WithSpan(context.Background(), methodName, func(ctx context.Context) (err error) {
+
+		if err := store.disconnected(ctx); err != nil {
+			return err
+		}
+
+		// If we need to do the read to get the revision, we will need an array of the keys
+		//
+		recordKeySet := RecordKeySet{Label: methodName, Keys: []string{name}}
+
+		readResponse, err := store.ReadMultipleTxn(recordKeySet)
+
+		if err != nil {
+			return err
+		}
+
+		u := &pb.User{}
+
+		err = jsonpb.Unmarshal(strings.NewReader(readResponse.Records[name].Value), u)
+
+		if err != nil {
+			return err
+		}
+
+		user = u
+		rev = readResponse.Records[name].Revision
+
+		st.Infof(ctx, -1, "Read User %q with revision %v", name, rev)
+
+		return nil
+	})
+
+	return user, rev, err
+}
+
+// UserUpdate is a method
+//
+func (store *Store) UserUpdate() error {
+	methodName := tracing.MethodName(1)
+	return st.WithSpan(context.Background(), methodName, func(ctx context.Context) (err error) {
+		return ErrStoreNotImplemented(methodName)
+	})
+}
+
+// UserDelete is a method
+//
+func (store *Store) UserDelete() error {
+	methodName := tracing.MethodName(1)
+	return st.WithSpan(context.Background(), methodName, func(ctx context.Context) (err error) {
+		return ErrStoreNotImplemented(methodName)
+	})
+}

--- a/internal/clients/store/storeapi.go
+++ b/internal/clients/store/storeapi.go
@@ -23,13 +23,13 @@ const (
 //
 // No consistency check is performed on the content of the user record itself
 //
-func (store *Store) UserCreate(u *pb.User) (rev int64, err error) {
+func (store *Store) UserCreate(ctx context.Context, u *pb.User) (rev int64, err error) {
 
 	key := storeRootUsers + u.Name
 
 	methodName := tracing.MethodName(1)
 
-	err = st.WithSpan(context.Background(), methodName, func(ctx context.Context) (err error) {
+	err = st.WithSpan(ctx, methodName, func(ctx context.Context) (err error) {
 
 		if err := store.disconnected(ctx); err != nil {
 			return err
@@ -53,7 +53,7 @@ func (store *Store) UserCreate(u *pb.User) (rev int64, err error) {
 				},
 			}
 
-		revStore, err := store.WriteMultipleTxn(&recordSet)
+		revStore, err := store.WriteMultipleTxn(ctx, &recordSet)
 
 		if err != nil {
 			return err
@@ -73,13 +73,13 @@ func (store *Store) UserCreate(u *pb.User) (rev int64, err error) {
 //
 // No validation is performed on the content of the user record itself
 //
-func (store *Store) UserUpdate(u *pb.User, revision int64) (rev int64, err error) {
+func (store *Store) UserUpdate(ctx context.Context, u *pb.User, revision int64) (rev int64, err error) {
 
 	key := storeRootUsers + u.Name
 
 	methodName := tracing.MethodName(1)
 
-	err = st.WithSpan(context.Background(), methodName, func(ctx context.Context) (err error) {
+	err = st.WithSpan(ctx, methodName, func(ctx context.Context) (err error) {
 
 		if err := store.disconnected(ctx); err != nil {
 			return err
@@ -103,7 +103,7 @@ func (store *Store) UserUpdate(u *pb.User, revision int64) (rev int64, err error
 				},
 			}
 
-		revStore, err := store.WriteMultipleTxn(&recordSet)
+		revStore, err := store.WriteMultipleTxn(ctx, &recordSet)
 
 		if err != nil {
 			return err
@@ -121,13 +121,13 @@ func (store *Store) UserUpdate(u *pb.User, revision int64) (rev int64, err error
 
 // UserDelete is a method used to delete the user record for the specified user
 //
-func (store *Store) UserDelete(u *pb.User, revision int64) (rev int64, err error) {
+func (store *Store) UserDelete(ctx context.Context, u *pb.User, revision int64) (rev int64, err error) {
 
 	key := storeRootUsers + u.Name
 
 	methodName := tracing.MethodName(1)
 
-	err = st.WithSpan(context.Background(), methodName, func(ctx context.Context) (err error) {
+	err = st.WithSpan(ctx, methodName, func(ctx context.Context) (err error) {
 
 		if err := store.disconnected(ctx); err != nil {
 			return err
@@ -144,7 +144,7 @@ func (store *Store) UserDelete(u *pb.User, revision int64) (rev int64, err error
 				},
 			}
 
-		revStore, err := store.DeleteMultipleTxn(&recordSet)
+		revStore, err := store.DeleteMultipleTxn(ctx, &recordSet)
 
 		if err != nil {
 			return err
@@ -170,14 +170,14 @@ func (store *Store) UserDelete(u *pb.User, revision int64) (rev int64, err error
 //       the keys used to persist the callers records but not have to worry
 //       about the encode/decode formats or indeed the target record itself.
 //
-func (store *Store) UserRead(name string) (user *pb.User, rev int64, err error) {
+func (store *Store) UserRead(ctx context.Context, name string) (user *pb.User, rev int64, err error) {
 
 	rev = RevisionInvalid
 	key := storeRootUsers + name
 
 	methodName := tracing.MethodName(1)
 
-	err = st.WithSpan(context.Background(), methodName, func(ctx context.Context) (err error) {
+	err = st.WithSpan(ctx, methodName, func(ctx context.Context) (err error) {
 
 		if err := store.disconnected(ctx); err != nil {
 			return err
@@ -187,7 +187,7 @@ func (store *Store) UserRead(name string) (user *pb.User, rev int64, err error) 
 		//
 		recordKeySet := RecordKeySet{Label: methodName, Keys: []string{key}}
 
-		readResponse, err := store.ReadMultipleTxn(recordKeySet)
+		readResponse, err := store.ReadMultipleTxn(ctx, recordKeySet)
 
 		if err != nil {
 			return err
@@ -241,10 +241,10 @@ type UserRecordSet struct {
 //       be updated to user an "interupted" enum style call to allow for
 //		 an essentially infinite number of records.
 //
-func (store *Store) UserList() (recordSet *UserRecordSet, err error) {
+func (store *Store) UserList(ctx context.Context) (recordSet *UserRecordSet, err error) {
 	methodName := tracing.MethodName(1)
 
-	err = st.WithSpan(context.Background(), methodName, func(ctx context.Context) (err error) {
+	err = st.WithSpan(ctx, methodName, func(ctx context.Context) (err error) {
 
 		if err := store.disconnected(ctx); err != nil {
 			return err

--- a/internal/clients/store/storeapi_test.go
+++ b/internal/clients/store/storeapi_test.go
@@ -173,7 +173,7 @@ func TestUserDelete(t *testing.T) {
 	assert.Equalf(t, user, userRead, "Unexpected difference in updated user record and read user record")
 
 	revDelete, err := store.UserDelete(context.Background(), user, revRead-1)
-	assert.NotNilf(t, err, "Unecpected success trying to update with wrong revision for user %q - error: %v", userName, err)
+	assert.NotNilf(t, err, "Unexpected success trying to update with wrong revision for user %q - error: %v", userName, err)
 	assert.Equalf(t, RevisionInvalid, revDelete, "Expected post-delete revision to be greater than read revision")
 
 	revDelete, err = store.UserDelete(context.Background(), user, revRead)

--- a/internal/clients/store/storeapi_test.go
+++ b/internal/clients/store/storeapi_test.go
@@ -248,8 +248,15 @@ func TestUserList(t *testing.T) {
 	userList, err := store.UserList(context.Background())
 	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
 	assert.Lessf(t, RevisionInvalid, userList.StoreRevision, "Expected new store revision to be greater than initial revision")
-	assert.Equalf(t, len(recordSet.Records), len(userList.Records), "Unexpected difference in count of records returned from user list")
 
+	// Use "less than or equal" relationship to allow for the cases where all the
+	// file tests are being executed and there are potentially user records left over
+	// from tests running earlier in the set.
+	//
+	assert.LessOrEqualf(t, len(recordSet.Records), len(userList.Records), "Unexpected difference in count of records returned from user list")
+
+	// Check that the records this test created are present. There may be others.
+	//
 	for n, ur := range recordSet.Records {
 		assert.Equalf(t, ur.Revision, userList.Records[n].Revision, "Unexpected difference in revision from create for user %q", n)
 		assert.Equalf(t, ur.User, userList.Records[n].User, "Unexpected difference in record from create for user %q", n)

--- a/internal/clients/store/storeapi_test.go
+++ b/internal/clients/store/storeapi_test.go
@@ -1,0 +1,60 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters/unit_test"
+	pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	userURI       = "/api/users/"
+	admin         = "Admin"
+	adminPassword = "AdminPassword"
+	alice         = "Alice"
+	bob           = "Bob"
+	alicePassword = "AlicePassowrd"
+	bobPassword   = "BobPassword"
+)
+
+func TestUserCreate(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
+	store := NewStore()
+	assert.NotNilf(t, store, "Failed to get the store as expected")
+
+	err := store.Connect()
+	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(adminPassword), bcrypt.DefaultCost)
+
+	user := &pb.User{
+		Name:           admin,
+		PasswordHash:   passwordHash,
+		UserId:         1,
+		Enabled:        true,
+		AccountManager: true,
+		NeverDelete:    true,
+	}
+
+	rev, err := store.UserCreate(user)
+	assert.Nilf(t, err, "Failed to create new user %q - error: %v", admin, err)
+	assert.Greaterf(t, 0, rev, "Expected new store revision to be greater than zero")
+
+	rev, err = store.UserCreate(user)
+	assert.Nilf(t, err, "Unexpected succeeded to (re-)create new user %q - error: %v", admin, err)
+
+	readUser, readRev, err := store.UserRead(admin)
+
+	assert.Nilf(t, err, "Failed to read user %q - error: %v", admin, err)
+	assert.Equalf(t, rev, readRev, "Unexpected difference in creation revision vs read revision")
+	assert.Equalf(t, user, readUser, "Unexpected difference in creation user record and read user record")
+
+	store.Disconnect()
+
+	store = nil
+	return
+}

--- a/internal/clients/store/storeapi_test.go
+++ b/internal/clients/store/storeapi_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters/unit_test"
@@ -49,15 +50,15 @@ func TestUserCreate(t *testing.T) {
 		NeverDelete:    true,
 	}
 
-	revCreate, err := store.UserCreate(user)
+	revCreate, err := store.UserCreate(context.Background(), user)
 	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
 	assert.Lessf(t, RevisionInvalid, revCreate, "Expected new store revision to be greater than initial revision")
 
-	revRecreate, err := store.UserCreate(user)
+	revRecreate, err := store.UserCreate(context.Background(), user)
 	assert.NotNilf(t, err, "Unexpected success attempting to (re-)create new user %q - error: %v", userName, err)
 	assert.Equalf(t, RevisionInvalid, revRecreate, "Expected failure should result in invalid revision")
 
-	readUser, readRev, err := store.UserRead(userName)
+	readUser, readRev, err := store.UserRead(context.Background(), userName)
 
 	assert.Nilf(t, err, "Failed to read user %q - error: %v", userName, err)
 	assert.Equalf(t, revCreate, readRev, "Unexpected difference in creation revision vs read revision")
@@ -92,15 +93,15 @@ func TestUserUpdate(t *testing.T) {
 		NeverDelete:    true,
 	}
 
-	revCreate, err := store.UserCreate(user)
+	revCreate, err := store.UserCreate(context.Background(), user)
 	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
 	assert.Lessf(t, RevisionInvalid, revCreate, "Expected new store revision to be greater than initial revision")
 
-	revRecreate, err := store.UserCreate(user)
+	revRecreate, err := store.UserCreate(context.Background(), user)
 	assert.NotNilf(t, err, "Unexpected success attempting to (re-)create new user %q - error: %v", userName, err)
 	assert.Equalf(t, RevisionInvalid, revRecreate, "Expected failure should result in invalid revision")
 
-	readUser, readRev, err := store.UserRead(userName)
+	readUser, readRev, err := store.UserRead(context.Background(), userName)
 	assert.Nilf(t, err, "Failed to read user %q - error: %v", userName, err)
 	assert.Equalf(t, revCreate, readRev, "Unexpected difference in creation revision vs read revision")
 	assert.Equalf(t, user, readUser, "Unexpected difference in creation user record and read user record")
@@ -118,18 +119,18 @@ func TestUserUpdate(t *testing.T) {
 		NeverDelete:    true,
 	}
 
-	revUpdate, err := store.UserUpdate(userUpdate, readRev)
+	revUpdate, err := store.UserUpdate(context.Background(), userUpdate, readRev)
 	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
 	assert.Lessf(t, readRev, revUpdate, "Expected update revision to be greater than create revision")
 
-	readUserUpdate, readRevUpdate, err := store.UserRead(userName)
+	readUserUpdate, readRevUpdate, err := store.UserRead(context.Background(), userName)
 	assert.Nilf(t, err, "Failed to read user %q - error: %v", userName, err)
 	assert.Equalf(t, revUpdate, readRevUpdate, "Unexpected difference in update revision vs read revision")
 	assert.Equalf(t, userUpdate, readUserUpdate, "Unexpected difference in updated user record and read user record")
 
 	// Now try to update with the wrong revision
 	//
-	readRevUpdate, err = store.UserUpdate(userUpdate, readRev)
+	readRevUpdate, err = store.UserUpdate(context.Background(), userUpdate, readRev)
 	assert.NotNilf(t, err, "Unecpected success trying to update with wrong revision for user %q - error: %v", userName, err)
 	assert.Equalf(t, RevisionInvalid, readRevUpdate, "Expected update revision to be greater than create revision")
 
@@ -162,29 +163,29 @@ func TestUserDelete(t *testing.T) {
 		NeverDelete:    true,
 	}
 
-	revCreate, err := store.UserCreate(user)
+	revCreate, err := store.UserCreate(context.Background(), user)
 	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
 	assert.Lessf(t, RevisionInvalid, revCreate, "Expected new store revision to be greater than initial revision")
 
-	userRead, revRead, err := store.UserRead(userName)
+	userRead, revRead, err := store.UserRead(context.Background(), userName)
 	assert.Nilf(t, err, "Failed to read user %q - error: %v", userName, err)
 	assert.Equalf(t, revCreate, revRead, "Unexpected difference in update revision vs read revision")
 	assert.Equalf(t, user, userRead, "Unexpected difference in updated user record and read user record")
 
-	revDelete, err := store.UserDelete(user, revRead-1)
+	revDelete, err := store.UserDelete(context.Background(), user, revRead-1)
 	assert.NotNilf(t, err, "Unecpected success trying to update with wrong revision for user %q - error: %v", userName, err)
 	assert.Equalf(t, RevisionInvalid, revDelete, "Expected post-delete revision to be greater than read revision")
 
-	revDelete, err = store.UserDelete(user, revRead)
+	revDelete, err = store.UserDelete(context.Background(), user, revRead)
 	assert.Nilf(t, err, "Failed to delete user %q - error: %v", userName, err)
 	assert.Lessf(t, revRead, revDelete, "Expected post-delete revision to be greater than read revision")
 
-	userReread, revReread, err := store.UserRead(userName)
+	userReread, revReread, err := store.UserRead(context.Background(), userName)
 	assert.NotNilf(t, err, "Unexpected success reading user %q after deletion - error: %v", userName, err)
 	assert.Equalf(t, RevisionInvalid, revReread, "Unexpected difference in update revision vs read revision")
 	assert.Nilf(t, userReread, "Unexpected success in reading user %q after delete", userName)
 
-	revDeleteAgain, err := store.UserDelete(user, revRead)
+	revDeleteAgain, err := store.UserDelete(context.Background(), user, revRead)
 	assert.NotNilf(t, err, "Unecpected success trying to update with wrong revision for user %q - error: %v", userName, err)
 	assert.Equalf(t, RevisionInvalid, revDeleteAgain, "Expected post-re-delete revision invalid")
 
@@ -237,14 +238,14 @@ func TestUserList(t *testing.T) {
 	recordSet := UserRecordSet{StoreRevision: RevisionInvalid, Records: make(map[string]UserRecord, len(userSet))}
 
 	for name, rec := range users {
-		revCreate, err := store.UserCreate(rec)
+		revCreate, err := store.UserCreate(context.Background(), rec)
 		assert.Nilf(t, err, "Failed to create new user %q - error: %v", name, err)
 		assert.Lessf(t, RevisionInvalid, revCreate, "Expected new store revision to be greater than initial revision")
 
 		recordSet.Records[name] = UserRecord{Revision: revCreate, User: rec}
 	}
 
-	userList, err := store.UserList()
+	userList, err := store.UserList(context.Background())
 	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
 	assert.Equalf(t, RevisionInvalid, userList.StoreRevision, "Expected new store revision to be greater than initial revision")
 	assert.Equalf(t, len(recordSet.Records), len(userList.Records), "Unexpected difference in count of records returned from user list")

--- a/internal/clients/store/storeapi_test.go
+++ b/internal/clients/store/storeapi_test.go
@@ -247,7 +247,7 @@ func TestUserList(t *testing.T) {
 
 	userList, err := store.UserList(context.Background())
 	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
-	assert.Equalf(t, RevisionInvalid, userList.StoreRevision, "Expected new store revision to be greater than initial revision")
+	assert.Lessf(t, RevisionInvalid, userList.StoreRevision, "Expected new store revision to be greater than initial revision")
 	assert.Equalf(t, len(recordSet.Records), len(userList.Records), "Unexpected difference in count of records returned from user list")
 
 	for n, ur := range recordSet.Records {

--- a/internal/clients/store/storeapi_test.go
+++ b/internal/clients/store/storeapi_test.go
@@ -10,18 +10,23 @@ import (
 )
 
 const (
-	userURI       = "/api/users/"
-	admin         = "Admin"
-	adminPassword = "AdminPassword"
-	alice         = "Alice"
-	bob           = "Bob"
-	alicePassword = "AlicePassowrd"
-	bobPassword   = "BobPassword"
+	userURI              = "/api/users/"
+	admin                = "Admin"
+	adminPassword        = "AdminPassword"
+	adminUpdate          = "AdminUpdate"
+	adminUpdatePassword  = "AdminUpdatePassword"
+	adminUpdatePassword2 = "AdminUpdatePasswordUpdated"
+	alice                = "Alice"
+	bob                  = "Bob"
+	alicePassword        = "AlicePassowrd"
+	bobPassword          = "BobPassword"
 )
 
 func TestUserCreate(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
+
+	userName := admin
 
 	store := NewStore()
 	assert.NotNilf(t, store, "Failed to get the store as expected")
@@ -32,7 +37,7 @@ func TestUserCreate(t *testing.T) {
 	passwordHash, err := bcrypt.GenerateFromPassword([]byte(adminPassword), bcrypt.DefaultCost)
 
 	user := &pb.User{
-		Name:           admin,
+		Name:           userName,
 		PasswordHash:   passwordHash,
 		UserId:         1,
 		Enabled:        true,
@@ -40,18 +45,89 @@ func TestUserCreate(t *testing.T) {
 		NeverDelete:    true,
 	}
 
-	rev, err := store.UserCreate(user)
-	assert.Nilf(t, err, "Failed to create new user %q - error: %v", admin, err)
-	assert.Greaterf(t, 0, rev, "Expected new store revision to be greater than zero")
+	revCreate, err := store.UserCreate(user)
+	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
+	assert.Lessf(t, RevisionInvalid, revCreate, "Expected new store revision to be greater than initial revision")
 
-	rev, err = store.UserCreate(user)
-	assert.Nilf(t, err, "Unexpected succeeded to (re-)create new user %q - error: %v", admin, err)
+	revRecreate, err := store.UserCreate(user)
+	assert.NotNilf(t, err, "Unexpected success attempting to (re-)create new user %q - error: %v", userName, err)
+	assert.Equalf(t, RevisionInvalid, revRecreate, "Expected failure should result in invalid revision")
 
-	readUser, readRev, err := store.UserRead(admin)
+	readUser, readRev, err := store.UserRead(userName)
 
-	assert.Nilf(t, err, "Failed to read user %q - error: %v", admin, err)
-	assert.Equalf(t, rev, readRev, "Unexpected difference in creation revision vs read revision")
+	assert.Nilf(t, err, "Failed to read user %q - error: %v", userName, err)
+	assert.Equalf(t, revCreate, readRev, "Unexpected difference in creation revision vs read revision")
 	assert.Equalf(t, user, readUser, "Unexpected difference in creation user record and read user record")
+
+	store.Disconnect()
+
+	store = nil
+	return
+}
+
+func TestUserUpdate(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
+	userName := adminUpdate
+
+	store := NewStore()
+	assert.NotNilf(t, store, "Failed to get the store as expected")
+
+	err := store.Connect()
+	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(adminUpdatePassword), bcrypt.DefaultCost)
+
+	user := &pb.User{
+		Name:           userName,
+		PasswordHash:   passwordHash,
+		UserId:         1,
+		Enabled:        true,
+		AccountManager: true,
+		NeverDelete:    true,
+	}
+
+	revCreate, err := store.UserCreate(user)
+	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
+	assert.Lessf(t, RevisionInvalid, revCreate, "Expected new store revision to be greater than initial revision")
+
+	revRecreate, err := store.UserCreate(user)
+	assert.NotNilf(t, err, "Unexpected success attempting to (re-)create new user %q - error: %v", userName, err)
+	assert.Equalf(t, RevisionInvalid, revRecreate, "Expected failure should result in invalid revision")
+
+	readUser, readRev, err := store.UserRead(userName)
+	assert.Nilf(t, err, "Failed to read user %q - error: %v", userName, err)
+	assert.Equalf(t, revCreate, readRev, "Unexpected difference in creation revision vs read revision")
+	assert.Equalf(t, user, readUser, "Unexpected difference in creation user record and read user record")
+
+	// Now update the user record and see if the changes made it.
+	//
+	passwordHash, err = bcrypt.GenerateFromPassword([]byte(adminUpdatePassword2), bcrypt.DefaultCost)
+
+	userUpdate := &pb.User{
+		Name:           userName,
+		PasswordHash:   passwordHash,
+		UserId:         1,
+		Enabled:        false,
+		AccountManager: true,
+		NeverDelete:    true,
+	}
+
+	revUpdate, err := store.UserUpdate(userUpdate, readRev)
+	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
+	assert.Lessf(t, readRev, revUpdate, "Expected update revision to be greater than create revision")
+
+	readUserUpdate, readRevUpdate, err := store.UserRead(userName)
+	assert.Nilf(t, err, "Failed to read user %q - error: %v", userName, err)
+	assert.Equalf(t, revUpdate, readRevUpdate, "Unexpected difference in update revision vs read revision")
+	assert.Equalf(t, userUpdate, readUserUpdate, "Unexpected difference in updated user record and read user record")
+
+	// Now try to update with the wrong revision
+	//
+	readRevUpdate, err = store.UserUpdate(userUpdate, readRev)
+	assert.NotNilf(t, err, "Unecpected success trying to update with wrong revision for user %q - error: %v", userName, err)
+	assert.Equalf(t, RevisionInvalid, readRevUpdate, "Expected update revision to be greater than create revision")
 
 	store.Disconnect()
 


### PR DESCRIPTION
The aim of this change is the first cut of actually storing useful data in the underlying store, in particular the "user" records as already defined. This is done using the transactional (txn) support provided by etcd which allows for conditional updates to the store based upon the current revisions of the store and the revision of the record being modified.

At this point the user record layer is a little simplistic and will be simplified using a more generic style if interface in a future update.

Any suggestions for trace improvements would be welcome.

Testing of conditions other than unconditional and equal will be added in subsequent releases as required.