### PR TITLE
Add section to operational environment doc about startetcd configurability

### DIFF
--- a/docs/OperationalEnvironmentForWindows.md
+++ b/docs/OperationalEnvironmentForWindows.md
@@ -104,6 +104,27 @@ delete the complete directory tree where the instance was storing its
 data. If etcd was started using the startetcd.cmd script, this will
 likely be %SystemDrive%\\etcd (typically c:\\etcd)
 
+## Configuring Etcd Instance Parameters
+
+There are many configuration options for etcd itself, but the startetcd
+command script has set a number of values sufficient for basic use
+cases. However, it does allow for configuration of some basic properties
+which are listed along with there default values in the help text
+obtained by
+
+  - %GOPATH%\\src\\github.com\\Jim3Things\\CloudChamber\\Scripts\\startetcd.cmd
+    -?
+
+Currently these configurable values are all set via environment variable
+which when set will override the defaults. These are
+
+| Environment Variable | Description                                          | Default                   |
+| -------------------- | ---------------------------------------------------- | ------------------------- |
+| ETCDINSTANCE         | name of the ETCD instance                            | %COMPUTERNAME%            |
+| ETCDNODEADDR         | IP address of the node hosting the Etcd instance     | 127.0.0.1                 |
+| ETCDPORTCLNT         | IP port to be used for communication with the client | 2379                      |
+| ETCDDATA             | directory for ETCD data (adds .etcd suffix)          | %SystemDrive%\\etcd\\data |
+
 ## Using the Etcdctl Utility
 
 The following all assumes the etcdctl.exe utility was placed in the

--- a/scripts/startetcd.cmd
+++ b/scripts/startetcd.cmd
@@ -31,10 +31,11 @@ if /i "%ETCDPORTPEER%" == "" (set ETCDPORTPEER=%DEFAULT_ETCDPORTPEER%)
 
 rem Check for requests for help without actually doing anything
 rem 
-if /i "%1" == "/?" (goto :StartEtcdHelp)
-if /i "%1" == "/h" (goto :StartEtcdHelp)
-if /i "%1" == "-?" (goto :StartEtcdHelp)
-if /i "%1" == "-h" (goto :StartEtcdHelp)
+if /i "%1" == "/?"    (goto :StartEtcdHelp)
+if /i "%1" == "-?"    (goto :StartEtcdHelp)
+if /i "%1" == "/h"    (goto :StartEtcdHelp)
+if /i "%1" == "-h"    (goto :StartEtcdHelp)
+if /i "%1" == "--help"(goto :StartEtcdHelp)
 
 
 rem Find a binary to use
@@ -87,8 +88,9 @@ echo which can be overriden by setting environment variables using the appropria
 echo desired values.
 echo.
 echo ETCDINSTANCE (defaults to %DEFAULT_ETCDINSTANCE%) - name of the ETCD instance
+echo ETCDNODEADDR (defaults to %DEFAULT_ETCDNODEADDR%) - IP address of the ETCD instance
 echo ETCDPORTCLNT (defaults to %DEFAULT_ETCDPORTCLNT%) - IP port to be used for communication with the client
-echo ETCDDATA     (defaults to %DEFAULT_ETCDDATA%)     - directory where the ETCD data files are to be placed- 
+echo ETCDDATA     (defaults to %DEFAULT_ETCDDATA%)     - directory where the ETCD data files are to be placed
 echo.
 echo.
 


### PR DESCRIPTION
Add a section to the Windows Operational Environment doc to describe the parameters available to configure the the startetcd.cmd script used to start an etcd instance.

Update the script to ensure it all matches the doc.