### PR TITLE
Replace frontend users dummy in-memory db with connection to the real store

### DIFF
--- a/configs/cloudchamber.yaml
+++ b/configs/cloudchamber.yaml
@@ -49,9 +49,12 @@ store:
     hostname: localhost
     port: 2379
 
-  # Client and peer ports for the etcd instance to be created
-  # when running the local tests. These values are ignored
-  # for production use.
+  # Test specific configuration. 
+  #
+  # Setting UseTestNamespace to 1 will instruct the store to use
+  # a pre-defined test namespace which optionally can be deleted
+  # prior to running the any tests. Only the test namespace is
+  # affected by any cleanining.
   #
   # If UseUniqueInstance is set to 1, the tests will write to a
   # unique namespace to isolate test results from run to run.
@@ -62,6 +65,7 @@ store:
   # will not match.
   #
   Test:
+    UseTestNamespace: 0
     UseUniqueInstance: 0
     PreCleanStore: 0
 

--- a/internal/clients/store/cloudchamber.yaml
+++ b/internal/clients/store/cloudchamber.yaml
@@ -44,9 +44,12 @@ store:
     hostname: localhost
     port: 2379
 
-  # Client and peer ports for the etcd instance to be created
-  # when running the local tests. These values are ignored
-  # for production use.
+  # Test specific configuration. 
+  #
+  # Setting UseTestNamespace to 1 will instruct the store to use
+  # a pre-defined test namespace which optionally can be deleted
+  # prior to running the any tests. Only the test namespace is
+  # affected by any cleanining.
   #
   # If UseUniqueInstance is set to 1, the tests will write to a
   # unique namespace to isolate test results from run to run.
@@ -57,6 +60,7 @@ store:
   # will not match.
   #
   Test:
+    UseTestNamespace: 1
     UseUniqueInstance: 0
     PreCleanStore: 1
 

--- a/internal/clients/store/errors.go
+++ b/internal/clients/store/errors.go
@@ -158,3 +158,11 @@ type ErrStoreAlreadyExists string
 func (esae ErrStoreAlreadyExists) Error() string {
 	return fmt.Sprintf("CloudChamber: condition failure (already exists) on create for key %q", string(esae))
 }
+
+// ErrStoreInvalidConfiguration indicates the key, value pair being created already exists
+//
+type ErrStoreInvalidConfiguration string
+
+func (esic ErrStoreInvalidConfiguration) Error() string {
+	return fmt.Sprintf("CloudChamber: invalid store configuration - %v", string(esic))
+}

--- a/internal/clients/store/errors.go
+++ b/internal/clients/store/errors.go
@@ -60,7 +60,7 @@ func (eskff ErrStoreKeyReadFailure) Error() string {
 	return fmt.Sprintf("CloudChamber: transaction failed reading key %q", string(eskff))
 }
 
-// ErrStoreKeyWriteFailure indicates the read transaction failed.
+// ErrStoreKeyWriteFailure indicates the write transaction failed as a result of a pre-condition failure.
 //
 type ErrStoreKeyWriteFailure string
 
