### PR TITLE
Minor typo - need extra space

### DIFF
--- a/scripts/startetcd.cmd
+++ b/scripts/startetcd.cmd
@@ -31,11 +31,11 @@ if /i "%ETCDPORTPEER%" == "" (set ETCDPORTPEER=%DEFAULT_ETCDPORTPEER%)
 
 rem Check for requests for help without actually doing anything
 rem 
-if /i "%1" == "/?"    (goto :StartEtcdHelp)
-if /i "%1" == "-?"    (goto :StartEtcdHelp)
-if /i "%1" == "/h"    (goto :StartEtcdHelp)
-if /i "%1" == "-h"    (goto :StartEtcdHelp)
-if /i "%1" == "--help"(goto :StartEtcdHelp)
+if /i "%1" == "/?"     (goto :StartEtcdHelp)
+if /i "%1" == "-?"     (goto :StartEtcdHelp)
+if /i "%1" == "/h"     (goto :StartEtcdHelp)
+if /i "%1" == "-h"     (goto :StartEtcdHelp)
+if /i "%1" == "--help" (goto :StartEtcdHelp)
 
 
 rem Find a binary to use


### PR DESCRIPTION
Just used startetcd.cmd on a different machine (different sku of Windows) and ran into a syntax error.

Seems this other version requires a space before the open brace in the "if" statement for the "--help" variant. The other added spaces are just for alignment prettification.