@@ -97,7 +97,7 @@ func (esbrk ErrStoreBadRecordKey) Error() string {
 type ErrStoreBadRecordContent string
 
 func (esbrk ErrStoreBadRecordContent) Error() string {
-	return fmt.Sprintf("CloudChamber: discovered found record where content does not match key %q", string(esbrk))
+	return fmt.Sprintf("CloudChamber: discovered record where content does not match key %q", string(esbrk))
 }
 
 // ErrStoreBadRecordCount indicates the record count for the operation was not valid.
@@ -149,4 +149,12 @@ type ErrStoreConditionFail struct {
 
 func (esucf ErrStoreConditionFail) Error() string {
 	return fmt.Sprintf("CloudChamber: condition failure on update for key %q - requested: %v condition: %v actual: %v", esucf.key, esucf.requested, esucf.condition, esucf.actual)
+}
+
+// ErrStoreRecordExists indicates the key, value pair being created already exists
+//
+type ErrStoreRecordExists string
+
+func (esre ErrStoreRecordExists) Error() string {
+	return fmt.Sprintf("CloudChamber: condition failure (already exists) on create for key %q", string(esre))
 }

--- a/internal/clients/store/errors.go
+++ b/internal/clients/store/errors.go
@@ -151,10 +151,10 @@ func (esucf ErrStoreConditionFail) Error() string {
 	return fmt.Sprintf("CloudChamber: condition failure on update for key %q - requested: %v condition: %v actual: %v", esucf.key, esucf.requested, esucf.condition, esucf.actual)
 }
 
-// ErrStoreRecordExists indicates the key, value pair being created already exists
+// ErrStoreAlreadyExists indicates the key, value pair being created already exists
 //
-type ErrStoreRecordExists string
+type ErrStoreAlreadyExists string
 
-func (esre ErrStoreRecordExists) Error() string {
-	return fmt.Sprintf("CloudChamber: condition failure (already exists) on create for key %q", string(esre))
+func (esae ErrStoreAlreadyExists) Error() string {
+	return fmt.Sprintf("CloudChamber: condition failure (already exists) on create for key %q", string(esae))
 }

--- a/internal/clients/store/storeapi.go
+++ b/internal/clients/store/storeapi.go
@@ -25,12 +25,14 @@ const (
 	KeyRootBlades
 	KeyRootRacks
 	KeyRootWorkloads
+	KeyRootStoreTest
 )
 const (
-	namespaceRootUsers     = "/users/"
-	namespaceRootRacks     = "/racks/"
-	namespaceRootBlades    = "/blades/"
-	namespaceRootWorkloads = "/workloads/"
+	namespaceRootUsers     = "users/"
+	namespaceRootRacks     = "racks/"
+	namespaceRootBlades    = "blades/"
+	namespaceRootWorkloads = "workloads/"
+	namespaceRootStoreTest = "storetest/"
 )
 
 var namespaceRoots = map[KeyRoot]string{
@@ -38,6 +40,7 @@ var namespaceRoots = map[KeyRoot]string{
 	KeyRootRacks:     namespaceRootBlades,
 	KeyRootBlades:    namespaceRootBlades,
 	KeyRootWorkloads: namespaceRootWorkloads,
+	KeyRootStoreTest: namespaceRootStoreTest,
 }
 
 func getNamespaceRootFromKeyRoot(r KeyRoot) string {
@@ -48,10 +51,10 @@ func getKeyFromKeyRootAndName(r KeyRoot, n string) string {
 	return namespaceRoots[r] + GetNormalizedName(n)
 }
 
-// GetKeyFromUsername is a utility function to convert a supplied username to
+// GetKeyFromUsername1 is a utility function to convert a supplied username to
 // a store usable key for use when operating with user records.
 //
-func GetKeyFromUsername(name string) string {
+func GetKeyFromUsername1(name string) string {
 	return getKeyFromKeyRootAndName(KeyRootUsers, name)
 }
 
@@ -212,8 +215,6 @@ func (store *Store) ReadNew(ctx context.Context, r KeyRoot, n string, m protoifa
 			response *Response
 		)
 
-		key := GetKeyFromUsername(n)
-
 		// If we need to do the read to get the revision, we will need an array of the keys
 		//
 		request := &Request{Records: make(map[string]Record), Conditions: make(map[string]Condition)}
@@ -236,8 +237,8 @@ func (store *Store) ReadNew(ctx context.Context, r KeyRoot, n string, m protoifa
 			return ErrStoreKeyNotFound(n)
 
 		case 1:
-			rev = response.Records[key].Revision
-			val = response.Records[key].Value
+			rev = response.Records[k].Revision
+			val = response.Records[k].Value
 			st.Infof(ctx, -1, "found record for %q with revision %v and value %q", n, rev, val)
 
 			err = Decode(val, m)
@@ -279,8 +280,6 @@ func (store *Store) ReadNewValue(ctx context.Context, r KeyRoot, n string) (valu
 			response *Response
 		)
 
-		key := GetKeyFromUsername(n)
-
 		// If we need to do the read to get the revision, we will need an array of the keys
 		//
 		request := &Request{Records: make(map[string]Record), Conditions: make(map[string]Condition)}
@@ -303,8 +302,8 @@ func (store *Store) ReadNewValue(ctx context.Context, r KeyRoot, n string) (valu
 			return ErrStoreKeyNotFound(n)
 
 		case 1:
-			rev = response.Records[key].Revision
-			val = response.Records[key].Value
+			rev = response.Records[k].Revision
+			val = response.Records[k].Value
 			st.Infof(ctx, -1, "found record for %q with revision %v and value %q", n, rev, val)
 
 			st.Infof(ctx, -1, "Read record for %q with revision %v", n, rev)

--- a/internal/clients/store/storeapi.go
+++ b/internal/clients/store/storeapi.go
@@ -4,21 +4,432 @@ import (
 	"context"
 	"strings"
 
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+
 	"github.com/Jim3Things/CloudChamber/internal/tracing"
 	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 	pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
-	"github.com/golang/protobuf/jsonpb"
+
+	"google.golang.org/protobuf/runtime/protoiface"
 )
 
+// KeyRoot is used to describe which part of the store namespace
+// should be used for the corresponding record access.
+//
+type KeyRoot int
+
+// The set of avalable namespace roots used by vcarious record types
+//
 const (
-	storeRootUsers     = "users/"
-	storeRootRacks     = "racks/"
-	storeRootBlades    = "blades/"
-	storeRootWorkloads = "workloads/"
+	KeyRootUsers KeyRoot = iota
+	KeyRootBlades
+	KeyRootRacks
+	KeyRootWorkloads
+)
+const (
+	namespaceRootUsers     = "users/"
+	namespaceRootRacks     = "racks/"
+	namespaceRootBlades    = "blades/"
+	namespaceRootWorkloads = "workloads/"
 )
 
-func getKeyFromUsername(name string) string {
-	return storeRootUsers + name
+var namespaceRoots = map[KeyRoot]string{
+	KeyRootUsers:     namespaceRootUsers,
+	KeyRootRacks:     namespaceRootBlades,
+	KeyRootBlades:    namespaceRootBlades,
+	KeyRootWorkloads: namespaceRootWorkloads,
+}
+
+func getNamespaceRootFromKeyRoot(r KeyRoot) string {
+	return namespaceRoots[r]
+}
+
+func getKeyFromKeyRootAndName(r KeyRoot, n string) string {
+	return namespaceRoots[r] + GetNormalizedName(n)
+}
+
+// GetKeyFromUsername is a utility function to convert a supplied username to
+// a store usable key for use when operating with user records.
+//
+func GetKeyFromUsername(name string) string {
+	return getKeyFromKeyRootAndName(KeyRootUsers, name)
+}
+
+// GetNormalizedName is a utility function to prepare a name for use when
+// building a key suitable for operating with records in the store
+//
+func GetNormalizedName(name string) string {
+	return strings.ToLower(name)
+}
+
+// Request is a struct defining the collection of values needed to make a request
+// of the underlying store. Which values need to be set depend on the request.
+// For example, setting any "value" for a read request is ignored.
+//
+type Request struct {
+	Reason     string
+	Records    map[string]Record
+	Conditions map[string]Condition
+}
+
+// Response is a struct defining the set of values returned from a request.
+//
+type Response struct {
+	Revision int64
+	Records  map[string]Record
+}
+
+// Encode is a default protobuf defined message to JSON encoded string encoder
+//
+func Encode(m proto.Message) (s string, err error) {
+
+	p := jsonpb.Marshaler{}
+
+	if s, err = p.MarshalToString(m); err != nil {
+		return "", err
+	}
+
+	return s, nil
+}
+
+// Decode is a default JSON encoded string to protobuf defined message decoder
+//
+func Decode(s string, m protoiface.MessageV1) error {
+	if err := jsonpb.Unmarshal(strings.NewReader(s), m); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateNew is a function to create a single key, value record pair
+//
+func (store *Store) CreateNew(ctx context.Context, r KeyRoot, n string, m protoiface.MessageV1) (revision int64, err error) {
+
+	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+
+		if err = store.disconnected(ctx); err != nil {
+			return err
+		}
+
+		v, err := Encode(m)
+
+		if err != nil {
+			return err
+		}
+
+		request := &Request{Records: make(map[string]Record), Conditions: make(map[string]Condition)}
+
+		k := getKeyFromKeyRootAndName(r, n)
+		request.Records[k] = Record{Revision: RevisionInvalid, Value: v}
+		request.Conditions[k] = ConditionCreate
+
+		resp, err := store.WriteTxn(ctx, request)
+
+		// Need to strip the namespace prefix and return something described
+		// in terms the caller should recognize
+		//
+		if err == ErrStoreRecordExists(k) {
+			return ErrStoreRecordExists(n)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		st.Infof(ctx, -1, "Created record for %q with revision %v", n, resp.Revision)
+
+		revision = resp.Revision
+
+		return nil
+	})
+
+	return revision, err
+}
+
+// CreateNewValue is a function to create a single key, value record pair
+//
+func (store *Store) CreateNewValue(ctx context.Context, r KeyRoot, n string, v string) (revision int64, err error) {
+
+	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+
+		if err = store.disconnected(ctx); err != nil {
+			return err
+		}
+
+		request := &Request{Records: make(map[string]Record), Conditions: make(map[string]Condition)}
+
+		k := getKeyFromKeyRootAndName(r, n)
+		request.Records[k] = Record{Revision: RevisionInvalid, Value: v}
+		request.Conditions[k] = ConditionCreate
+
+		resp, err := store.WriteTxn(ctx, request)
+
+		// Need to strip the namespace prefix and return something described
+		// in terms the caller should recognize
+		//
+		if err == ErrStoreRecordExists(k) {
+			return ErrStoreRecordExists(n)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		st.Infof(ctx, -1, "Created record for %q with revision %v", n, resp.Revision)
+
+		revision = resp.Revision
+
+		return nil
+	})
+
+	return revision, err
+}
+
+// ReadNew is a method to retrieve the user record associated with the
+// supplied name, deal with any store related key prefixes, and decore
+// the json encoded record into something the caller understands.
+//
+// NOTE: A future enhancement may occur where the caller supplies an action
+//       routine to take care of the decoding of the record itself allowing
+//       this layer to only have to deal with the manipulation of the store,
+//       the keys used to persist the callers records but not have to worry
+//       about the encode/decode formats or indeed the target record itself.
+//
+func (store *Store) ReadNew(ctx context.Context, r KeyRoot, n string, m protoiface.MessageV1) (revision int64, err error) {
+
+	revision = RevisionInvalid
+
+	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+
+		if err := store.disconnected(ctx); err != nil {
+			return err
+		}
+
+		var (
+			rev      int64
+			val      string
+			response *Response
+		)
+
+		key := GetKeyFromUsername(n)
+
+		// If we need to do the read to get the revision, we will need an array of the keys
+		//
+		request := &Request{Records: make(map[string]Record), Conditions: make(map[string]Condition)}
+
+		k := getKeyFromKeyRootAndName(r, n)
+		request.Records[k] = Record{Revision: RevisionInvalid}
+		request.Conditions[k] = ConditionUnconditional
+
+		if response, err = store.ReadTxn(ctx, request); err != nil {
+			return err
+		}
+
+		recordCount := len(response.Records)
+
+		switch recordCount {
+		default:
+			return ErrStoreBadRecordCount{n, 1, recordCount}
+
+		case 0:
+			return ErrStoreKeyNotFound(n)
+
+		case 1:
+			rev = response.Records[key].Revision
+			val = response.Records[key].Value
+			st.Infof(ctx, -1, "found record for %q with revision %v and value %q", n, rev, val)
+
+			err = Decode(val, m)
+
+			st.Infof(ctx, -1, "Read record for %q with revision %v", n, rev)
+
+			revision = rev
+
+			return nil
+		}
+	})
+
+	return revision, err
+}
+
+// ReadNewValue is a method to retrieve the user record associated with the
+// supplied name, deal with any store related key prefixes, and decore
+// the json encoded record into something the caller understands.
+//
+// NOTE: A future enhancement may occur where the caller supplies an action
+//       routine to take care of the decoding of the record itself allowing
+//       this layer to only have to deal with the manipulation of the store,
+//       the keys used to persist the callers records but not have to worry
+//       about the encode/decode formats or indeed the target record itself.
+//
+func (store *Store) ReadNewValue(ctx context.Context, r KeyRoot, n string) (value *string, revision int64, err error) {
+
+	revision = RevisionInvalid
+
+	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+
+		if err := store.disconnected(ctx); err != nil {
+			return err
+		}
+
+		var (
+			rev      int64
+			val      string
+			response *Response
+		)
+
+		key := GetKeyFromUsername(n)
+
+		// If we need to do the read to get the revision, we will need an array of the keys
+		//
+		request := &Request{Records: make(map[string]Record), Conditions: make(map[string]Condition)}
+
+		k := getKeyFromKeyRootAndName(r, n)
+		request.Records[k] = Record{Revision: RevisionInvalid}
+		request.Conditions[k] = ConditionUnconditional
+
+		if response, err = store.ReadTxn(ctx, request); err != nil {
+			return err
+		}
+
+		recordCount := len(response.Records)
+
+		switch recordCount {
+		default:
+			return ErrStoreBadRecordCount{n, 1, recordCount}
+
+		case 0:
+			return ErrStoreKeyNotFound(n)
+
+		case 1:
+			rev = response.Records[key].Revision
+			val = response.Records[key].Value
+			st.Infof(ctx, -1, "found record for %q with revision %v and value %q", n, rev, val)
+
+			st.Infof(ctx, -1, "Read record for %q with revision %v", n, rev)
+
+			revision = rev
+			value = &val
+
+			return nil
+		}
+	})
+
+	return value, revision, err
+}
+
+// UpdateNew is a function to conditionally update a value for a single key
+//
+func (store *Store) UpdateNew(ctx context.Context, r KeyRoot, n string, rev int64, m protoiface.MessageV1) (revision int64, err error) {
+
+	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+
+		if err = store.disconnected(ctx); err != nil {
+			return err
+		}
+
+		v, err := Encode(m)
+
+		if err != nil {
+			return err
+		}
+
+		var condition Condition
+
+		switch {
+		case rev == RevisionInvalid:
+			condition = ConditionUnconditional
+
+		default:
+			condition = ConditionRevisionEqual
+		}
+
+		request := &Request{Records: make(map[string]Record), Conditions: make(map[string]Condition)}
+
+		k := getKeyFromKeyRootAndName(r, n)
+		request.Records[k] = Record{Revision: rev, Value: v}
+		request.Conditions[k] = condition
+
+		resp, err := store.WriteTxn(ctx, request)
+
+		if err != nil {
+			return err
+		}
+
+		st.Infof(ctx, -1, "Updated record for %q from revision %v to revision %v", n, rev, resp.Revision)
+
+		revision = resp.Revision
+
+		return nil
+	})
+
+	return revision, err
+}
+
+// DeleteNew is a function to create a single key, value record pair
+//
+func (store *Store) DeleteNew(ctx context.Context, r KeyRoot, n string, rev int64) (revision int64, err error) {
+
+	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+
+		if err = store.disconnected(ctx); err != nil {
+			return err
+		}
+
+		var condition Condition
+
+		switch {
+		case rev == RevisionInvalid:
+			condition = ConditionUnconditional
+
+		default:
+			condition = ConditionRevisionEqual
+		}
+
+		request := &Request{Records: make(map[string]Record), Conditions: make(map[string]Condition)}
+
+		k := getKeyFromKeyRootAndName(r, n)
+		request.Records[k] = Record{Revision: rev}
+		request.Conditions[k] = condition
+
+		resp, err := store.DeleteTxn(ctx, request)
+
+		// Need to strip the namespace prefix and return something described
+		// in terms the caller should recognize
+		//
+		if err == ErrStoreKeyNotFound(k) {
+			return ErrStoreKeyNotFound(n)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		st.Infof(ctx, -1, "Deleted record for %q with revision %v at store revision %v", n, rev, resp.Revision)
+
+		revision = resp.Revision
+
+		return nil
+	})
+
+	return revision, err
+}
+
+// UserRecord represents the revision/user struct pair for a given user
+//
+type UserRecord struct {
+	Revision int64
+	User     *pb.User
+}
+
+// UserRecordSet is a collection of UserRecord structs used to describe
+// a set of users all with a common store revision.
+//
+type UserRecordSet struct {
+	StoreRevision int64
+	Records       map[string]UserRecord
 }
 
 // UserCreate is a method called by the user management routines to create
@@ -49,7 +460,7 @@ func (store *Store) UserCreate(ctx context.Context, u *pb.User) (revision int64,
 
 		recordSet := RecordUpdateSet{Label: methodName, Records: make(map[string]RecordUpdate)}
 
-		recordSet.Records[getKeyFromUsername(u.Name)] =
+		recordSet.Records[GetKeyFromUsername(u.Name)] =
 			RecordUpdate{
 				Condition: ConditionCreate,
 				Record: Record{
@@ -100,7 +511,7 @@ func (store *Store) UserUpdate(ctx context.Context, u *pb.User, revCond int64) (
 			condition = ConditionRevisionEqual
 		}
 
-		key := getKeyFromUsername(u.Name)
+		key := GetKeyFromUsername(u.Name)
 
 		p := jsonpb.Marshaler{}
 
@@ -137,7 +548,7 @@ func (store *Store) UserUpdate(ctx context.Context, u *pb.User, revCond int64) (
 //
 func (store *Store) UserDelete(ctx context.Context, u *pb.User, revision int64) (rev int64, err error) {
 
-	key := storeRootUsers + u.Name
+	key := GetKeyFromUsername(u.Name)
 
 	methodName := tracing.MethodName(1)
 
@@ -202,7 +613,7 @@ func (store *Store) UserRead(ctx context.Context, name string) (user *pb.User, r
 			readResponse *RecordSet
 		)
 
-		key := getKeyFromUsername(name)
+		key := GetKeyFromUsername(name)
 
 		// If we need to do the read to get the revision, we will need an array of the keys
 		//
@@ -243,21 +654,6 @@ func (store *Store) UserRead(ctx context.Context, name string) (user *pb.User, r
 	return user, revision, err
 }
 
-// UserRecord represents the revision/user struct pair for a given user
-//
-type UserRecord struct {
-	Revision int64
-	User     *pb.User
-}
-
-// UserRecordSet is a collection of UserRecord structs used to describe
-// a set of users all with a common store revision.
-//
-type UserRecordSet struct {
-	StoreRevision int64
-	Records       map[string]UserRecord
-}
-
 // UserList is a method to return all the user records using a single call.
 //
 // NOTE: The returned UserRecordSet may exist but contain no records.
@@ -269,9 +665,8 @@ type UserRecordSet struct {
 //		 an essentially infinite number of records.
 //
 func (store *Store) UserList(ctx context.Context) (recordSet *UserRecordSet, err error) {
-	methodName := tracing.MethodName(1)
 
-	err = st.WithSpan(ctx, methodName, func(ctx context.Context) (err error) {
+	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
 
 		if err := store.disconnected(ctx); err != nil {
 			return err
@@ -279,7 +674,9 @@ func (store *Store) UserList(ctx context.Context) (recordSet *UserRecordSet, err
 
 		var readResponse *RecordSet
 
-		if readResponse, err = store.ReadWithPrefix(ctx, storeRootUsers); err != nil {
+		prefix := getNamespaceRootFromKeyRoot(KeyRootUsers)
+
+		if readResponse, err = store.ReadWithPrefix(ctx, prefix); err != nil {
 			return err
 		}
 
@@ -291,23 +688,23 @@ func (store *Store) UserList(ctx context.Context) (recordSet *UserRecordSet, err
 			err = jsonpb.Unmarshal(strings.NewReader(r.Value), u)
 
 			if err != nil {
-				st.Errorf(ctx, -1, "failure unmarshalling record - user: %q rev: %vvalue %q", k, r.Revision, r.Value)
+				st.Errorf(ctx, -1, "failure unmarshalling record - user: %q rev: %v value %q", k, r.Revision, r.Value)
 				return err
 			}
 
-			if !strings.HasPrefix(k, storeRootUsers) {
+			if !strings.HasPrefix(k, prefix) {
 				return ErrStoreBadRecordKey(k)
 			}
 
-			userName := strings.TrimPrefix(k, storeRootUsers)
+			userName := strings.TrimPrefix(k, prefix)
 
-			if userName != u.Name {
+			if userName != GetNormalizedName(u.Name) {
 				return ErrStoreBadRecordContent(k)
 			}
 
 			rs.Records[userName] = UserRecord{Revision: r.Revision, User: u}
 
-			st.Infof(ctx, -1, "found record for user %q either revision %v", u.Name, r.Revision)
+			st.Infof(ctx, -1, "found record for user %q (%q) with revision %v", userName, u.Name, r.Revision)
 		}
 
 		rs.StoreRevision = readResponse.Revision

--- a/internal/clients/store/storeapi.go
+++ b/internal/clients/store/storeapi.go
@@ -366,7 +366,7 @@ func (store *Store) UpdateNew(ctx context.Context, r KeyRoot, n string, rev int6
 	return revision, err
 }
 
-// DeleteNew is a function to create a single key, value record pair
+// DeleteNew is a function to delete a single key, value record pair
 //
 func (store *Store) DeleteNew(ctx context.Context, r KeyRoot, n string, rev int64) (revision int64, err error) {
 

--- a/internal/clients/store/storeapi.go
+++ b/internal/clients/store/storeapi.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Jim3Things/CloudChamber/internal/tracing"
 	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
-	pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
 
 	"google.golang.org/protobuf/runtime/protoiface"
 )
@@ -28,10 +27,10 @@ const (
 	KeyRootWorkloads
 )
 const (
-	namespaceRootUsers     = "users/"
-	namespaceRootRacks     = "racks/"
-	namespaceRootBlades    = "blades/"
-	namespaceRootWorkloads = "workloads/"
+	namespaceRootUsers     = "/users/"
+	namespaceRootRacks     = "/racks/"
+	namespaceRootBlades    = "/blades/"
+	namespaceRootWorkloads = "/workloads/"
 )
 
 var namespaceRoots = map[KeyRoot]string{
@@ -130,8 +129,8 @@ func (store *Store) CreateNew(ctx context.Context, r KeyRoot, n string, m protoi
 		// Need to strip the namespace prefix and return something described
 		// in terms the caller should recognize
 		//
-		if err == ErrStoreRecordExists(k) {
-			return ErrStoreRecordExists(n)
+		if err == ErrStoreAlreadyExists(k) {
+			return ErrStoreAlreadyExists(n)
 		}
 
 		if err != nil {
@@ -169,8 +168,8 @@ func (store *Store) CreateNewValue(ctx context.Context, r KeyRoot, n string, v s
 		// Need to strip the namespace prefix and return something described
 		// in terms the caller should recognize
 		//
-		if err == ErrStoreRecordExists(k) {
-			return ErrStoreRecordExists(n)
+		if err == ErrStoreAlreadyExists(k) {
+			return ErrStoreAlreadyExists(n)
 		}
 
 		if err != nil {
@@ -417,246 +416,9 @@ func (store *Store) DeleteNew(ctx context.Context, r KeyRoot, n string, rev int6
 	return revision, err
 }
 
-// UserRecord represents the revision/user struct pair for a given user
+// ListNew is a method to return all the user records using a single call.
 //
-type UserRecord struct {
-	Revision int64
-	User     *pb.User
-}
-
-// UserRecordSet is a collection of UserRecord structs used to describe
-// a set of users all with a common store revision.
-//
-type UserRecordSet struct {
-	StoreRevision int64
-	Records       map[string]UserRecord
-}
-
-// UserCreate is a method called by the user management routines to create
-// a persistent user record in the store.
-//
-// No consistency check is performed on the content of the user record itself
-//
-func (store *Store) UserCreate(ctx context.Context, u *pb.User) (revision int64, err error) {
-
-	methodName := tracing.MethodName(1)
-
-	err = st.WithSpan(ctx, methodName, func(ctx context.Context) (err error) {
-
-		if err := store.disconnected(ctx); err != nil {
-			return err
-		}
-
-		var (
-			rev int64
-			val string
-		)
-
-		p := jsonpb.Marshaler{}
-
-		if val, err = p.MarshalToString(u); err != nil {
-			return err
-		}
-
-		recordSet := RecordUpdateSet{Label: methodName, Records: make(map[string]RecordUpdate)}
-
-		recordSet.Records[GetKeyFromUsername(u.Name)] =
-			RecordUpdate{
-				Condition: ConditionCreate,
-				Record: Record{
-					Revision: RevisionInvalid,
-					Value:    val,
-				},
-			}
-
-		if rev, err = store.WriteMultipleTxn(ctx, &recordSet); err != nil {
-			return err
-		}
-
-		st.Infof(ctx, -1, "Created user %q with revision %v", u.Name, rev)
-
-		revision = rev
-
-		return nil
-	})
-
-	return revision, err
-}
-
-// UserUpdate is a method used to update the user record for the sepcified user.
-//
-// No validation is performed on the content of the user record itself
-//
-func (store *Store) UserUpdate(ctx context.Context, u *pb.User, revCond int64) (revision int64, err error) {
-
-	methodName := tracing.MethodName(1)
-
-	err = st.WithSpan(ctx, methodName, func(ctx context.Context) (err error) {
-
-		if err := store.disconnected(ctx); err != nil {
-			return err
-		}
-
-		var (
-			rev       int64
-			val       string
-			condition Condition
-		)
-
-		switch {
-		case revCond == RevisionInvalid:
-			condition = ConditionUnconditional
-
-		default:
-			condition = ConditionRevisionEqual
-		}
-
-		key := GetKeyFromUsername(u.Name)
-
-		p := jsonpb.Marshaler{}
-
-		if val, err = p.MarshalToString(u); err != nil {
-			return err
-		}
-
-		recordSet := RecordUpdateSet{Label: methodName, Records: make(map[string]RecordUpdate)}
-
-		recordSet.Records[key] =
-			RecordUpdate{
-				Condition: condition,
-				Record: Record{
-					Revision: revCond,
-					Value:    val,
-				},
-			}
-
-		if rev, err = store.WriteMultipleTxn(ctx, &recordSet); err != nil {
-			return err
-		}
-
-		st.Infof(ctx, -1, "Updated user %q using condition revision %v to revision %v using condition %v", u.Name, revCond, rev, condition)
-
-		revision = rev
-
-		return nil
-	})
-
-	return revision, err
-}
-
-// UserDelete is a method used to delete the user record for the specified user
-//
-func (store *Store) UserDelete(ctx context.Context, u *pb.User, revision int64) (rev int64, err error) {
-
-	key := GetKeyFromUsername(u.Name)
-
-	methodName := tracing.MethodName(1)
-
-	err = st.WithSpan(ctx, methodName, func(ctx context.Context) (err error) {
-
-		if err := store.disconnected(ctx); err != nil {
-			return err
-		}
-
-		recordSet := RecordUpdateSet{Label: methodName, Records: make(map[string]RecordUpdate)}
-
-		recordSet.Records[key] =
-			RecordUpdate{
-				Condition: ConditionRevisionEqual,
-				Record: Record{
-					Revision: revision,
-					Value:    "",
-				},
-			}
-
-		revStore, err := store.DeleteMultipleTxn(ctx, &recordSet)
-
-		if err != nil {
-			return err
-		}
-
-		rev = revStore
-
-		st.Infof(ctx, -1, "Deleted user %q with revision %v", u.Name, rev)
-
-		return nil
-	})
-
-	return rev, err
-}
-
-// UserRead is a method to retrieve the user record associated with the
-// supplied name, deal with any store related key prefixes, and decore
-// the json encoded record into something the caller understands.
-//
-// NOTE: A future enhancement may occur where the caller supplies an action
-//       routine to take care of the decoding of the record itself allowing
-//       this layer to only have to deal with the manipulation of the store,
-//       the keys used to persist the callers records but not have to worry
-//       about the encode/decode formats or indeed the target record itself.
-//
-func (store *Store) UserRead(ctx context.Context, name string) (user *pb.User, revision int64, err error) {
-
-	revision = RevisionInvalid
-
-	methodName := tracing.MethodName(1)
-
-	err = st.WithSpan(ctx, methodName, func(ctx context.Context) (err error) {
-
-		if err := store.disconnected(ctx); err != nil {
-			return err
-		}
-
-		var (
-			rev          int64
-			val          string
-			readResponse *RecordSet
-		)
-
-		key := GetKeyFromUsername(name)
-
-		// If we need to do the read to get the revision, we will need an array of the keys
-		//
-		recordKeySet := RecordKeySet{Label: methodName, Keys: []string{key}}
-
-		if readResponse, err = store.ReadMultipleTxn(ctx, recordKeySet); err != nil {
-			return err
-		}
-
-		recordCount := len(readResponse.Records)
-
-		switch recordCount {
-		default:
-			return ErrStoreBadRecordCount{name, 1, recordCount}
-
-		case 0:
-			return ErrStoreKeyNotFound(name)
-
-		case 1:
-			rev = readResponse.Records[key].Revision
-			val = readResponse.Records[key].Value
-			st.Infof(ctx, -1, "found record for user %q with revision %v and value %q", name, rev, val)
-
-			u := &pb.User{}
-			if err = jsonpb.Unmarshal(strings.NewReader(val), u); err != nil {
-				return err
-			}
-
-			st.Infof(ctx, -1, "Read User %q with revision %v", name, rev)
-
-			user = u
-			revision = rev
-
-			return nil
-		}
-	})
-
-	return user, revision, err
-}
-
-// UserList is a method to return all the user records using a single call.
-//
-// NOTE: The returned UserRecordSet may exist but contain no records.
+// NOTE: The returned set of records may exist but contain no records.
 //
 // NOTE: This should only be used at present if the number of user records
 //       is limited as there is a limit to the number of records that can
@@ -664,7 +426,7 @@ func (store *Store) UserRead(ctx context.Context, name string) (user *pb.User, r
 //       be updated to user an "interupted" enum style call to allow for
 //		 an essentially infinite number of records.
 //
-func (store *Store) UserList(ctx context.Context) (recordSet *UserRecordSet, err error) {
+func (store *Store) ListNew(ctx context.Context, r KeyRoot) (records *map[string]Record, revision int64, err error) {
 
 	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
 
@@ -672,49 +434,36 @@ func (store *Store) UserList(ctx context.Context) (recordSet *UserRecordSet, err
 			return err
 		}
 
-		var readResponse *RecordSet
+		prefix := getNamespaceRootFromKeyRoot(r)
 
-		prefix := getNamespaceRootFromKeyRoot(KeyRootUsers)
+		response, err := store.ListWithPrefix(ctx, prefix)
 
-		if readResponse, err = store.ReadWithPrefix(ctx, prefix); err != nil {
+		if err != nil {
 			return err
 		}
 
-		rs := &UserRecordSet{StoreRevision: readResponse.Revision, Records: make(map[string]UserRecord, len(readResponse.Records))}
+		recs := make(map[string]Record, len(response.Records))
 
-		for k, r := range readResponse.Records {
-			u := &pb.User{}
-
-			err = jsonpb.Unmarshal(strings.NewReader(r.Value), u)
-
-			if err != nil {
-				st.Errorf(ctx, -1, "failure unmarshalling record - user: %q rev: %v value %q", k, r.Revision, r.Value)
-				return err
-			}
+		for k, r := range response.Records {
 
 			if !strings.HasPrefix(k, prefix) {
 				return ErrStoreBadRecordKey(k)
 			}
 
-			userName := strings.TrimPrefix(k, prefix)
+			name := strings.TrimPrefix(k, prefix)
 
-			if userName != GetNormalizedName(u.Name) {
-				return ErrStoreBadRecordContent(k)
-			}
+			recs[name] = Record{Revision: r.Revision, Value: r.Value}
 
-			rs.Records[userName] = UserRecord{Revision: r.Revision, User: u}
-
-			st.Infof(ctx, -1, "found record for user %q (%q) with revision %v", userName, u.Name, r.Revision)
+			st.Infof(ctx, -1, "found record with key %q for name %q with revision %v", k, name, r.Revision)
 		}
 
-		rs.StoreRevision = readResponse.Revision
+		st.Infof(ctx, -1, "returned %v records at store revision %v", len(response.Records), response.Revision)
 
-		st.Infof(ctx, -1, "returned %v records at store revision %v", len(rs.Records), rs.StoreRevision)
-
-		recordSet = rs
+		records = &recs
+		revision = response.Revision
 
 		return nil
 	})
 
-	return recordSet, err
+	return records, revision, err
 }

--- a/internal/clients/store/storeapi_test.go
+++ b/internal/clients/store/storeapi_test.go
@@ -32,7 +32,7 @@ func TestCreate(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
 
-	userName := admin + tracing.MethodName(1)
+	userName := admin + "." + tracing.MethodName(1)
 
 	store := NewStore()
 	assert.NotNilf(t, store, "Failed to get the store as expected")
@@ -77,7 +77,7 @@ func TestReadNew(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
 
-	userName := admin + tracing.MethodName(1)
+	userName := admin + "." + tracing.MethodName(1)
 
 	store := NewStore()
 	assert.NotNilf(t, store, "Failed to get the store as expected")
@@ -128,7 +128,7 @@ func TestReadNewValue(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
 
-	userName := admin + tracing.MethodName(1)
+	userName := admin + "." + tracing.MethodName(1)
 
 	store := NewStore()
 	assert.NotNilf(t, store, "Failed to get the store as expected")
@@ -182,7 +182,7 @@ func TestUpdate(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
 
-	userName := admin + tracing.MethodName(1)
+	userName := admin + "." + tracing.MethodName(1)
 
 	store := NewStore()
 	assert.NotNilf(t, store, "Failed to get the store as expected")
@@ -263,7 +263,7 @@ func TestUpdateUnconditional(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
 
-	userName := admin + tracing.MethodName(1)
+	userName := admin + "." + tracing.MethodName(1)
 
 	store := NewStore()
 	assert.NotNilf(t, store, "Failed to get the store as expected")
@@ -359,8 +359,7 @@ func TestDelete(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
 
-	suffix := tracing.MethodName(1)
-	userName := alice + suffix
+	userName := alice + "." + tracing.MethodName(1)
 	passWord := alicePassword
 
 	store := NewStore()
@@ -439,7 +438,7 @@ func TestList(t *testing.T) {
 	err := store.Connect()
 	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
 
-	suffix := tracing.MethodName(1)
+	suffix := "." + tracing.MethodName(1)
 
 	userSet := []urec{
 		{name: alice + suffix, pwd: alicePassword},

--- a/internal/clients/store/storeapi_test.go
+++ b/internal/clients/store/storeapi_test.go
@@ -42,12 +42,12 @@ func TestUserCreate(t *testing.T) {
 	passwordHash, err := bcrypt.GenerateFromPassword([]byte(adminPassword), bcrypt.DefaultCost)
 
 	user := &pb.User{
-		Name:           	userName,
-		PasswordHash:   	passwordHash,
-		UserId:         	1,
-		Enabled:        	true,
-		CanManageAccounts: 	true,
-		NeverDelete:    	true,
+		Name:              userName,
+		PasswordHash:      passwordHash,
+		UserId:            1,
+		Enabled:           true,
+		CanManageAccounts: true,
+		NeverDelete:       true,
 	}
 
 	revCreate, err := store.UserCreate(context.Background(), user)
@@ -85,12 +85,12 @@ func TestUserUpdate(t *testing.T) {
 	passwordHash, err := bcrypt.GenerateFromPassword([]byte(adminUpdatePassword), bcrypt.DefaultCost)
 
 	user := &pb.User{
-		Name:           	userName,
-		PasswordHash:   	passwordHash,
-		UserId:         	1,
-		Enabled:        	true,
-		CanManageAccounts: 	true,
-		NeverDelete:    	true,
+		Name:              userName,
+		PasswordHash:      passwordHash,
+		UserId:            1,
+		Enabled:           true,
+		CanManageAccounts: true,
+		NeverDelete:       true,
 	}
 
 	revCreate, err := store.UserCreate(context.Background(), user)
@@ -111,12 +111,12 @@ func TestUserUpdate(t *testing.T) {
 	passwordHash, err = bcrypt.GenerateFromPassword([]byte(adminUpdatePassword2), bcrypt.DefaultCost)
 
 	userUpdate := &pb.User{
-		Name:           	userName,
-		PasswordHash:   	passwordHash,
-		UserId:         	1,
-		Enabled:        	false,
-		CanManageAccounts: 	true,
-		NeverDelete:    	true,
+		Name:              userName,
+		PasswordHash:      passwordHash,
+		UserId:            1,
+		Enabled:           false,
+		CanManageAccounts: true,
+		NeverDelete:       true,
 	}
 
 	revUpdate, err := store.UserUpdate(context.Background(), userUpdate, readRev)
@@ -131,7 +131,7 @@ func TestUserUpdate(t *testing.T) {
 	// Now try to update with the wrong revision
 	//
 	readRevUpdate, err = store.UserUpdate(context.Background(), userUpdate, readRev)
-	assert.NotNilf(t, err, "Unecpected success trying to update with wrong revision for user %q - error: %v", userName, err)
+	assert.NotNilf(t, err, "Unexpected success trying to update with wrong revision for user %q - error: %v", userName, err)
 	assert.Equalf(t, RevisionInvalid, readRevUpdate, "Expected update revision to be greater than create revision")
 
 	store.Disconnect()
@@ -155,12 +155,12 @@ func TestUserDelete(t *testing.T) {
 	passwordHash, err := bcrypt.GenerateFromPassword([]byte(adminDeletePassword), bcrypt.DefaultCost)
 
 	user := &pb.User{
-		Name:           	userName,
-		PasswordHash:   	passwordHash,
-		UserId:         	1,
-		Enabled:        	true,
-		CanManageAccounts: 	true,
-		NeverDelete:    	true,
+		Name:              userName,
+		PasswordHash:      passwordHash,
+		UserId:            1,
+		Enabled:           true,
+		CanManageAccounts: true,
+		NeverDelete:       true,
 	}
 
 	revCreate, err := store.UserCreate(context.Background(), user)
@@ -226,12 +226,468 @@ func TestUserList(t *testing.T) {
 		assert.Nilf(t, err, "Failed to create password hash for user %q - error: %v", u.name, err)
 
 		users[u.name] = &pb.User{
-			Name:           	u.name,
-			PasswordHash:   	pwdHash,
-			UserId:         	int64(i + 1),
-			Enabled:        	true,
-			CanManageAccounts: 	false,
-			NeverDelete:    	false,
+			Name:              u.name,
+			PasswordHash:      pwdHash,
+			UserId:            int64(i + 1),
+			Enabled:           true,
+			CanManageAccounts: false,
+			NeverDelete:       false,
+		}
+	}
+
+	recordSet := UserRecordSet{StoreRevision: RevisionInvalid, Records: make(map[string]UserRecord, len(userSet))}
+
+	for name, rec := range users {
+		revCreate, err := store.UserCreate(context.Background(), rec)
+		assert.Nilf(t, err, "Failed to create new user %q - error: %v", name, err)
+		assert.Lessf(t, RevisionInvalid, revCreate, "Expected new store revision to be greater than initial revision")
+
+		recordSet.Records[name] = UserRecord{Revision: revCreate, User: rec}
+	}
+
+	userList, err := store.UserList(context.Background())
+	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
+	assert.Lessf(t, RevisionInvalid, userList.StoreRevision, "Expected new store revision to be greater than initial revision")
+
+	// Use "less than or equal" relationship to allow for the cases where all the
+	// file tests are being executed and there are potentially user records left over
+	// from tests running earlier in the set.
+	//
+	assert.LessOrEqualf(t, len(recordSet.Records), len(userList.Records), "Unexpected difference in count of records returned from user list")
+
+	// Check that the records this test created are present. There may be others.
+	//
+	for n, ur := range recordSet.Records {
+		assert.Equalf(t, ur.Revision, userList.Records[n].Revision, "Unexpected difference in revision from create for user %q", n)
+		assert.Equalf(t, ur.User, userList.Records[n].User, "Unexpected difference in record from create for user %q", n)
+	}
+
+	store.Disconnect()
+
+	store = nil
+	return
+}
+
+func TestCreate(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
+	userName := admin
+
+	store := NewStore()
+	assert.NotNilf(t, store, "Failed to get the store as expected")
+
+	err := store.Connect()
+	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(adminPassword), bcrypt.DefaultCost)
+
+	user := &pb.User{
+		Name:              userName,
+		PasswordHash:      passwordHash,
+		UserId:            1,
+		Enabled:           true,
+		CanManageAccounts: true,
+		NeverDelete:       true,
+	}
+
+	revCreate, err := store.CreateNew(context.Background(), KeyRootUsers, userName, user)
+	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
+	assert.Lessf(t, RevisionInvalid, revCreate, "Expected new store revision to be greater than initial revision")
+
+	revCreate2, err := store.CreateNew(context.Background(), KeyRootUsers, userName, user)
+	assert.NotNilf(t, err, "Unexpected success attempting to (re-)create new user %q - error: %v", userName, err)
+	assert.Equalf(t, RevisionInvalid, revCreate2, "Expected failure should result in no response")
+
+	userRead := &pb.User{}
+
+	revRead, err := store.ReadNew(context.Background(), KeyRootUsers, userName, userRead)
+
+	assert.Nilf(t, err, "Failed to read user %q - error: %v", userName, err)
+	assert.Equalf(t, revCreate, revRead, "Unexpected difference in creation revision vs read revision")
+	assert.Equalf(t, user, userRead, "Unexpected difference in creation user record and read user record")
+
+	store.Disconnect()
+
+	store = nil
+	return
+}
+
+func TestCreate2(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
+	userName := admin
+
+	store := NewStore()
+	assert.NotNilf(t, store, "Failed to get the store as expected")
+
+	err := store.Connect()
+	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(adminPassword), bcrypt.DefaultCost)
+
+	user := &pb.User{
+		Name:              userName,
+		PasswordHash:      passwordHash,
+		UserId:            1,
+		Enabled:           true,
+		CanManageAccounts: true,
+		NeverDelete:       true,
+	}
+
+	revision, err := store.CreateNew(context.Background(), KeyRootUsers, userName, user)
+	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
+	assert.Lessf(t, RevisionInvalid, revision, "Expected new store revision to be greater than initial revision")
+
+	revision2, err := store.CreateNew(context.Background(), KeyRootUsers, userName, user)
+	assert.NotNilf(t, err, "Unexpected success attempting to (re-)create new user %q - error: %v", userName, err)
+	assert.Equalf(t, RevisionInvalid, revision2, "Expected failure should result in no response")
+
+	readUser, readRev, err := store.UserRead(context.Background(), userName)
+
+	assert.Nilf(t, err, "Failed to read user %q - error: %v", userName, err)
+	assert.Equalf(t, revision, readRev, "Unexpected difference in creation revision vs read revision")
+	assert.Equalf(t, user, readUser, "Unexpected difference in creation user record and read user record")
+
+	store.Disconnect()
+
+	store = nil
+	return
+}
+
+func TestReadNew(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
+	userName := admin
+
+	store := NewStore()
+	assert.NotNilf(t, store, "Failed to get the store as expected")
+
+	err := store.Connect()
+	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(adminPassword), bcrypt.DefaultCost)
+
+	user := &pb.User{
+		Name:              userName,
+		PasswordHash:      passwordHash,
+		UserId:            1,
+		Enabled:           true,
+		CanManageAccounts: true,
+		NeverDelete:       true,
+	}
+
+	revCreate, err := store.CreateNew(context.Background(), KeyRootUsers, userName, user)
+	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
+	assert.Lessf(t, RevisionInvalid, revCreate, "Expected new store revision to be greater than initial revision")
+
+	readUser := &pb.User{}
+
+	revRead, err := store.ReadNew(context.Background(), KeyRootUsers, userName, readUser)
+	assert.Nilf(t, err, "Unexpected failure attempting to read user %q - error: %v", userName, err)
+	assert.Equalf(t, revCreate, revRead, "Expected read revision to be equal to create revision")
+	assert.Equalf(t, user, readUser, "Unexpected difference in creation user record and read user record")
+
+	readUserString, revReadValue, err := store.ReadNewValue(context.Background(), KeyRootUsers, userName)
+	assert.Nilf(t, err, "Unexpected failure attempting to read user %q - error: %v", userName, err)
+	assert.Equalf(t, revCreate, revReadValue, "Expected read revision to be equal to create revision")
+
+	readUserValue := &pb.User{}
+
+	err = Decode(*readUserString, readUserValue)
+
+	assert.Nilf(t, err, "Unexpected failure attempting to decode string for user %q - error: %v", userName, err, *readUserString)
+	assert.Equalf(t, user, readUserValue, "Unexpected difference in creation user record and read user record")
+
+	store.Disconnect()
+
+	store = nil
+	return
+}
+
+func TestUpdate(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
+	userName := adminUpdate
+
+	store := NewStore()
+	assert.NotNilf(t, store, "Failed to get the store as expected")
+
+	err := store.Connect()
+	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(adminUpdatePassword), bcrypt.DefaultCost)
+
+	user := &pb.User{
+		Name:              userName,
+		PasswordHash:      passwordHash,
+		UserId:            1,
+		Enabled:           true,
+		CanManageAccounts: true,
+		NeverDelete:       true,
+	}
+
+	revCreate, err := store.CreateNew(context.Background(), KeyRootUsers, userName, user)
+	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
+	assert.Lessf(t, RevisionInvalid, revCreate, "Expected new store revision to be greater than initial revision")
+
+	userRead := &pb.User{}
+
+	revRead, err := store.ReadNew(context.Background(), KeyRootUsers, userName, userRead)
+
+	assert.Nilf(t, err, "Failed to read user %q - error: %v", userName, err)
+	assert.Equalf(t, revCreate, revRead, "Unexpected difference in creation revision vs read revision")
+	assert.Equalf(t, user, userRead, "Unexpected difference in creation user record and read user record")
+
+	// Now update the user record and see if the changes made it.
+	//
+	passwordHash, err = bcrypt.GenerateFromPassword([]byte(adminUpdatePassword2), bcrypt.DefaultCost)
+
+	userUpdate := &pb.User{
+		Name:              userName,
+		PasswordHash:      passwordHash,
+		UserId:            1,
+		Enabled:           false,
+		CanManageAccounts: true,
+		NeverDelete:       true,
+	}
+
+	revUpdate, err := store.UpdateNew(context.Background(), KeyRootUsers, userName, revRead, userUpdate)
+	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
+	assert.Lessf(t, revRead, revUpdate, "Expected update revision to be greater than create revision")
+
+	userReadUpdate := &pb.User{}
+
+	revReadUpdate, err := store.ReadNew(context.Background(), KeyRootUsers, userName, userReadUpdate)
+
+	assert.Nilf(t, err, "Failed to read user %q - error: %v", userName, err)
+	assert.Equalf(t, revUpdate, revReadUpdate, "Unexpected difference in update revision vs read revision")
+	assert.Equalf(t, userUpdate, userReadUpdate, "Unexpected difference in updated user record and read user record")
+
+	// Now try to update with the wrong revision
+	//
+	userUpdate2 := &pb.User{
+		Name:              userName,
+		PasswordHash:      passwordHash,
+		UserId:            1,
+		Enabled:           true,
+		CanManageAccounts: false,
+		NeverDelete:       true,
+	}
+
+	revReadUpdate2, err := store.UpdateNew(context.Background(), KeyRootUsers, userName, revRead, userUpdate2)
+	assert.NotNilf(t, err, "Unexpected success trying to update with wrong revision for user %q - error: %v", userName, err)
+	assert.Equalf(t, RevisionInvalid, revReadUpdate2, "Expected update revision to be greater than create revision")
+
+	store.Disconnect()
+
+	store = nil
+	return
+}
+
+func TestUpdateUnconditional(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
+	userName := adminUpdate
+
+	store := NewStore()
+	assert.NotNilf(t, store, "Failed to get the store as expected")
+
+	err := store.Connect()
+	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(adminUpdatePassword), bcrypt.DefaultCost)
+
+	user := &pb.User{
+		Name:              userName,
+		PasswordHash:      passwordHash,
+		UserId:            1,
+		Enabled:           true,
+		CanManageAccounts: true,
+		NeverDelete:       true,
+	}
+
+	revCreate, err := store.CreateNew(context.Background(), KeyRootUsers, userName, user)
+	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
+	assert.Lessf(t, RevisionInvalid, revCreate, "Expected create revision to be greater than initial revision")
+
+	userRead := &pb.User{}
+
+	revRead, err := store.ReadNew(context.Background(), KeyRootUsers, userName, userRead)
+
+	assert.Nilf(t, err, "Failed to read user %q - error: %v", userName, err)
+	assert.Equalf(t, revCreate, revRead, "Unexpected difference in creation revision vs read revision")
+	assert.Equalf(t, user, userRead, "Unexpected difference in creation user record and read user record")
+
+	// Now update the user record and see if the changes made it.
+	//
+	passwordHash, err = bcrypt.GenerateFromPassword([]byte(adminUpdatePassword2), bcrypt.DefaultCost)
+
+	userUpdate := &pb.User{
+		Name:              userName,
+		PasswordHash:      passwordHash,
+		UserId:            1,
+		Enabled:           false,
+		CanManageAccounts: true,
+		NeverDelete:       true,
+	}
+
+	revUpdate, err := store.UpdateNew(context.Background(), KeyRootUsers, userName, revRead, userUpdate)
+	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
+	assert.Lessf(t, revRead, revUpdate, "Expected update revision to be greater than first read revision")
+
+	userReadUpdate := &pb.User{}
+
+	revReadUpdate, err := store.ReadNew(context.Background(), KeyRootUsers, userName, userReadUpdate)
+
+	assert.Nilf(t, err, "Failed to read user %q - error: %v", userName, err)
+	assert.Equalf(t, revUpdate, revReadUpdate, "Unexpected difference in update revision vs read revision")
+	assert.Equalf(t, userUpdate, userReadUpdate, "Unexpected difference in updated user record and read user record")
+
+	// Now try to update with the wrong revision
+	//
+	userUpdate2 := &pb.User{
+		Name:              userName,
+		PasswordHash:      passwordHash,
+		UserId:            1,
+		Enabled:           true,
+		CanManageAccounts: false,
+		NeverDelete:       true,
+	}
+
+	revReadUpdate2, err := store.UpdateNew(context.Background(), KeyRootUsers, userName, revRead, userUpdate2)
+	assert.NotNilf(t, err, "Unexpected success trying to update with wrong revision for user %q - error: %v", userName, err)
+	assert.Equalf(t, RevisionInvalid, revReadUpdate2, "Expected update revision to be nil")
+
+	// Now try to update unconditioanlly
+	//
+	userUpdate3 := &pb.User{
+		Name:              userName,
+		PasswordHash:      passwordHash,
+		UserId:            1,
+		Enabled:           false,
+		CanManageAccounts: false,
+		NeverDelete:       true,
+	}
+
+	revReadUpdate3, err := store.UpdateNew(context.Background(), KeyRootUsers, userName, RevisionInvalid, userUpdate3)
+	assert.Nilf(t, err, "Failed trying to update upconditionally for user %q - error: %v", userName, err)
+	assert.Lessf(t, revReadUpdate, revReadUpdate3, "Expected update revision to be greater than first update revision")
+
+	store.Disconnect()
+
+	store = nil
+	return
+}
+
+func TestDelete(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
+	userName := adminDelete
+
+	store := NewStore()
+	assert.NotNilf(t, store, "Failed to get the store as expected")
+
+	err := store.Connect()
+	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(adminDeletePassword), bcrypt.DefaultCost)
+
+	user := &pb.User{
+		Name:              userName,
+		PasswordHash:      passwordHash,
+		UserId:            1,
+		Enabled:           true,
+		CanManageAccounts: true,
+		NeverDelete:       true,
+	}
+
+	revCreate, err := store.CreateNew(context.Background(), KeyRootUsers, userName, user)
+	assert.Nilf(t, err, "Failed to create new user %q - error: %v", userName, err)
+	assert.Lessf(t, RevisionInvalid, revCreate, "Expected new store revision to be greater than initial revision")
+
+	userRead := &pb.User{}
+
+	revRead, err := store.ReadNew(context.Background(), KeyRootUsers, userName, userRead)
+
+	assert.Nilf(t, err, "Failed to read user %q - error: %v", userName, err)
+	assert.Equalf(t, revCreate, revRead, "Unexpected difference in creation revision vs read revision")
+	assert.Equalf(t, user, userRead, "Unexpected difference in creation user record and read user record")
+
+	// Fiurst try to delete using the wrong revision
+	//
+	revDelete, err := store.DeleteNew(context.Background(), KeyRootUsers, userName, revRead-1)
+	assert.NotNilf(t, err, "Unexpected success trying to update with wrong revision for user %q - error: %v", userName, err)
+	assert.Equalf(t, RevisionInvalid, revDelete, "Expected post-delete revision to be greater than read revision")
+
+	// Now delete with the correct revision
+	//
+	revDelete, err = store.DeleteNew(context.Background(), KeyRootUsers, userName, revRead)
+	assert.Nilf(t, err, "Failed to delete user %q - error: %v", userName, err)
+	assert.Lessf(t, revRead, revDelete, "Expected post-delete revision to be greater than read revision")
+
+	// Try to read after delete
+	//
+	userReread := &pb.User{}
+
+	revReread, err := store.ReadNew(context.Background(), KeyRootUsers, userName, userReread)
+	assert.NotNilf(t, err, "Unexpected success reading user %q after deletion - error: %v", userName, err)
+	assert.Equalf(t, RevisionInvalid, revReread, "Unexpected difference in update revision vs read revision")
+
+	// Try to delete a non-existing record.
+	//
+	revDeleteAgain, err := store.DeleteNew(context.Background(), KeyRootUsers, userName, revRead)
+	assert.NotNilf(t, err, "Unexpected success trying to update with wrong revision for user %q - error: %v", userName, err)
+	assert.Equalf(t, RevisionInvalid, revDeleteAgain, "Expected post-re-delete revision invalid")
+
+	store.Disconnect()
+
+	store = nil
+	return
+}
+
+func TestList(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
+	type urec struct {
+		name string
+		pwd  string
+	}
+
+	userName := adminDelete
+
+	store := NewStore()
+	assert.NotNilf(t, store, "Failed to get the store as expected")
+
+	err := store.Connect()
+	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
+
+	userSet := []urec{
+		{name: alice, pwd: alicePassword},
+		{name: bob, pwd: bobPassword},
+		{name: eve, pwd: evePassword},
+	}
+
+	users := make(map[string]*pb.User, len(userSet))
+
+	for i, u := range userSet {
+		pwdHash, err := bcrypt.GenerateFromPassword([]byte(u.pwd), bcrypt.DefaultCost)
+
+		assert.Nilf(t, err, "Failed to create password hash for user %q - error: %v", u.name, err)
+
+		users[GetNormalizedName(u.name)] = &pb.User{
+			Name:              u.name,
+			PasswordHash:      pwdHash,
+			UserId:            int64(i + 1),
+			Enabled:           true,
+			CanManageAccounts: false,
+			NeverDelete:       false,
 		}
 	}
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -17,6 +17,8 @@ import (
 	pb "github.com/Jim3Things/CloudChamber/pkg/protos/Stepper"
 )
 
+// Default values for the configurable parameters
+//
 const (
 	DefaultGlobalConfigFile     = "cloudchamber.yaml"
 	DefaultConfigType           = "yaml"
@@ -26,7 +28,7 @@ const (
 	WebServerDefaultPort        = 8084
 	WebServerFEDefaultPort      = 8080
 	DefaultHost                 = ""
-	DefaultStepperPolicy		= ""
+	DefaultStepperPolicy        = ""
 	DefaultRootFilePath         = "."
 	DefaultSystemAccount        = "Admin"
 	DefaultSystemPassword       = "SystemPassword"
@@ -36,6 +38,7 @@ const (
 	StoreDefaultEtcdSvcHostname = "localhost"
 	StoreDefaultEtcdSvcPort     = 2379
 
+	StoreDefaultTestUseTestNamespace  = false
 	StoreDefaultTestUseUniqueInstance = false
 	StoreDefaultTestPreCleanStore     = false
 )
@@ -115,6 +118,7 @@ type WebServerType struct {
 // a store test
 //
 type StoreTypeTest struct {
+	UseTestNamespace  bool
 	UseUniqueInstance bool
 	PreCleanStore     bool
 }
@@ -170,6 +174,7 @@ func newGlobalConfig() *GlobalConfig {
 				Port:     StoreDefaultEtcdSvcPort,
 			},
 			Test: StoreTypeTest{
+				UseTestNamespace:  StoreDefaultTestUseTestNamespace,
 				UseUniqueInstance: StoreDefaultTestUseUniqueInstance,
 				PreCleanStore:     StoreDefaultTestPreCleanStore,
 			},
@@ -238,7 +243,7 @@ func ToString(data *GlobalConfig) string {
 			"SimSupport:\n"+
 			"  EP:\n"+
 			"    port: %v\n    hostname: %v\n"+
-			"  StepperPolicy: %v\n" +
+			"  StepperPolicy: %v\n"+
 			"Webserver:\n"+
 			"  FE:\n"+
 			"    port: %v\n    hostname: %v\n"+
@@ -252,6 +257,7 @@ func ToString(data *GlobalConfig) string {
 			"  RequestTimeout: %v\n"+
 			"  TraceLevel: %v\n"+
 			"  Test:\n"+
+			"    UseTestNamespace: %v\n"+
 			"    UseUniqueInstance: %v\n"+
 			"    PreCleanStore: %v\n"+
 			"",
@@ -267,6 +273,7 @@ func ToString(data *GlobalConfig) string {
 		data.Store.ConnectTimeout,
 		data.Store.RequestTimeout,
 		data.Store.TraceLevel,
+		data.Store.Test.UseTestNamespace,
 		data.Store.Test.UseUniqueInstance,
 		data.Store.Test.PreCleanStore)
 }

--- a/internal/services/frontend/DBUsers.go
+++ b/internal/services/frontend/DBUsers.go
@@ -12,146 +12,219 @@
 package frontend
 
 import (
-    "strings"
-    "sync"
+	"context"
+	"strings"
+	"sync"
 
-    "github.com/Jim3Things/CloudChamber/internal/config"
-    pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
+	"github.com/golang/protobuf/jsonpb"
+
+	"github.com/Jim3Things/CloudChamber/internal/clients/store"
+	"github.com/Jim3Things/CloudChamber/internal/config"
+	pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
 )
 
 // DBUsers is a container used to established synchronized access to
 // the in-memory set of user records.
 //
 type DBUsers struct {
-    Mutex sync.Mutex
-    Users map[string]*pb.UserInternal
+	Mutex sync.Mutex
+	Users map[string]*pb.UserInternal
+
+	Store *store.Store
 }
 
-// Initialize the users store.  For now this is only a map in memory.
-func InitDBUsers(cfg *config.GlobalConfig) error {
-    if dbUsers == nil {
-        dbUsers = &DBUsers{
-            Mutex: sync.Mutex{},
-            Users: make(map[string]*pb.UserInternal),
-        }
-    }
+// InitDBUsers is a method to initialize the users store.  For now this is only a map in memory.
+func InitDBUsers(cfg *config.GlobalConfig) (err error) {
+	if dbUsers == nil {
+		dbUsers = &DBUsers{
+			Mutex: sync.Mutex{},
+			Users: make(map[string]*pb.UserInternal),
+			Store: store.NewStore(),
+		}
+	}
 
-    _, err := UserAdd(
-        cfg.WebServer.SystemAccount,
-        cfg.WebServer.SystemAccountPassword,
-        true,
-        true,
-        true)
-    return err
+	if err = dbUsers.Store.Connect(); err != nil {
+		return err
+	}
+
+	_, err = userAdd(
+		cfg.WebServer.SystemAccount,
+		cfg.WebServer.SystemAccountPassword,
+		true,
+		true,
+		true)
+
+	// If the SystemAccount already exists, eat the failure
+	//
+	if err == store.ErrStoreRecordExists(cfg.WebServer.SystemAccount) {
+		return nil
+	}
+
+	return err
 }
 
-// Create a new user entry in the store.
+func encode(u *pb.User) (s string, err error) {
+
+	p := jsonpb.Marshaler{}
+
+	if s, err = p.MarshalToString(u); err != nil {
+		return "", err
+	}
+
+	return s, nil
+}
+
+func decode(s string) (*pb.User, error) {
+	u := &pb.User{}
+
+	if err := jsonpb.Unmarshal(strings.NewReader(s), u); err != nil {
+		return nil, err
+	}
+
+	return u, nil
+}
+
+// Create a new user in the store
+//
 func (m *DBUsers) Create(u *pb.User) (int64, error) {
-    m.Mutex.Lock()
-    defer m.Mutex.Unlock()
 
-    key := strings.ToLower(u.Name)
+	rev, err := m.Store.CreateNew(context.Background(), store.KeyRootUsers, u.Name, u)
 
-    if _, ok := m.Users[key]; ok {
-        return InvalidRev, NewErrUserAlreadyCreated(u.Name)
-    }
+	if err != nil {
+		return InvalidRev, err
+	}
 
-    entry := &pb.UserInternal{
-        User:                 &pb.User{
-            Name:                 u.Name,
-            PasswordHash:         u.PasswordHash,
-            UserId:               u.UserId,
-            Enabled:              u.Enabled,
-            CanManageAccounts:    u.CanManageAccounts,
-            NeverDelete:          u.NeverDelete,
-        },
-        Revision:             1,
-    }
-    m.Users[key] = entry
-
-    return 1, nil
+	return rev, nil
 }
 
-// Get the specified user from the store.
-func (m *DBUsers) Get(name string) (*pb.User, int64, error) {
-    m.Mutex.Lock()
-    defer m.Mutex.Unlock()
+// Read the specified user from the store.
+//
+func (m *DBUsers) Read(name string) (*pb.User, int64, error) {
 
-    key := strings.ToLower(name)
+	u := &pb.User{}
 
-    entry, ok := m.Users[key]
-    if !ok {
-        return nil, InvalidRev, NewErrUserNotFound(name)
-    }
+	rev, err := m.Store.ReadNew(context.Background(), store.KeyRootUsers, name, u)
 
-    return entry.User, entry.Revision, nil
+	if err == store.ErrStoreKeyNotFound(name) {
+		return nil, InvalidRev, NewErrUserNotFound(name)
+	}
+
+	if err != nil {
+		return nil, InvalidRev, err
+	}
+
+	return u, rev, nil
 }
 
 // Scan the set of known users in the store, invoking the supplied
 // function with each entry.
 func (m *DBUsers) Scan(action func(entry *pb.User) error) error {
-    m.Mutex.Lock()
-    defer m.Mutex.Unlock()
+	m.Mutex.Lock()
+	defer m.Mutex.Unlock()
 
-    for _, user := range dbUsers.Users {
-        if err := action(user.User); err != nil {
-            return err
-        }
-    }
+	for _, user := range dbUsers.Users {
+		if err := action(user.User); err != nil {
+			return err
+		}
+	}
 
-    return nil
+	return nil
 }
 
 // Update an existing user entry, iff the current revision is the same as the
 // expected (match) revision
+//
+// NOTE: Currently, this uses a *VERY* clumsy read/modify/write action. What is
+//       really needed here is to provide the ability to feed anaction into the
+//       Update() routine itself to allow the caller to selectively update
+//       individual fields from within the transaction.
+//
 func (m *DBUsers) Update(u *pb.User, match int64) (int64, error) {
-    m.Mutex.Lock()
-    defer m.Mutex.Unlock()
 
-    key := strings.ToLower(u.Name)
+	old := &pb.User{}
 
-    old, ok := m.Users[key]
-    if !ok {
-        return InvalidRev, NewErrUserNotFound(u.Name)
-    }
+	//    rev, err := m.Store.ReadNewWithRevision(context.Background(), store.KeyRootUsers, key, old, match)
+	rev, err := m.Store.ReadNew(context.Background(), store.KeyRootUsers, u.Name, old)
 
-    if old.Revision != match {
-        return InvalidRev, NewErrUserStaleVersion(u.Name)
-    }
+	if err == store.ErrStoreKeyNotFound(u.Name) {
+		return InvalidRev, NewErrUserNotFound(u.Name)
+	}
 
-    // Update the entry, retaining the fields from the old version that are
-    // immutable
-    entry := &pb.UserInternal{
-        User:                 &pb.User{
-            Name:                 old.User.Name,
-            PasswordHash:         u.PasswordHash,
-            UserId:               old.User.UserId,
-            Enabled:              u.Enabled,
-            CanManageAccounts:    u.CanManageAccounts,
-            NeverDelete:          old.User.NeverDelete,
-        },
-        Revision:             match + 1,
-    }
-    m.Users[key] = entry
+	if err != nil {
+		return InvalidRev, err
+	}
 
-    return entry.Revision, nil
+	if rev != match {
+		return InvalidRev, NewErrUserStaleVersion(u.Name)
+	}
+
+	// Update the entry, retaining the fields from the old version that are
+	// immutable
+	//
+	user := &pb.User{
+		Name:              old.GetName(),
+		PasswordHash:      u.GetPasswordHash(),
+		UserId:            old.GetUserId(),
+		Enabled:           u.GetEnabled(),
+		CanManageAccounts: u.GetCanManageAccounts(),
+		NeverDelete:       old.GetNeverDelete(),
+	}
+
+	rev, err = m.Store.UpdateNew(context.Background(), store.KeyRootUsers, u.Name, match, user)
+
+	if err != nil {
+		return InvalidRev, err
+	}
+
+	return rev, nil
 }
 
-func (m *DBUsers) Remove(name string) error {
-    m.Mutex.Lock()
-    defer m.Mutex.Unlock()
+// Delete the entry
+//
+func (m *DBUsers) Delete(name string, match int64) error {
 
-    key := strings.ToLower(name)
+	n := store.GetNormalizedName(name)
 
-    old, ok := m.Users[key]
-    if !ok {
-        return NewErrUserNotFound(name)
-    }
+	old := &pb.User{}
 
-    if !old.User.NeverDelete {
-        delete(m.Users, key)
-        return nil
-    }
+	rev, err := m.Store.ReadNew(context.Background(), store.KeyRootUsers, n, old)
 
-    return NewErrUserProtected(name)
+	if err == store.ErrStoreKeyNotFound(n) {
+		return NewErrUserNotFound(name)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if old.GetNeverDelete() {
+		return NewErrUserProtected(name)
+	}
+
+	if InvalidRev == match {
+
+		// Requested an unconditional delete, at least as far as
+		// the revision is concerned
+		//
+		rev = store.RevisionInvalid
+
+	} else if rev != match {
+
+		// Revision matters, so if it does not match then report
+		// the problem
+		//
+		return NewErrUserStaleVersion(name)
+	}
+
+	_, err = m.Store.DeleteNew(context.Background(), store.KeyRootUsers, n, rev)
+
+	if err == store.ErrStoreKeyNotFound(n) {
+		return NewErrUserNotFound(name)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/services/frontend/common_test.go
+++ b/internal/services/frontend/common_test.go
@@ -120,7 +120,8 @@ func commonSetup() {
 				Port:     config.StoreDefaultEtcdSvcPort,
 			},
 			Test: config.StoreTypeTest{
-				UseUniqueInstance: config.StoreDefaultTestUseUniqueInstance,
+				UseTestNamespace:  true,
+				UseUniqueInstance: false,
 				PreCleanStore:     true,
 			},
 		},

--- a/internal/services/frontend/common_test.go
+++ b/internal/services/frontend/common_test.go
@@ -5,35 +5,35 @@
 package frontend
 
 import (
-    "bufio"
-    "bytes"
-    "context"
-    "fmt"
-    "io"
-    "io/ioutil"
-    "log"
-    "math/rand"
-    "net"
-    "net/http"
-    "net/http/httptest"
-    "os"
-    "strings"
-    "testing"
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
 
-    "github.com/golang/protobuf/jsonpb"
-    "github.com/golang/protobuf/proto"
-    "github.com/stretchr/testify/assert"
-    "google.golang.org/grpc"
-    "google.golang.org/grpc/test/bufconn"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
 
-    ts "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
-    "github.com/Jim3Things/CloudChamber/internal/config"
-    stepper "github.com/Jim3Things/CloudChamber/internal/services/stepper_actor"
-    ctrc "github.com/Jim3Things/CloudChamber/internal/tracing/client"
-    "github.com/Jim3Things/CloudChamber/internal/tracing/exporters"
-    strc "github.com/Jim3Things/CloudChamber/internal/tracing/server"
-    "github.com/Jim3Things/CloudChamber/internal/tracing/setup"
-    pb "github.com/Jim3Things/CloudChamber/pkg/protos/Stepper"
+	ts "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
+	"github.com/Jim3Things/CloudChamber/internal/config"
+	stepper "github.com/Jim3Things/CloudChamber/internal/services/stepper_actor"
+	ctrc "github.com/Jim3Things/CloudChamber/internal/tracing/client"
+	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters"
+	strc "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+	"github.com/Jim3Things/CloudChamber/internal/tracing/setup"
+	pb "github.com/Jim3Things/CloudChamber/pkg/protos/Stepper"
 )
 
 // The constants and global variables here are limited to items that needed by
@@ -42,132 +42,144 @@ import (
 // file should redefine the values set here.
 
 const (
-    adminAccountName = "Admin"
-    adminPassword = "AdminPassword"
-    bufSize = 1024 * 1024
+	adminAccountName = "Admin"
+	adminPassword    = "AdminPassword"
+	bufSize          = 1024 * 1024
 )
 
 var (
-    baseURI     string
-    initialized bool
-    lis *bufconn.Listener
+	baseURI     string
+	initialized bool
+	lis         *bufconn.Listener
 )
-
 
 // Common test startup method.  This is the _only_ Test* function in this
 // file.
 func TestMain(m *testing.M) {
-    commonSetup()
+	commonSetup()
 
-    os.Exit(m.Run())
+	os.Exit(m.Run())
 }
 
 // Establish the test environment, including starting a test frontend service
 // over a faked http connection.
 func commonSetup() {
-    if initialized {
-        log.Fatalf("Error initializing service for second or subsequent time")
-    }
+	if initialized {
+		log.Fatalf("Error initializing service for second or subsequent time")
+	}
 
-    setup.Init(exporters.UnitTest)
+	setup.Init(exporters.UnitTest)
 
-    // Set up the internal test deployment of the stepper service, in order to
-    // support the stepper frontend unit tests
-    lis = bufconn.Listen(bufSize)
-    s := grpc.NewServer(grpc.UnaryInterceptor(strc.Interceptor))
+	// Set up the internal test deployment of the stepper service, in order to
+	// support the stepper frontend unit tests
+	lis = bufconn.Listen(bufSize)
+	s := grpc.NewServer(grpc.UnaryInterceptor(strc.Interceptor))
 
-    if err := stepper.Register(s, pb.StepperPolicy_Manual); err != nil {
-        log.Fatalf("Failed to register stepper actor: %v", err)
-    }
+	if err := stepper.Register(s, pb.StepperPolicy_Manual); err != nil {
+		log.Fatalf("Failed to register stepper actor: %v", err)
+	}
 
-    go func() {
-        if err := s.Serve(lis); err != nil {
-            log.Fatalf("Server exited with error: %v", err)
-        }
-    }()
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			log.Fatalf("Server exited with error: %v", err)
+		}
+	}()
 
-    ts.InitTimestamp("bufnet",
-        grpc.WithContextDialer(bufDialer),
-        grpc.WithInsecure(),
-        grpc.WithUnaryInterceptor(ctrc.Interceptor))
+	ts.InitTimestamp("bufnet",
+		grpc.WithContextDialer(bufDialer),
+		grpc.WithInsecure(),
+		grpc.WithUnaryInterceptor(ctrc.Interceptor))
 
-    // Finally, start the test web service, which all tests will use
-    if err := initService(&config.GlobalConfig{
-        Controller: config.ControllerType{},
-        Inventory:  config.InventoryType{},
-        SimSupport: config.SimSupportType{
-            EP: config.Endpoint{
-                Hostname: "localhost",
-                Port:     8083,
-            },
-            StepperPolicy: "manual",
-        },
-        WebServer: config.WebServerType{
-            RootFilePath:          "C:\\CloudChamber",
-            SystemAccount:         adminAccountName,
-            SystemAccountPassword: adminPassword,
-            FE: config.Endpoint{
-                Hostname: "localhost",
-                Port:     8080,
-            },
-            BE: config.Endpoint{},
-        },
-    }); err != nil {
-        log.Fatalf("Error initializing service: %v", err)
-    }
+	// Finally, start the test web service, which all tests will use
+	if err := initService(&config.GlobalConfig{
+		Controller: config.ControllerType{},
+		Inventory:  config.InventoryType{},
+		SimSupport: config.SimSupportType{
+			EP: config.Endpoint{
+				Hostname: "localhost",
+				Port:     8083,
+			},
+			StepperPolicy: "manual",
+		},
+		WebServer: config.WebServerType{
+			RootFilePath:          "C:\\CloudChamber",
+			SystemAccount:         adminAccountName,
+			SystemAccountPassword: adminPassword,
+			FE: config.Endpoint{
+				Hostname: "localhost",
+				Port:     8080,
+			},
+			BE: config.Endpoint{},
+		},
+		Store: config.StoreType{
+			ConnectTimeout: config.StoreDefaultConnectTimeout,
+			RequestTimeout: config.StoreDefaultRequestTimeout,
+			TraceLevel:     config.StoreDefaultTraceLevel,
+			EtcdService: config.Endpoint{
+				Hostname: config.StoreDefaultEtcdSvcHostname,
+				Port:     config.StoreDefaultEtcdSvcPort,
+			},
+			Test: config.StoreTypeTest{
+				UseUniqueInstance: config.StoreDefaultTestUseUniqueInstance,
+				PreCleanStore:     true,
+			},
+		},
+	}); err != nil {
+		log.Fatalf("Error initializing service: %v", err)
+	}
 
-    baseURI = fmt.Sprintf("http://localhost:%d", server.port)
+	baseURI = fmt.Sprintf("http://localhost:%d", server.port)
 
-    initialized = true
+	initialized = true
 }
 
 // +++ Helper functions
 
 // Simple dialer for the test in-memory message grpc transport
 func bufDialer(_ context.Context, _ string) (net.Conn, error) {
-    return lis.Dial()
+	return lis.Dial()
 }
 
 // Convert a proto message into a reader with json-formatted contents
 func toJsonReader(v proto.Message) (io.Reader, error) {
-    var buf bytes.Buffer
-    w := bufio.NewWriter(&buf)
-    p := jsonpb.Marshaler{}
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+	p := jsonpb.Marshaler{}
 
-    if err := p.Marshal(w, v); err != nil {
-        return nil, err
-    }
+	if err := p.Marshal(w, v); err != nil {
+		return nil, err
+	}
 
-    if err := w.Flush(); err != nil {
-        return nil, err
-    }
+	if err := w.Flush(); err != nil {
+		return nil, err
+	}
 
-    return bufio.NewReader(&buf), nil
+	return bufio.NewReader(&buf), nil
 }
 
 // Execute an http request/response sequence
 func doHTTP(req *http.Request, cookies []*http.Cookie) *http.Response {
-    for _, c := range cookies {
-        req.AddCookie(c)
-    }
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
 
-    w := httptest.NewRecorder()
+	w := httptest.NewRecorder()
 
-    server.handler.ServeHTTP(w, req)
+	server.handler.ServeHTTP(w, req)
 
-    return w.Result()
+	return w.Result()
 }
 
 // Get the body of a response, and close it
 func getBody(resp *http.Response) ([]byte, error) {
-    defer func() { _ = resp.Body.Close() }()
-    return ioutil.ReadAll(resp.Body)
+	defer func() { _ = resp.Body.Close() }()
+	return ioutil.ReadAll(resp.Body)
 }
 
 // Get the body of a response, unmarshaled into the supplied message structure
 func getJsonBody(resp *http.Response, v proto.Message) error {
-    defer func() { _ = resp.Body.Close() }()
-    return jsonpb.Unmarshal(resp.Body, v)
+	defer func() { _ = resp.Body.Close() }()
+	return jsonpb.Unmarshal(resp.Body, v)
 }
 
 // Take a string and randomly return
@@ -177,47 +189,47 @@ func getJsonBody(resp *http.Response, v proto.Message) error {
 //
 // This allows validation that case insensitive string handling is.
 func randomCase(val string) string {
-    switch rand.Intn(3) {
-    case 0:
-        return val
+	switch rand.Intn(3) {
+	case 0:
+		return val
 
-    case 1:
-        return strings.ToUpper(val)
+	case 1:
+		return strings.ToUpper(val)
 
-    default:
-        return strings.ToLower(val)
-    }
+	default:
+		return strings.ToLower(val)
+	}
 }
 
 // --- Helper functions
 
 // Log the specified user into CloudChamber
 func doLogin(t *testing.T, user string, password string, cookies []*http.Cookie) *http.Response {
-    path := fmt.Sprintf("%s%s%s?op=login", baseURI, userURI, user)
-    t.Logf("[login as %q (%q)]", user, path)
+	path := fmt.Sprintf("%s%s%s?op=login", baseURI, userURI, user)
+	t.Logf("[login as %q (%q)]", user, path)
 
-    request := httptest.NewRequest("PUT", path, strings.NewReader(password))
-    response := doHTTP(request, cookies)
-    _, err := getBody(response)
+	request := httptest.NewRequest("PUT", path, strings.NewReader(password))
+	response := doHTTP(request, cookies)
+	_, err := getBody(response)
 
-    assert.Nilf(t, err, "Failed to read body returned from call to handler for route %q: %v", path, err)
-    assert.Equal(t, 1, len(response.Cookies()), "Unexpected number of cookies found")
-    assert.Equal(t, http.StatusOK, response.StatusCode, "Handler returned unexpected error: %v", response.StatusCode)
+	assert.Nilf(t, err, "Failed to read body returned from call to handler for route %q: %v", path, err)
+	assert.Equal(t, 1, len(response.Cookies()), "Unexpected number of cookies found")
+	assert.Equal(t, http.StatusOK, response.StatusCode, "Handler returned unexpected error: %v", response.StatusCode)
 
-    return response
+	return response
 }
 
 // Log the specified user out of CloudChamber
 func doLogout(t *testing.T, user string, cookies []*http.Cookie) *http.Response {
-    path := fmt.Sprintf("%s%s%s?op=logout", baseURI, userURI, user)
-    t.Logf("[logout from %q (%q)]", user, path)
+	path := fmt.Sprintf("%s%s%s?op=logout", baseURI, userURI, user)
+	t.Logf("[logout from %q (%q)]", user, path)
 
-    request := httptest.NewRequest("PUT", path, nil)
-    response := doHTTP(request, cookies)
-    _, err := getBody(response)
+	request := httptest.NewRequest("PUT", path, nil)
+	response := doHTTP(request, cookies)
+	_, err := getBody(response)
 
-    assert.Nilf(t, err, "Failed to read body returned from call to handler for route %v: %v", alice, err)
-    assert.Equal(t, http.StatusOK, response.StatusCode, "Handler returned unexpected error: %v", response.StatusCode)
+	assert.Nilf(t, err, "Failed to read body returned from call to handler for route %v: %v", alice, err)
+	assert.Equal(t, http.StatusOK, response.StatusCode, "Handler returned unexpected error: %v", response.StatusCode)
 
-    return response
+	return response
 }

--- a/internal/services/frontend/errors.go
+++ b/internal/services/frontend/errors.go
@@ -4,12 +4,12 @@
 package frontend
 
 import (
-    "context"
-    "errors"
-    "fmt"
-    "net/http"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
 
-    st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 )
 
 var (
@@ -24,6 +24,11 @@ var (
 	// created at this time
 	//
 	ErrUserUnableToCreate = errors.New("CloudChamber: unable to create a user account at this time")
+
+	// ErrUserAlreadyExists indicates the attempt to create a new user account
+	// failed as that user already exists.
+	//
+	ErrUserAlreadyExists = errors.New("CloudChamber: user account already exists")
 
 	// ErrUserAlreadyLoggedIn indicates that the session is currently logged in
 	// and a new log in cannot be processed
@@ -64,24 +69,24 @@ func (he *HTTPError) Error() string {
 // Note that this returns the original error in case there is later processing
 // to be done with it.
 func httpError(ctx context.Context, w http.ResponseWriter, err error) error {
-    // We're hoping this is an HTTPError form of error, which would have the
-    // preferred HTTP status code included.
-    //
-    // If it isn't, then the error originated in some support or library logic,
-    // rather than the web server's business logic.  In that case we assume a
-    // status code of internal server error as the most likely correct value.
-    he, ok := err.(*HTTPError)
-    if !ok {
-        he = &HTTPError{
-            SC:   http.StatusInternalServerError,
-            Base: err,
-        }
-    }
+	// We're hoping this is an HTTPError form of error, which would have the
+	// preferred HTTP status code included.
+	//
+	// If it isn't, then the error originated in some support or library logic,
+	// rather than the web server's business logic.  In that case we assume a
+	// status code of internal server error as the most likely correct value.
+	he, ok := err.(*HTTPError)
+	if !ok {
+		he = &HTTPError{
+			SC:   http.StatusInternalServerError,
+			Base: err,
+		}
+	}
 
-    _ = st.Errorf(ctx, -1, "http error %v: %s", he.StatusCode(), he.Error())
-    http.Error(w, he.Error(), he.StatusCode())
+	_ = st.Errorf(ctx, -1, "http error %v: %s", he.StatusCode(), he.Error())
+	http.Error(w, he.Error(), he.StatusCode())
 
-    return err
+	return err
 }
 
 // +++ HTTPError specializations
@@ -174,37 +179,37 @@ func NewErrRackNotFound(name string) *HTTPError {
 // ErrInvalidStepperMode indicates that an unrecognized simulated policy mode
 // was requested.
 func NewErrInvalidStepperMode(mode string) *HTTPError {
-    return &HTTPError{
-        SC:   http.StatusBadRequest,
-        Base: fmt.Errorf("CloudChamber: mode %q is invalid.  Supported modes are 'manual' and 'automatic'", mode),
-    }
+	return &HTTPError{
+		SC:   http.StatusBadRequest,
+		Base: fmt.Errorf("CloudChamber: mode %q is invalid.  Supported modes are 'manual' and 'automatic'", mode),
+	}
 }
 
 // ErrInvalidRateRequest indicates that the automatic ticks-per-second rate was
 // present, but the selected policy mode was not 'automatic'.
 func NewErrInvalidRateRequest() *HTTPError {
-    return &HTTPError{
-        SC:   http.StatusBadRequest,
-        Base: errors.New("CloudChamber: manual mode does not accept additional arguments"),
-    }
+	return &HTTPError{
+		SC:   http.StatusBadRequest,
+		Base: errors.New("CloudChamber: manual mode does not accept additional arguments"),
+	}
 }
 
 // ErrInvalidStepperRate indicates that the supplied ticks-per-second rate was
 // not recognized as a valid number.
 func NewErrInvalidStepperRate(rate string) *HTTPError {
-    return &HTTPError{
-        SC:   http.StatusBadRequest,
-        Base: fmt.Errorf("CloudChamber: requested rate %q could not be parsed as a positive decimal number", rate),
-    }
+	return &HTTPError{
+		SC:   http.StatusBadRequest,
+		Base: fmt.Errorf("CloudChamber: requested rate %q could not be parsed as a positive decimal number", rate),
+	}
 }
 
 // ErrStepperFailedToSetPolicy indicates that an error occurred while setting
 // the new policy.  This most likely is due to an ETag mismatch.
 func NewErrStepperFailedToSetPolicy() *HTTPError {
-    return &HTTPError{
-        SC:   http.StatusBadRequest,
-        Base: errors.New("CloudChamber: Set simulated time policy operation failed"),
-    }
+	return &HTTPError{
+		SC:   http.StatusBadRequest,
+		Base: errors.New("CloudChamber: Set simulated time policy operation failed"),
+	}
 }
 
 // ErrInvalidStepperRate indicates that the supplied ticks-per-second rate was

--- a/internal/services/frontend/errors.go
+++ b/internal/services/frontend/errors.go
@@ -25,11 +25,6 @@ var (
 	//
 	ErrUserUnableToCreate = errors.New("CloudChamber: unable to create a user account at this time")
 
-	// ErrUserAlreadyExists indicates the attempt to create a new user account
-	// failed as that user already exists.
-	//
-	ErrUserAlreadyExists = errors.New("CloudChamber: user account already exists")
-
 	// ErrUserAlreadyLoggedIn indicates that the session is currently logged in
 	// and a new log in cannot be processed
 	ErrUserAlreadyLoggedIn = errors.New("CloudChamber: session already has a logged in user")
@@ -39,6 +34,55 @@ var (
 	//
 	ErrUserAuthFailed = errors.New("CloudChamber: authentication failed, invalid user name or password")
 )
+
+// ErrUserAlreadyExists indicates the attempt to create a new user account
+// failed as that user already exists.
+//
+type ErrUserAlreadyExists string
+
+func (euae ErrUserAlreadyExists) Error() string {
+	return fmt.Sprintf("CloudChamber: user %q already exists", string(euae))
+}
+
+// ErrUserNotFound indicates the attempt to locate a user account failed as that
+// user does not exist.
+//
+type ErrUserNotFound string
+
+func (eunf ErrUserNotFound) Error() string {
+	return fmt.Sprintf("CloudChamber: user %q not found", string(eunf))
+}
+
+// ErrUserStaleVersion indicates the attempt to locate a user account failed as that
+// user does not exist.
+//
+type ErrUserStaleVersion string
+
+func (eusv ErrUserStaleVersion) Error() string {
+	return fmt.Sprintf("CloudChamber: user %q has a newer version than expected", string(eusv))
+}
+
+// ErrUserProtected indicates the attempt to locate a user account failed as that
+// user does not exist.
+//
+type ErrUserProtected string
+
+func (eup ErrUserProtected) Error() string {
+	return fmt.Sprintf("CloudChamber: user %q is protected and cannot be deleted", string(eup))
+}
+
+// ErrUserBadRecordContent indicates the user record retrieved from the store store
+// has some content that does not match the key. An example might be that the user
+// name used for a key does not match the user name field in the record.
+//
+type ErrUserBadRecordContent struct {
+	name  string
+	value string
+}
+
+func (eubrc ErrUserBadRecordContent) Error() string {
+	return fmt.Sprintf("CloudChamber: discovered record for user %q where the content does not match key %q", eubrc.name, eubrc.value)
+}
 
 // Custom common HTTP error type that includes the status code to use in
 // the response.
@@ -91,7 +135,7 @@ func httpError(ctx context.Context, w http.ResponseWriter, err error) error {
 
 // +++ HTTPError specializations
 
-// ErrNoLoginActive indicates that the specified user is not logged into this session
+// NewErrNoLoginActive indicates that the specified user is not logged into this session
 func NewErrNoLoginActive(name string) *HTTPError {
 	return &HTTPError{
 		SC:   http.StatusBadRequest,
@@ -99,7 +143,7 @@ func NewErrNoLoginActive(name string) *HTTPError {
 	}
 }
 
-// ErrUserNotFound indicates the specified user account was determined to
+// NewErrUserNotFound indicates the specified user account was determined to
 // not exist (i.e. the search succeeded but no record was found)
 //
 func NewErrUserNotFound(name string) *HTTPError {
@@ -109,17 +153,17 @@ func NewErrUserNotFound(name string) *HTTPError {
 	}
 }
 
-// ErrUserAlreadyCreated indicates the specified user account was previously
+// NewErrUserAlreadyExists indicates the specified user account was previously
 // created and the request was determined to be a duplicate Create request.
 //
-func NewErrUserAlreadyCreated(name string) *HTTPError {
+func NewErrUserAlreadyExists(name string) *HTTPError {
 	return &HTTPError{
 		SC:   http.StatusBadRequest,
 		Base: fmt.Errorf("CloudChamber: user %q already exists", name),
 	}
 }
 
-// ErrUserPermissionDenied indicates the user does not have the appropriate
+// NewErrUserPermissionDenied indicates the user does not have the appropriate
 // permissions for the requested operation.
 //
 func NewErrUserPermissionDenied() *HTTPError {
@@ -129,7 +173,7 @@ func NewErrUserPermissionDenied() *HTTPError {
 	}
 }
 
-// ErrUserStaleVersion indicates that an operation against the specified user
+// NewErrUserStaleVersion indicates that an operation against the specified user
 // expected a different revision number than was found
 //
 func NewErrUserStaleVersion(name string) *HTTPError {
@@ -139,7 +183,7 @@ func NewErrUserStaleVersion(name string) *HTTPError {
 	}
 }
 
-// ErrBadMatchType indicates that the If-Match value was syntactically incorrect,
+// NewErrBadMatchType indicates that the If-Match value was syntactically incorrect,
 // and could not be processed
 func NewErrBadMatchType(match string) *HTTPError {
 	return &HTTPError{
@@ -148,7 +192,7 @@ func NewErrBadMatchType(match string) *HTTPError {
 	}
 }
 
-// ErrUserInvalidOperation indicates the operation requested for the supplied
+// NewErrUserInvalidOperation indicates the operation requested for the supplied
 // user account is invalid in some way, likely a non-existent operation code.
 //
 func NewErrUserInvalidOperation(op string) *HTTPError {
@@ -158,7 +202,7 @@ func NewErrUserInvalidOperation(op string) *HTTPError {
 	}
 }
 
-// ErrUserProected indicates that the user entry may not be deleted.
+// NewErrUserProtected indicates that the user entry may not be deleted.
 func NewErrUserProtected(name string) *HTTPError {
 	return &HTTPError{
 		SC:   http.StatusForbidden,
@@ -166,7 +210,7 @@ func NewErrUserProtected(name string) *HTTPError {
 	}
 }
 
-// ErrRackNotFound indicates the specified rack do not exist and the http
+// NewErrRackNotFound indicates the specified rack do not exist and the http
 // request (http.statusNotFound) determines to be the request was made against
 // a non-existing rack.
 func NewErrRackNotFound(name string) *HTTPError {
@@ -176,7 +220,7 @@ func NewErrRackNotFound(name string) *HTTPError {
 	}
 }
 
-// ErrInvalidStepperMode indicates that an unrecognized simulated policy mode
+// NewErrInvalidStepperMode indicates that an unrecognized simulated policy mode
 // was requested.
 func NewErrInvalidStepperMode(mode string) *HTTPError {
 	return &HTTPError{
@@ -185,7 +229,7 @@ func NewErrInvalidStepperMode(mode string) *HTTPError {
 	}
 }
 
-// ErrInvalidRateRequest indicates that the automatic ticks-per-second rate was
+// NewErrInvalidRateRequest indicates that the automatic ticks-per-second rate was
 // present, but the selected policy mode was not 'automatic'.
 func NewErrInvalidRateRequest() *HTTPError {
 	return &HTTPError{
@@ -194,7 +238,7 @@ func NewErrInvalidRateRequest() *HTTPError {
 	}
 }
 
-// ErrInvalidStepperRate indicates that the supplied ticks-per-second rate was
+// NewErrInvalidStepperRate indicates that the supplied ticks-per-second rate was
 // not recognized as a valid number.
 func NewErrInvalidStepperRate(rate string) *HTTPError {
 	return &HTTPError{
@@ -203,7 +247,7 @@ func NewErrInvalidStepperRate(rate string) *HTTPError {
 	}
 }
 
-// ErrStepperFailedToSetPolicy indicates that an error occurred while setting
+// NewErrStepperFailedToSetPolicy indicates that an error occurred while setting
 // the new policy.  This most likely is due to an ETag mismatch.
 func NewErrStepperFailedToSetPolicy() *HTTPError {
 	return &HTTPError{
@@ -212,7 +256,7 @@ func NewErrStepperFailedToSetPolicy() *HTTPError {
 	}
 }
 
-// ErrInvalidStepperRate indicates that the supplied ticks-per-second rate was
+// NewErrInvalidStepperAfter indicates that the supplied ticks-per-second rate was
 // not recognized as a valid number.
 func NewErrInvalidStepperAfter(after string) *HTTPError {
 	return &HTTPError{

--- a/internal/services/frontend/errors.go
+++ b/internal/services/frontend/errors.go
@@ -84,8 +84,8 @@ func (eubrc ErrUserBadRecordContent) Error() string {
 	return fmt.Sprintf("CloudChamber: discovered record for user %q where the content does not match key %q", eubrc.name, eubrc.value)
 }
 
-// Custom common HTTP error type that includes the status code to use in
-// the response.
+// HTTPError is a custom common HTTP error type that includes the status code
+// to use in a response.
 type HTTPError struct {
 	// HTTP status code
 	SC int
@@ -94,6 +94,8 @@ type HTTPError struct {
 	Base error
 }
 
+// StatusCode is used to extract a status from a standard HTTPError
+//
 func (he *HTTPError) StatusCode() int {
 	// We should not need this, but if we're called with no error at all,
 	// then the status should be success...

--- a/internal/services/frontend/frontend.go
+++ b/internal/services/frontend/frontend.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gorilla/sessions"
 	"google.golang.org/grpc"
 
+	"github.com/Jim3Things/CloudChamber/internal/clients/store"
 	ts "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
 	"github.com/Jim3Things/CloudChamber/internal/config"
 	ctrc "github.com/Jim3Things/CloudChamber/internal/tracing/client"
@@ -154,6 +155,10 @@ func initService(cfg *config.GlobalConfig) error {
 	if err := InitDBInventory(); err != nil {
 		return err
 	}
+
+	// Initialize the underlying store
+	//
+	store.Initialize(cfg)
 
 	// Finally, initialize the user store
 	return InitDBUsers(cfg)

--- a/internal/services/frontend/session_manager.go
+++ b/internal/services/frontend/session_manager.go
@@ -2,30 +2,30 @@
 package frontend
 
 import (
-    "context"
-    "fmt"
-    "net/http"
-    "sync"
-    "time"
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
 
-    "github.com/gorilla/sessions"
+	"github.com/gorilla/sessions"
 
-    ts "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
-    st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
-    pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
+	ts "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
+	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+	pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
 )
 
 const (
-    sessionCookieName = "CC-Session"
+	sessionCookieName = "CC-Session"
 
-    sessionIdKey = "session-id"
+	sessionIdKey = "session-id"
 
-    expirationTimeout = time.Duration(1) * time.Hour
+	expirationTimeout = time.Duration(1) * time.Hour
 )
 
 type SessionState struct {
-    name string
-    timeout time.Time
+	name    string
+	timeout time.Time
 }
 
 var mutex = sync.Mutex{}
@@ -42,124 +42,124 @@ var lastId int64 = 0
 // newSession is a function that creates a new login session, so long as
 // one is not currently active
 func newSession(session *sessions.Session, state SessionState) error {
-    mutex.Lock()
-    defer mutex.Unlock()
+	mutex.Lock()
+	defer mutex.Unlock()
 
-    purgeStaleSessions()
+	purgeStaleSessions()
 
-    // Fail if there is already a valid active session
-    if id, ok := session.Values[sessionIdKey].(int64); ok {
-        if _, ok = activeSessions[id]; ok {
-            return ErrUserAlreadyLoggedIn
-        }
-    }
+	// Fail if there is already a valid active session
+	if id, ok := session.Values[sessionIdKey].(int64); ok {
+		if _, ok = activeSessions[id]; ok {
+			return ErrUserAlreadyLoggedIn
+		}
+	}
 
-    // Create the new session
-    lastId++
-    state.timeout = time.Now().Add(expirationTimeout)
+	// Create the new session
+	lastId++
+	state.timeout = time.Now().Add(expirationTimeout)
 
-    activeSessions[lastId] = state
-    timeouts[state.timeout] = lastId
-    session.Values[sessionIdKey] = lastId
+	activeSessions[lastId] = state
+	timeouts[state.timeout] = lastId
+	session.Values[sessionIdKey] = lastId
 
-    return nil
+	return nil
 }
 
 // removeSession is a function to remove the designated session, or
 // silently proceed if there is no active session
 func removeSession(session *sessions.Session) {
-    mutex.Lock()
-    defer mutex.Unlock()
+	mutex.Lock()
+	defer mutex.Unlock()
 
-    purgeStaleSessions()
+	purgeStaleSessions()
 
-    if id, ok := session.Values[sessionIdKey].(int64); ok {
-        if entry, ok := activeSessions[id]; ok {
-            delete(activeSessions, id)
-            delete(timeouts, entry.timeout)
+	if id, ok := session.Values[sessionIdKey].(int64); ok {
+		if entry, ok := activeSessions[id]; ok {
+			delete(activeSessions, id)
+			delete(timeouts, entry.timeout)
 
-            delete(session.Values, sessionIdKey)
-        }
-    }
+			delete(session.Values, sessionIdKey)
+		}
+	}
 }
 
 // getSession is a function that returns the state associated with the current
 // session.  It also returns a true/false flag indicating if the state was
 // found in the active sessions, much like map lookup does.
 func getSession(session *sessions.Session) (SessionState, bool) {
-    mutex.Lock()
-    defer mutex.Unlock()
+	mutex.Lock()
+	defer mutex.Unlock()
 
-    purgeStaleSessions()
+	purgeStaleSessions()
 
-    if id, ok := session.Values[sessionIdKey].(int64); ok {
-        if entry, ok := activeSessions[id]; ok {
-            // Bump timeout to account for the usage of the session
-            delete(timeouts, entry.timeout)
+	if id, ok := session.Values[sessionIdKey].(int64); ok {
+		if entry, ok := activeSessions[id]; ok {
+			// Bump timeout to account for the usage of the session
+			delete(timeouts, entry.timeout)
 
-            entry.timeout = time.Now().Add(expirationTimeout)
-            activeSessions[id] = entry
-            timeouts[entry.timeout] = id
+			entry.timeout = time.Now().Add(expirationTimeout)
+			activeSessions[id] = entry
+			timeouts[entry.timeout] = id
 
-            // .. and return the resulting entry
-            return entry, true
-        } else {
+			// .. and return the resulting entry
+			return entry, true
+		} else {
 
-            // We have a key in the cookie, but that key is invalid, so
-            // delete it.
-            delete(session.Values, sessionIdKey)
-        }
-    }
+			// We have a key in the cookie, but that key is invalid, so
+			// delete it.
+			delete(session.Values, sessionIdKey)
+		}
+	}
 
-    return SessionState{}, false
+	return SessionState{}, false
 }
 
 // purgeStaleSessions removes stale sessions from the active session list.  It
 // assumes that the number of sessions is not so large that the active session
 // list cannot be scanned.
 func purgeStaleSessions() {
-    now := time.Now()
+	now := time.Now()
 
-    for k, v := range timeouts {
-        if k.Before(now) {
-            delete(activeSessions, v)
-            delete(timeouts, k)
-        }
-    }
+	for k, v := range timeouts {
+		if k.Before(now) {
+			delete(activeSessions, v)
+			delete(timeouts, k)
+		}
+	}
 }
 
 // +++ logging helpers
 
 // getActiveSessionCount gets the number of active sessions currently held
 func getActiveSessionCount() int {
-    mutex.Lock()
-    defer mutex.Unlock()
+	mutex.Lock()
+	defer mutex.Unlock()
 
-    return len(activeSessions)
+	return len(activeSessions)
 }
 
 // dumpSessionState returns a string that has the current session's state
 // formatted.  This is intended for use by tracing calls.
 func dumpSessionState(session *sessions.Session) string {
-    stateString := "session state not found"
-    idString := "session ID not found"
+	stateString := "session state not found"
+	idString := "session ID not found"
 
-    if id, ok := session.Values[sessionIdKey].(int64); ok {
-        idString = fmt.Sprintf("ID: %d", id)
-    }
+	if id, ok := session.Values[sessionIdKey].(int64); ok {
+		idString = fmt.Sprintf("ID: %d", id)
+	}
 
-    if state, ok := getSession(session); ok {
-        stateString = fmt.Sprintf(
-            "[Username: %s, expiry: %v",
-            state.name,
-            state.timeout)
-    }
+	if state, ok := getSession(session); ok {
+		stateString = fmt.Sprintf(
+			"[Username: %s, expiry: %v",
+			state.name,
+			state.timeout)
+	}
 
-    return fmt.Sprintf(
-        "Session state: [%s, %s], active session count: %d",
-        idString,
-        stateString,
-        getActiveSessionCount())
+	return fmt.Sprintf(
+		"Session state: [%s, %s], active session count: %d",
+		idString,
+		stateString,
+		getActiveSessionCount())
 }
 
 // --- logging helpers
@@ -167,16 +167,16 @@ func dumpSessionState(session *sessions.Session) string {
 // getLoggedInUser returns the user definition for the current session,
 // or an error, if no user can be found.
 func getLoggedInUser(session *sessions.Session) (*pb.User, error) {
-    entry, ok := getSession(session)
-    if !ok {
-        return nil, &HTTPError{
-            SC:   http.StatusBadRequest,
-            Base: http.ErrNoCookie,
-        }
-    }
+	entry, ok := getSession(session)
+	if !ok {
+		return nil, &HTTPError{
+			SC:   http.StatusBadRequest,
+			Base: http.ErrNoCookie,
+		}
+	}
 
-    user, _, err := dbUsers.Get(entry.name)
-    return user, err
+	user, _, err := dbUsers.Read(entry.name)
+	return user, err
 }
 
 // doSessionHeader wraps a handler action with the necessary code to retrieve any existing session state,
@@ -184,42 +184,42 @@ func getLoggedInUser(session *sessions.Session) (*pb.User, error) {
 //
 // The session object is passed out for reference use by any later body processing.
 func doSessionHeader(
-    ctx context.Context, w http.ResponseWriter, r *http.Request,
-    action func(ctx context.Context, session *sessions.Session) error) error {
+	ctx context.Context, w http.ResponseWriter, r *http.Request,
+	action func(ctx context.Context, session *sessions.Session) error) error {
 
-    session, _ := server.cookieStore.Get(r, sessionCookieName)
+	session, _ := server.cookieStore.Get(r, sessionCookieName)
 
-    err := action(ctx, session)
+	err := action(ctx, session)
 
-    if errx := session.Save(r, w); errx != nil {
-        return &HTTPError{
-            SC:   http.StatusInternalServerError,
-            Base: errx,
-        }
-    }
+	if errx := session.Save(r, w); errx != nil {
+		return &HTTPError{
+			SC:   http.StatusInternalServerError,
+			Base: errx,
+		}
+	}
 
-    return err
+	return err
 }
 
 // ensureEstablishedSession verifies that the session is not new, and triggers
 // an error if it is.
 func ensureEstablishedSession(ctx context.Context, session *sessions.Session) error {
-    if session.IsNew {
-        return st.Errorf(
-            ctx, -1,
-            "Unexpected new session, value=%s", dumpSessionState(session))
-    }
+	if session.IsNew {
+		return st.Errorf(
+			ctx, -1,
+			"Unexpected new session, value=%s", dumpSessionState(session))
+	}
 
-    return nil
+	return nil
 }
 
 // tick provides the current simulated time tick, or '-1' if the simulated time
 // cannot be retrieved (e.g. during startup)
 func tick() int64 {
-    now, err := ts.Now()
-    if err != nil {
-        return -1
-    }
+	now, err := ts.Now()
+	if err != nil {
+		return -1
+	}
 
-    return now.Ticks
+	return now.Ticks
 }

--- a/internal/services/frontend/users.go
+++ b/internal/services/frontend/users.go
@@ -5,33 +5,33 @@
 package frontend
 
 import (
-    "context"
-    "fmt"
-    "io/ioutil"
-    "net/http"
-    "strconv"
-    "strings"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
 
-    "github.com/golang/protobuf/jsonpb"
-    "github.com/gorilla/mux"
-    "github.com/gorilla/sessions"
-    "golang.org/x/crypto/bcrypt"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+	"golang.org/x/crypto/bcrypt"
 
-    "github.com/Jim3Things/CloudChamber/internal/tracing"
-    st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
-    pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
+	"github.com/Jim3Things/CloudChamber/internal/tracing"
+	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+	pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
 )
 
 const (
-    // Value that can never be a valid version number
-    InvalidRev = -1
+	// InvalidRev is a value that can never be a valid version number
+	InvalidRev = -1
 
-    Login = "login"
-    Logout = "logout"
+	Login  = "login"
+	Logout = "logout"
 )
 
 var (
-    dbUsers *DBUsers
+	dbUsers *DBUsers
 )
 
 // +++ Route handling methods
@@ -39,263 +39,262 @@ var (
 // This section contains the route definitions, and the top level handlers for
 // each route.
 
-
 func usersAddRoutes(routeBase *mux.Router) {
 
-    const routeString = "/{username:[a-z,A-Z][a-z,A-Z,0-9]*}"
+	const routeString = "/{username:[a-z,A-Z][a-z,A-Z,0-9]*}"
 
-    routeUsers := routeBase.PathPrefix("/users").Subrouter()
+	routeUsers := routeBase.PathPrefix("/users").Subrouter()
 
-    routeUsers.HandleFunc("", handlerUsersList).Methods("GET")
-    routeUsers.HandleFunc("/", handlerUsersList).Methods("GET")
+	routeUsers.HandleFunc("", handlerUsersList).Methods("GET")
+	routeUsers.HandleFunc("/", handlerUsersList).Methods("GET")
 
-    // As a reminder,
-    //   PUT is idempotent so translates to UPDATE in the CRUD methodology
-    //   POST is NOT idempotent so translates to CREATE in the CRUD methodology
-    //
+	// As a reminder,
+	//   PUT is idempotent so translates to UPDATE in the CRUD methodology
+	//   POST is NOT idempotent so translates to CREATE in the CRUD methodology
+	//
 
-    // Routes for routes with query tags.  Note that this must come before the
-    // route handlers without query tags, as query tags are optional and will
-    // be matched to the first handler encountered with a matching route.
-    routeUsers.HandleFunc(routeString, handlerUsersOperation).Queries("op", "{op}").Methods("PUT")
+	// Routes for routes with query tags.  Note that this must come before the
+	// route handlers without query tags, as query tags are optional and will
+	// be matched to the first handler encountered with a matching route.
+	routeUsers.HandleFunc(routeString, handlerUsersOperation).Queries("op", "{op}").Methods("PUT")
 
-    // Routes for individual user operations
-    routeUsers.HandleFunc(routeString, handlerUsersCreate).Methods("POST")
-    routeUsers.HandleFunc(routeString, handlerUsersRead).Methods("GET")
-    routeUsers.HandleFunc(routeString, handlerUsersUpdate).Methods("PUT")
-    routeUsers.HandleFunc(routeString, handlerUsersDelete).Methods("DELETE")
+	// Routes for individual user operations
+	routeUsers.HandleFunc(routeString, handlerUsersCreate).Methods("POST")
+	routeUsers.HandleFunc(routeString, handlerUsersRead).Methods("GET")
+	routeUsers.HandleFunc(routeString, handlerUsersUpdate).Methods("PUT")
+	routeUsers.HandleFunc(routeString, handlerUsersDelete).Methods("DELETE")
 }
 
 // Process an http request for the list of users.  Response should contain a document of links to the
 // details URI for each known user.
 func handlerUsersList(w http.ResponseWriter, r *http.Request) {
-    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-        err = doSessionHeader(
-            ctx, w, r,
-            func(ctx context.Context, session *sessions.Session) error {
-                return canManageAccounts(session, "")
-            })
+	_ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+		err = doSessionHeader(
+			ctx, w, r,
+			func(ctx context.Context, session *sessions.Session) error {
+				return canManageAccounts(session, "")
+			})
 
-        if err != nil {
-            return httpError(ctx, w, err)
-        }
+		if err != nil {
+			return httpError(ctx, w, err)
+		}
 
-        if _, err := fmt.Fprintln(w, "Users (List)"); err != nil {
-            return httpError(ctx, w, err)
-        }
+		if _, err := fmt.Fprintln(w, "Users (List)"); err != nil {
+			return httpError(ctx, w, err)
+		}
 
-        b := r.URL.String()
-        if !strings.HasSuffix(b, "/") {
-            b += "/"
-        }
+		b := r.URL.String()
+		if !strings.HasSuffix(b, "/") {
+			b += "/"
+		}
 
-        return dbUsers.Scan(func(entry *pb.User) (err error) {
-            target := fmt.Sprintf("%s%s", b, entry.Name)
+		return dbUsers.Scan(func(entry *pb.User) (err error) {
+			target := fmt.Sprintf("%s%s", b, entry.Name)
 
-            st.Infof(ctx, tick(), "   Listing user '%s' at '%s'", entry.Name, target)
+			st.Infof(ctx, tick(), "   Listing user '%s' at '%s'", entry.Name, target)
 
-            if _, err = fmt.Fprintln(w, target); err != nil {
-                return httpError(ctx, w, err)
-            }
+			if _, err = fmt.Fprintln(w, target); err != nil {
+				return httpError(ctx, w, err)
+			}
 
-            return err
-        })
-    })
+			return err
+		})
+	})
 }
 
 func handlerUsersCreate(w http.ResponseWriter, r *http.Request) {
-    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-        vars := mux.Vars(r)
-        username := vars["username"]
+	_ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+		vars := mux.Vars(r)
+		username := vars["username"]
 
-        err = doSessionHeader(
-            ctx, w, r,
-            func(ctx context.Context, session *sessions.Session) error {
-                return canManageAccounts(session, "")
-            })
+		err = doSessionHeader(
+			ctx, w, r,
+			func(ctx context.Context, session *sessions.Session) error {
+				return canManageAccounts(session, "")
+			})
 
-        if err != nil {
-            return httpError(ctx, w, err)
-        }
+		if err != nil {
+			return httpError(ctx, w, err)
+		}
 
-        st.Infof(ctx, tick(), "Creating user %q", username)
+		st.Infof(ctx, tick(), "Creating user %q", username)
 
-        u := &pb.UserDefinition{}
-        if err = jsonpb.Unmarshal(r.Body, u); err != nil {
-            return httpError(ctx, w, &HTTPError{SC: http.StatusBadRequest, Base: err})
-        }
+		u := &pb.UserDefinition{}
+		if err = jsonpb.Unmarshal(r.Body, u); err != nil {
+			return httpError(ctx, w, &HTTPError{SC: http.StatusBadRequest, Base: err})
+		}
 
-        var rev int64
+		var rev int64
 
-        if rev, err = UserAdd(username, u.Password, u.CanManageAccounts, u.Enabled, false); err != nil {
-            return httpError(ctx, w, err)
-        }
+		if rev, err = userAdd(username, u.Password, u.CanManageAccounts, u.Enabled, false); err != nil {
+			return httpError(ctx, w, err)
+		}
 
-        w.Header().Set("ETag", fmt.Sprintf("%v", rev))
+		w.Header().Set("ETag", fmt.Sprintf("%v", rev))
 
-        st.Infof(ctx, tick(), "Created user %q, pwd: <redacted>, enabled: %v, accountManager: %v", username, u.Enabled, u.CanManageAccounts)
-        _, err = fmt.Fprintf(w, "User %q created.  enabled: %v, can manage accounts: %v", username, u.Enabled, u.CanManageAccounts)
-        return err
-    })
+		st.Infof(ctx, tick(), "Created user %q, pwd: <redacted>, enabled: %v, accountManager: %v", username, u.Enabled, u.CanManageAccounts)
+		_, err = fmt.Fprintf(w, "User %q created.  enabled: %v, can manage accounts: %v", username, u.Enabled, u.CanManageAccounts)
+		return err
+	})
 }
 
 func handlerUsersRead(w http.ResponseWriter, r *http.Request) {
-    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-        vars := mux.Vars(r)
-        username := vars["username"]
+	_ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+		vars := mux.Vars(r)
+		username := vars["username"]
 
-        err = doSessionHeader(
-            ctx, w, r,
-            func(ctx context.Context, session *sessions.Session) error {
-                return canManageAccounts(session, username)
-            })
+		err = doSessionHeader(
+			ctx, w, r,
+			func(ctx context.Context, session *sessions.Session) error {
+				return canManageAccounts(session, username)
+			})
 
-        if err != nil {
-            return httpError(ctx, w, err)
-        }
+		if err != nil {
+			return httpError(ctx, w, err)
+		}
 
-        u, rev, err := dbUsers.Get(username)
-        if err != nil {
-            return httpError(ctx, w, err)
-        }
+		u, rev, err := dbUsers.Read(username)
+		if err != nil {
+			return httpError(ctx, w, err)
+		}
 
-        w.Header().Set("Content-Type", "application/json")
-        w.Header().Set("ETag", fmt.Sprintf("%v", rev))
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("ETag", fmt.Sprintf("%v", rev))
 
-        ext := &pb.UserPublic{
-            Enabled:            u.Enabled,
-            CanManageAccounts:  u.CanManageAccounts,
-            NeverDelete:        u.NeverDelete,
-        }
+		ext := &pb.UserPublic{
+			Enabled:           u.Enabled,
+			CanManageAccounts: u.CanManageAccounts,
+			NeverDelete:       u.NeverDelete,
+		}
 
-        st.Infof(ctx, tick(), "Returning details for user %q: %v", username, u)
+		st.Infof(ctx, tick(), "Returning details for user %q: %v", username, u)
 
-        // Get the user entry, and serialize it to json
-        // (export userPublic to json and return that as the body)
-        p := jsonpb.Marshaler{}
-        return p.Marshal(w, ext)
-    })
+		// Get the user entry, and serialize it to json
+		// (export userPublic to json and return that as the body)
+		p := jsonpb.Marshaler{}
+		return p.Marshal(w, ext)
+	})
 }
 
 // Update the user entry
 func handlerUsersUpdate(w http.ResponseWriter, r *http.Request) {
-    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-        vars := mux.Vars(r)
-        username := vars["username"]
+	_ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+		vars := mux.Vars(r)
+		username := vars["username"]
 
-        err = doSessionHeader(
-            ctx, w, r,
-            func(ctx context.Context, session *sessions.Session) error {
-                return canManageAccounts(session, username)
-            })
+		err = doSessionHeader(
+			ctx, w, r,
+			func(ctx context.Context, session *sessions.Session) error {
+				return canManageAccounts(session, username)
+			})
 
-        if err != nil {
-            return httpError(ctx, w, err)
-        }
+		if err != nil {
+			return httpError(ctx, w, err)
+		}
 
-        // All updates are qualified by an ETag match.  The ETag comes from the database
-        // revision number.  So, first we get the 'if-match' tag to determine the revision
-        // that must be current for the update to proceed.
+		// All updates are qualified by an ETag match.  The ETag comes from the database
+		// revision number.  So, first we get the 'if-match' tag to determine the revision
+		// that must be current for the update to proceed.
 
-        var match int64
+		var match int64
 
-        matchString := r.Header.Get("If-Match")
-        match, err = strconv.ParseInt(matchString, 10, 64)
-        if err != nil {
-            return httpError(ctx, w, NewErrBadMatchType(matchString))
-        }
+		matchString := r.Header.Get("If-Match")
+		match, err = strconv.ParseInt(matchString, 10, 64)
+		if err != nil {
+			return httpError(ctx, w, NewErrBadMatchType(matchString))
+		}
 
-        // Next, get the new definition values, and make sure that they are valid.
-        upd := &pb.UserDefinition{}
-        if err = jsonpb.Unmarshal(r.Body, upd); err != nil {
-            return httpError(ctx, w, &HTTPError{SC: http.StatusBadRequest, Base: err})
-        }
+		// Next, get the new definition values, and make sure that they are valid.
+		upd := &pb.UserDefinition{}
+		if err = jsonpb.Unmarshal(r.Body, upd); err != nil {
+			return httpError(ctx, w, &HTTPError{SC: http.StatusBadRequest, Base: err})
+		}
 
-        // All the prep is done.  Proceed with the update.  This may get a version
-        // mismatch, or the user may have been deleted.  Given the check above, these
-        // can all be considered version conflicts.
-        var rev int64
-        if rev, err = userUpdate(username, upd.Password, upd.CanManageAccounts, upd.Enabled, match); err != nil {
-            return httpError(ctx, w, err)
-        }
+		// All the prep is done.  Proceed with the update.  This may get a version
+		// mismatch, or the user may have been deleted.  Given the check above, these
+		// can all be considered version conflicts.
+		var rev int64
+		if rev, err = userUpdate(username, upd.Password, upd.CanManageAccounts, upd.Enabled, match); err != nil {
+			return httpError(ctx, w, err)
+		}
 
-        w.Header().Set("Content-Type", "application/json")
-        w.Header().Set("ETag", fmt.Sprintf("%v", rev))
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("ETag", fmt.Sprintf("%v", rev))
 
-        ext := &pb.UserPublic{
-            Enabled:            upd.Enabled,
-            CanManageAccounts:  upd.CanManageAccounts,
-        }
+		ext := &pb.UserPublic{
+			Enabled:           upd.Enabled,
+			CanManageAccounts: upd.CanManageAccounts,
+		}
 
-        st.Infof(ctx, tick(), "Returning details for user %q: %v", username, upd)
+		st.Infof(ctx, tick(), "Returning details for user %q: %v", username, upd)
 
-        p := jsonpb.Marshaler{}
-        return p.Marshal(w, ext)
-    })
+		p := jsonpb.Marshaler{}
+		return p.Marshal(w, ext)
+	})
 }
 
 // Delete the user entry
 func handlerUsersDelete(w http.ResponseWriter, r *http.Request) {
-    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-        vars := mux.Vars(r)
-        username := vars["username"]
+	_ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+		vars := mux.Vars(r)
+		username := vars["username"]
 
-        err = doSessionHeader(
-            ctx, w, r,
-            func(ctx context.Context, session *sessions.Session) error {
-                return canManageAccounts(session, username)
-            })
+		err = doSessionHeader(
+			ctx, w, r,
+			func(ctx context.Context, session *sessions.Session) error {
+				return canManageAccounts(session, username)
+			})
 
-        if err != nil {
-            return httpError(ctx, w, err)
-        }
+		if err != nil {
+			return httpError(ctx, w, err)
+		}
 
-        if err = userRemove(username); err != nil {
-            return httpError(ctx, w, err)
-        }
+		if err = userRemove(username); err != nil {
+			return httpError(ctx, w, err)
+		}
 
-        _, err = fmt.Fprintf(w, "User %q deleted.", username)
-        return err
-    })
+		_, err = fmt.Fprintf(w, "User %q deleted.", username)
+		return err
+	})
 }
 
 // Perform an admin operation (login, logout, enable, disable) on an account
 func handlerUsersOperation(w http.ResponseWriter, r *http.Request) {
-    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-        var s string
+	_ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+		var s string
 
-        err = doSessionHeader(ctx, w, r, func(ctx context.Context, session *sessions.Session) (err error) {
-            op := r.FormValue("op")
-            vars := mux.Vars(r)
-            username := vars["username"]
+		err = doSessionHeader(ctx, w, r, func(ctx context.Context, session *sessions.Session) (err error) {
+			op := r.FormValue("op")
+			vars := mux.Vars(r)
+			username := vars["username"]
 
-            st.Infof(ctx, tick(), "Operation %q, user %q, session %v", op, username, session)
+			st.Infof(ctx, tick(), "Operation %q, user %q, session %v", op, username, session)
 
-            switch op {
-            case Login:
-                s, err = login(session, r)
+			switch op {
+			case Login:
+				s, err = login(session, r)
 
-            case Logout:
-                s, err = logout(session, r)
+			case Logout:
+				s, err = logout(session, r)
 
-            default:
-                err = NewErrUserInvalidOperation(op)
-            }
+			default:
+				err = NewErrUserInvalidOperation(op)
+			}
 
-            if err != nil {
-                _ = st.Error(ctx, tick(), dumpSessionState(session))
-            }
-            return err
-        })
+			if err != nil {
+				_ = st.Error(ctx, tick(), dumpSessionState(session))
+			}
+			return err
+		})
 
-        if err != nil {
-            return httpError(ctx, w, err)
-        }
+		if err != nil {
+			return httpError(ctx, w, err)
+		}
 
-        _, err = fmt.Fprintln(w, s)
+		_, err = fmt.Fprintln(w, s)
 
-        return err
-    })
+		return err
+	})
 }
 
 // --- Route handling methods
@@ -309,75 +308,75 @@ func handlerUsersOperation(w http.ResponseWriter, r *http.Request) {
 
 // Process a login request (?op=login)
 func login(session *sessions.Session, r *http.Request) (_ string, err error) {
-    var pwd []byte
+	var pwd []byte
 
-    vars := mux.Vars(r)
-    username := vars["username"]
+	vars := mux.Vars(r)
+	username := vars["username"]
 
-    // Verify that there is no logged in user
-    if _, ok := getSession(session); ok {
-        return "", &HTTPError{
-            SC:   http.StatusBadRequest,
-            Base: ErrUserAlreadyLoggedIn,
-        }
-    }
+	// Verify that there is no logged in user
+	if _, ok := getSession(session); ok {
+		return "", &HTTPError{
+			SC:   http.StatusBadRequest,
+			Base: ErrUserAlreadyLoggedIn,
+		}
+	}
 
-    // We have a session that could support a login.  Let's verify that this
-    // is a good login
+	// We have a session that could support a login.  Let's verify that this
+	// is a good login
 
-    // First, verify that this is an actual user account, and that account is
-    // enabled for login operations.
-    if u, _, err := dbUsers.Get(username); err != nil || !u.Enabled {
-        return "", &HTTPError{
-            SC:   http.StatusNotFound,
-            Base: ErrUserAuthFailed,
-        }
-    }
+	// First, verify that this is an actual user account, and that account is
+	// enabled for login operations.
+	if u, _, err := dbUsers.Read(username); err != nil || !u.Enabled {
+		return "", &HTTPError{
+			SC:   http.StatusNotFound,
+			Base: ErrUserAuthFailed,
+		}
+	}
 
-    // .. next, let's get the password, which is the body of the request
-    if pwd, err = ioutil.ReadAll(r.Body); err != nil {
-        return "", &HTTPError{
-            SC:   http.StatusBadRequest,
-            Base: ErrUserAuthFailed,
-        }
-    }
+	// .. next, let's get the password, which is the body of the request
+	if pwd, err = ioutil.ReadAll(r.Body); err != nil {
+		return "", &HTTPError{
+			SC:   http.StatusBadRequest,
+			Base: ErrUserAuthFailed,
+		}
+	}
 
-    // .. finally, let's confirm that this password matches the one for the
-    // designated user account.
-    if userVerifyPassword(username, pwd) != nil {
-        return "", &HTTPError{
-            SC:   http.StatusForbidden,
-            Base: ErrUserAuthFailed,
-        }
-    }
+	// .. finally, let's confirm that this password matches the one for the
+	// designated user account.
+	if userVerifyPassword(username, pwd) != nil {
+		return "", &HTTPError{
+			SC:   http.StatusForbidden,
+			Base: ErrUserAuthFailed,
+		}
+	}
 
-    // .. all passed.  So finally mark the session as logged in
-    //
-    if err = newSession(session, SessionState{ name: username }); err != nil {
-        return "", &HTTPError{
-            SC:   http.StatusBadRequest,
-            Base: err,
-        }
-    }
+	// .. all passed.  So finally mark the session as logged in
+	//
+	if err = newSession(session, SessionState{name: username}); err != nil {
+		return "", &HTTPError{
+			SC:   http.StatusBadRequest,
+			Base: err,
+		}
+	}
 
-    return fmt.Sprintf("User %q logged in", username), nil
+	return fmt.Sprintf("User %q logged in", username), nil
 }
 
 // Process a logout request (?op=logout)
 func logout(session *sessions.Session, r *http.Request) (_ string, err error) {
-    vars := mux.Vars(r)
-    username := vars["username"]
+	vars := mux.Vars(r)
+	username := vars["username"]
 
-    // Verify that there is a logged in user on this session
-    // .. and that it is the user we're trying to logout
-    if state, ok := getSession(session); !ok  || !strings.EqualFold(state.name, username) {
-        return "", NewErrNoLoginActive(username)
-    }
+	// Verify that there is a logged in user on this session
+	// .. and that it is the user we're trying to logout
+	if state, ok := getSession(session); !ok || !strings.EqualFold(state.name, username) {
+		return "", NewErrNoLoginActive(username)
+	}
 
-    // .. and now log the user out
-    removeSession(session)
+	// .. and now log the user out
+	removeSession(session)
 
-    return fmt.Sprintf("User %q logged out", username), nil
+	return fmt.Sprintf("User %q logged out", username), nil
 }
 
 // --- Query tag implementations
@@ -388,49 +387,49 @@ func logout(session *sessions.Session, r *http.Request) (_ string, err error) {
 // attributes that are understood by the route handlers to the internal user
 // attributes understood by the storage system.
 
-func UserAdd(name string, password string, accountManager bool, enabled bool, neverDelete bool) (int64, error) {
-    passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+func userAdd(name string, password string, accountManager bool, enabled bool, neverDelete bool) (int64, error) {
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 
-    if err != nil {
-        return InvalidRev, err
-    }
+	if err != nil {
+		return InvalidRev, err
+	}
 
-    return dbUsers.Create(&pb.User{
-        Name:               name,
-        PasswordHash:       passwordHash,
-        Enabled:            enabled,
-        CanManageAccounts:  accountManager,
-        NeverDelete:        neverDelete})
+	return dbUsers.Create(&pb.User{
+		Name:              name,
+		PasswordHash:      passwordHash,
+		Enabled:           enabled,
+		CanManageAccounts: accountManager,
+		NeverDelete:       neverDelete})
 }
 
 func userUpdate(name string, password string, accountManager bool, enabled bool, rev int64) (int64, error) {
-    passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 
-    if err != nil {
-        return InvalidRev, err
-    }
+	if err != nil {
+		return InvalidRev, err
+	}
 
-    return dbUsers.Update(&pb.User{
-        Name: name,
-        PasswordHash: passwordHash,
-        Enabled: enabled,
-        CanManageAccounts: accountManager}, rev)
+	return dbUsers.Update(&pb.User{
+		Name:              name,
+		PasswordHash:      passwordHash,
+		Enabled:           enabled,
+		CanManageAccounts: accountManager}, rev)
 }
 
 func userRemove(name string) error {
-    return dbUsers.Remove(name)
+	return dbUsers.Delete(name, InvalidRev)
 }
 
 // TODO: Figure out how to better protect leakage of the password in memory.
 func userVerifyPassword(name string, password []byte) error {
 
-    entry, _, err := dbUsers.Get(name)
+	entry, _, err := dbUsers.Read(name)
 
-    if err != nil {
-        return err
-    }
+	if err != nil {
+		return err
+	}
 
-    return bcrypt.CompareHashAndPassword(entry.PasswordHash, password)
+	return bcrypt.CompareHashAndPassword(entry.PasswordHash, password)
 }
 
 // --- Mid-level support methods
@@ -440,16 +439,16 @@ func userVerifyPassword(name string, password []byte) error {
 // Determine if this session's active login has permission to change or
 // manage the targeted account.  Note that any account may manage itself.
 func canManageAccounts(session *sessions.Session, username string) error {
-    user, err := getLoggedInUser(session)
-    if err != nil {
-        return NewErrUserPermissionDenied()
-    }
+	user, err := getLoggedInUser(session)
+	if err != nil {
+		return NewErrUserPermissionDenied()
+	}
 
-    if !user.CanManageAccounts && !strings.EqualFold(user.Name, username) {
-        return NewErrUserPermissionDenied()
-    }
+	if !user.CanManageAccounts && !strings.EqualFold(user.Name, username) {
+		return NewErrUserPermissionDenied()
+	}
 
-    return nil
+	return nil
 }
 
 // Get the secret associated with this session

--- a/internal/services/frontend/users_test.go
+++ b/internal/services/frontend/users_test.go
@@ -31,15 +31,15 @@ const (
 )
 
 var (
-	aliceDef    = &pb.UserDefinition{
-		Password:       	alicePassword,
-		Enabled:        	true,
-		CanManageAccounts: 	false,
+	aliceDef = &pb.UserDefinition{
+		Password:          alicePassword,
+		Enabled:           true,
+		CanManageAccounts: false,
 	}
 	bobDef = &pb.UserDefinition{
-		Password:       	bobPassword,
-		Enabled:        	true,
-		CanManageAccounts: 	false,
+		Password:          bobPassword,
+		Enabled:           true,
+		CanManageAccounts: false,
 	}
 
 	// The user URLs that have been added and not deleted during the test run.
@@ -507,7 +507,7 @@ func TestUsersList(t *testing.T) {
 
 	// .. and then verify that all following lines correctly consist of all the expected names
 	match := knownNames
-	match[baseURI + admin] = baseURI + admin
+	match[baseURI+admin] = baseURI + admin
 
 	// .. this involves converting the set of keys to an array for matching
 	keys := make([]string, 0, len(match))
@@ -563,7 +563,8 @@ func TestUsersRead(t *testing.T) {
 	assert.Nilf(t, err, "Failed to convert body to valid json.  err: %v", err)
 
 	assert.Equal(t, "application/json", strings.ToLower(response.Header.Get("Content-Type")))
-	assert.Equal(t, "1", response.Header.Get("ETag"))
+	// TODO MCJ - false expectation for E-Tag assert.Equal(t, "1", response.Header.Get("ETag"))
+	assert.Less(t, "1", response.Header.Get("ETag"))
 	assert.True(t, user.Enabled)
 	assert.True(t, user.CanManageAccounts)
 	assert.True(t, user.NeverDelete)
@@ -670,9 +671,9 @@ func TestUsersOperationIllegal(t *testing.T) {
 
 func TestUsersUpdate(t *testing.T) {
 	aliceUpd := &pb.UserDefinition{
-		Password:       	alicePassword,
-		Enabled:        	true,
-		CanManageAccounts: 	true,
+		Password:          alicePassword,
+		Enabled:           true,
+		CanManageAccounts: true,
 	}
 
 	unit_test.SetTesting(t)
@@ -695,7 +696,8 @@ func TestUsersUpdate(t *testing.T) {
 	err = getJsonBody(response, user)
 	assert.Nilf(t, err, "Failed to convert body to valid json.  err: %v", err)
 
-	assert.Equal(t, fmt.Sprintf("%v", rev+1), response.Header.Get("ETag"))
+	// TODO MCJ False assumption on expectation for E-Tag	assert.Equal(t, fmt.Sprintf("%v", rev+1), response.Header.Get("ETag"))
+	assert.Less(t, fmt.Sprintf("%v", rev), response.Header.Get("ETag"))
 	assert.True(t, user.Enabled)
 	assert.True(t, user.CanManageAccounts)
 	assert.False(t, user.NeverDelete)
@@ -738,9 +740,9 @@ func TestUsersUpdateBadData(t *testing.T) {
 
 func TestUsersUpdateBadMatch(t *testing.T) {
 	aliceUpd := &pb.UserDefinition{
-		Password:       	alicePassword,
-		Enabled:        	true,
-		CanManageAccounts: 	true,
+		Password:          alicePassword,
+		Enabled:           true,
+		CanManageAccounts: true,
 	}
 
 	unit_test.SetTesting(t)
@@ -773,9 +775,9 @@ func TestUsersUpdateBadMatch(t *testing.T) {
 
 func TestUsersUpdateBadMatchSyntax(t *testing.T) {
 	aliceUpd := &pb.UserDefinition{
-		Password:       	alicePassword,
-		Enabled:        	true,
-		CanManageAccounts: 	true,
+		Password:          alicePassword,
+		Enabled:           true,
+		CanManageAccounts: true,
 	}
 
 	unit_test.SetTesting(t)
@@ -805,9 +807,9 @@ func TestUsersUpdateBadMatchSyntax(t *testing.T) {
 
 func TestUsersUpdateNoUser(t *testing.T) {
 	upd := &pb.UserDefinition{
-		Password:       	"bogus",
-		Enabled:        	true,
-		CanManageAccounts: 	true,
+		Password:          "bogus",
+		Enabled:           true,
+		CanManageAccounts: true,
 	}
 
 	unit_test.SetTesting(t)
@@ -834,9 +836,9 @@ func TestUsersUpdateNoUser(t *testing.T) {
 
 func TestUsersUpdateNoPriv(t *testing.T) {
 	aliceUpd := &pb.UserDefinition{
-		Password:       	alicePassword,
-		Enabled:        	true,
-		CanManageAccounts: 	true,
+		Password:          alicePassword,
+		Enabled:           true,
+		CanManageAccounts: true,
 	}
 
 	unit_test.SetTesting(t)
@@ -969,4 +971,5 @@ func TestUsersDeleteProtected(t *testing.T) {
 
 	doLogout(t, adminAccountName, response.Cookies())
 }
+
 // --- Delete user tests


### PR DESCRIPTION
This update connects the frontend user db to the backend store to allow the persistence of records across service restarts etc. The dummy in-memory db was also removed and the tests updated to account for the persistence of records across test runs.

The store test namespace with pre-test cleanup was made available to all test cohorts, not just that for the store itself and the frontend tests were configured to use it to avoid interference between separate test runs.

Some issues with fuzzy layering were also fixed to ensure that each layer from users<->dbusers<->storeapi<->store were properly separated 

- user layer deals with http, http handlers, httperrors and userXxxx() routines, converts specific ErrUserXxxXxx to httperror for semantically significant cases.

- dbUsers deals with ErrUserXxxXxx errors, encodes and decodes pb.User structs to/from JSON buffers, and provides a CRUD style set of calls to the users layer, converts some specific ErrStoreXxxXxx to ErrUserXxxXxx errors for reportable situations

- storeapi provides a simplified CRUD style transactional api to the dbUsers layers, does name to/from key conversion, does NO encode/decode of values, returns ErrStoreXxxXxx errors.

- store provides the transactional primitives and interacts directly with the backend etcd store.

A few lint-er complaints were also fixed to reduce clutter in VsCode's "Problems" panel.


All tests run cleanly, even with multiple invocations. End-to-end use with the UI has not yet been verified.