### PR TITLE
Cleanup some store tracing and assorted VsCode lint-er complaints

### DIFF
--- a/internal/services/frontend/DBInventory.go
+++ b/internal/services/frontend/DBInventory.go
@@ -17,7 +17,7 @@ import (
 
 // DBInventory is a container used to establish synchronized access to
 // the in-memory set of Racks records.
-
+//
 type DBInventory struct { //A struct for the collection of Racks
 	Mutex sync.Mutex
 	Racks map[string]*pb.ExternalRack
@@ -25,6 +25,13 @@ type DBInventory struct { //A struct for the collection of Racks
 
 var dbInventory *DBInventory
 
+// InitDBInventory initializes the base state for the inventory.
+//
+// At present the primary state is sufficient data in an in-memory db sufficient
+// for testing purposes. Eventually, this will be removed and the calls will be
+// connected to the store in order to persist the inventory read from an external
+// definition file
+//
 func InitDBInventory() error {
 	if dbInventory == nil {
 		dbInventory = &DBInventory{
@@ -94,6 +101,8 @@ func (m *DBInventory) Scan(action func(entry string) error) error {
 	return nil
 }
 
+// Get returns the rack details to match the supplied rackId
+//
 func (m *DBInventory) Get(rackid string) (*pb.ExternalRack, error) {
 
 	m.Mutex.Lock()
@@ -107,6 +116,10 @@ func (m *DBInventory) Get(rackid string) (*pb.ExternalRack, error) {
 
 }
 
+// ScanBladesInRack enumerates over all the blades in a rack of the
+// given rackId, and invokes the supplied action on each discovered
+// bladeId in turn.
+//
 func (m *DBInventory) ScanBladesInRack(rackid string, action func(bladeid int64) error) error {
 	m.Mutex.Lock()
 	defer m.Mutex.Unlock()
@@ -123,6 +136,9 @@ func (m *DBInventory) ScanBladesInRack(rackid string, action func(bladeid int64)
 	return nil
 }
 
+// GetBlade returns the details of a blade matching the
+// supplied rackId and bladeId
+//
 func (m *DBInventory) GetBlade(rackid string, bladeid int64) (*common.BladeCapacity, error) {
 	m.Mutex.Lock()
 	defer m.Mutex.Unlock()

--- a/internal/services/frontend/common_test.go
+++ b/internal/services/frontend/common_test.go
@@ -142,7 +142,7 @@ func bufDialer(_ context.Context, _ string) (net.Conn, error) {
 }
 
 // Convert a proto message into a reader with json-formatted contents
-func toJsonReader(v proto.Message) (io.Reader, error) {
+func toJSONReader(v proto.Message) (io.Reader, error) {
 	var buf bytes.Buffer
 	w := bufio.NewWriter(&buf)
 	p := jsonpb.Marshaler{}
@@ -178,7 +178,7 @@ func getBody(resp *http.Response) ([]byte, error) {
 }
 
 // Get the body of a response, unmarshaled into the supplied message structure
-func getJsonBody(resp *http.Response, v proto.Message) error {
+func getJSONBody(resp *http.Response, v proto.Message) error {
 	defer func() { _ = resp.Body.Close() }()
 	return jsonpb.Unmarshal(resp.Body, v)
 }

--- a/internal/services/frontend/errors.go
+++ b/internal/services/frontend/errors.go
@@ -222,8 +222,8 @@ func NewErrRackNotFound(name string) *HTTPError {
 	}
 }
 
-//BladeNotFound indicates that the rack was found but no blade was found
-
+// NewErrBladeNotFound indicates that the rack was found but no blade was found
+//
 func NewErrBladeNotFound(rackid string, bladeid int64) *HTTPError {
 	return &HTTPError{
 		SC:   http.StatusNotFound,
@@ -231,7 +231,7 @@ func NewErrBladeNotFound(rackid string, bladeid int64) *HTTPError {
 	}
 }
 
-// ErrInvalidStepperMode indicates that an unrecognized simulated policy mode
+// NewErrInvalidStepperMode indicates that an unrecognized simulated policy mode
 // was requested.
 func NewErrInvalidStepperMode(mode string) *HTTPError {
 	return &HTTPError{

--- a/internal/services/frontend/inventory_test.go
+++ b/internal/services/frontend/inventory_test.go
@@ -52,7 +52,7 @@ func TestInventoryRackRead(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.StatusCode, "Handler returned unexpected error: %v", response.StatusCode)
 
 	rack := &pb.ExternalRack{}
-	err := getJsonBody(response, rack)
+	err := getJSONBody(response, rack)
 	assert.Nilf(t, err, "Failed to convert body to valid json.  err: %v", err)
 
 	assert.Equal(t, "application/json", strings.ToLower(response.Header.Get("Content-Type")))
@@ -157,7 +157,7 @@ func TestInventoryBladeRead(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.StatusCode, "Handler returned the Blade: %v", response.StatusCode)
 
 	blade := &common.BladeCapacity{}
-	err := getJsonBody(response, blade)
+	err := getJSONBody(response, blade)
 	assert.Nilf(t, err, "Failed to convert body to valid json.  err: %v", err)
 
 	assert.Equal(t, "application/json", strings.ToLower(response.Header.Get("Content-Type")))
@@ -180,7 +180,7 @@ func TestInventoryBlade2Read(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.StatusCode, "Handler returned the Blade: %v", response.StatusCode)
 
 	blade := &common.BladeCapacity{}
-	err := getJsonBody(response, blade)
+	err := getJSONBody(response, blade)
 	assert.Nilf(t, err, "Failed to convert body to valid json.  err: %v", err)
 
 	assert.Equal(t, "application/json", strings.ToLower(response.Header.Get("Content-Type")))

--- a/internal/services/frontend/stepper_test.go
+++ b/internal/services/frontend/stepper_test.go
@@ -1,371 +1,371 @@
 package frontend
 
 import (
-    "fmt"
-    "net/http"
-    "net/http/httptest"
-    "testing"
-    "time"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
 
-    "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 
-    ts "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
-    "github.com/Jim3Things/CloudChamber/internal/tracing/exporters/unit_test"
-    pb "github.com/Jim3Things/CloudChamber/pkg/protos/Stepper"
-    "github.com/Jim3Things/CloudChamber/pkg/protos/common"
+	ts "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
+	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters/unit_test"
+	pb "github.com/Jim3Things/CloudChamber/pkg/protos/Stepper"
+	"github.com/Jim3Things/CloudChamber/pkg/protos/common"
 )
 
 const (
-	stepperURI    = "/api/stepper"
+	stepperURI = "/api/stepper"
 )
 
 func testStepperPath() string { return baseURI + stepperURI }
 
 func testStepperReset(t *testing.T) {
-    err := ts.Reset()
-    assert.Nilf(t, err, "Unexpected error when resetting the stepper service)")
+	err := ts.Reset()
+	assert.Nilf(t, err, "Unexpected error when resetting the stepper service)")
 }
 
 func testStepperSetManual(t *testing.T, match int64, cookies []*http.Cookie) []*http.Cookie {
-    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?mode=manual"), nil)
-    request.Header.Set("If-Match", fmt.Sprintf("%v", match))
+	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?mode=manual"), nil)
+	request.Header.Set("If-Match", fmt.Sprintf("%v", match))
 
-    response := doHTTP(request, cookies)
+	response := doHTTP(request, cookies)
 
-    assert.Equal(t, http.StatusOK, response.StatusCode)
-    assert.Equal(t, fmt.Sprintf("%v", match + 1), response.Header.Get("ETag"))
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, fmt.Sprintf("%v", match+1), response.Header.Get("ETag"))
 
-    return response.Cookies()
+	return response.Cookies()
 }
 
 func testStepperGetNow(t *testing.T, cookies []*http.Cookie) (*common.Timestamp, []*http.Cookie) {
-    request := httptest.NewRequest("GET", fmt.Sprintf("%s%s", testStepperPath(), "/now"), nil)
-    response := doHTTP(request, cookies)
+	request := httptest.NewRequest("GET", fmt.Sprintf("%s%s", testStepperPath(), "/now"), nil)
+	response := doHTTP(request, cookies)
 
-    assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
 
-    res := &common.Timestamp{}
-    err := getJsonBody(response, res)
+	res := &common.Timestamp{}
+	err := getJSONBody(response, res)
 
-    assert.Nilf(t, err, "Unexpected error, err: %v", err)
+	assert.Nilf(t, err, "Unexpected error, err: %v", err)
 
-    return res, response.Cookies()
+	return res, response.Cookies()
 }
 
 func testStepperGetStatus(t *testing.T, cookies []*http.Cookie) (*pb.StatusResponse, []*http.Cookie) {
-    request := httptest.NewRequest("GET", testStepperPath(), nil)
-    response := doHTTP(request, cookies)
+	request := httptest.NewRequest("GET", testStepperPath(), nil)
+	response := doHTTP(request, cookies)
 
-    assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
 
-    res := &pb.StatusResponse{}
-    err := getJsonBody(response, res)
+	res := &pb.StatusResponse{}
+	err := getJSONBody(response, res)
 
-    assert.Nilf(t, err, "Unexpected error, err: %v", err)
+	assert.Nilf(t, err, "Unexpected error, err: %v", err)
 
-    return res, response.Cookies()
+	return res, response.Cookies()
 }
 
 func testStepperAdvance(t *testing.T, cookies []*http.Cookie) (*common.Timestamp, []*http.Cookie) {
-    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?advance"), nil)
-    response := doHTTP(request, cookies)
-    assert.Equal(t, http.StatusOK, response.StatusCode)
+	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?advance"), nil)
+	response := doHTTP(request, cookies)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
 
-    res := &common.Timestamp{}
-    err := getJsonBody(response, res)
+	res := &common.Timestamp{}
+	err := getJSONBody(response, res)
 
-    assert.Nilf(t, err, "Unexpected error, err: %v", err)
+	assert.Nilf(t, err, "Unexpected error, err: %v", err)
 
-    return res, response.Cookies()
+	return res, response.Cookies()
 }
 
-func testStepperAfter(t *testing.T, after int64, cookies []*http.Cookie) (*common.Timestamp, []*http.Cookie)  {
-    request := httptest.NewRequest("GET", fmt.Sprintf("%s/now?after=%d", testStepperPath(), after), nil)
-    response := doHTTP(request, cookies)
+func testStepperAfter(t *testing.T, after int64, cookies []*http.Cookie) (*common.Timestamp, []*http.Cookie) {
+	request := httptest.NewRequest("GET", fmt.Sprintf("%s/now?after=%d", testStepperPath(), after), nil)
+	response := doHTTP(request, cookies)
 
-    assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
 
-    res := &common.Timestamp{}
-    err := getJsonBody(response, res)
+	res := &common.Timestamp{}
+	err := getJSONBody(response, res)
 
-    assert.Nilf(t, err, "Unexpected error, err: %v", err)
+	assert.Nilf(t, err, "Unexpected error, err: %v", err)
 
-    return res, response.Cookies()
+	return res, response.Cookies()
 }
 
 func TestStepperGetStatus(t *testing.T) {
-    unit_test.SetTesting(t)
-    defer unit_test.SetTesting(nil)
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
-    response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-    res, cookies := testStepperGetStatus(t, response.Cookies())
-    t.Log(res)
+	res, cookies := testStepperGetStatus(t, response.Cookies())
+	t.Log(res)
 
-    doLogout(t, randomCase(adminAccountName), cookies)
+	doLogout(t, randomCase(adminAccountName), cookies)
 }
 
 func TestStepperSetManual(t *testing.T) {
-    unit_test.SetTesting(t)
-    defer unit_test.SetTesting(nil)
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
-    testStepperReset(t)
-    response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+	testStepperReset(t)
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-    stat, cookies := testStepperGetStatus(t, response.Cookies())
-    cookies = testStepperSetManual(t, stat.Epoch, cookies)
+	stat, cookies := testStepperGetStatus(t, response.Cookies())
+	cookies = testStepperSetManual(t, stat.Epoch, cookies)
 
-    res, cookies := testStepperGetStatus(t, cookies)
-    assert.Equal(t, pb.StepperPolicy_Manual, res.Policy, "Unexpected policy")
-    assert.Equal(t, int64(0), res.MeasuredDelay.Seconds, "Unexpected delay")
-    assert.Equal(t, int32(0), res.MeasuredDelay.Nanos, "Unexpected delay")
-    assert.Equal(t, int64(0), res.Now.Ticks, "Unexpected current time")
-    assert.Equal(t, int64(0), res.WaiterCount, "Unexpected active waiter count")
-    assert.Equal(t, stat.Epoch + 1, res.Epoch, "Unexpected epoch value")
+	res, cookies := testStepperGetStatus(t, cookies)
+	assert.Equal(t, pb.StepperPolicy_Manual, res.Policy, "Unexpected policy")
+	assert.Equal(t, int64(0), res.MeasuredDelay.Seconds, "Unexpected delay")
+	assert.Equal(t, int32(0), res.MeasuredDelay.Nanos, "Unexpected delay")
+	assert.Equal(t, int64(0), res.Now.Ticks, "Unexpected current time")
+	assert.Equal(t, int64(0), res.WaiterCount, "Unexpected active waiter count")
+	assert.Equal(t, stat.Epoch+1, res.Epoch, "Unexpected epoch value")
 
-    doLogout(t, randomCase(adminAccountName), cookies)
+	doLogout(t, randomCase(adminAccountName), cookies)
 }
 
 func TestStepperSetModeInvalid(t *testing.T) {
-    unit_test.SetTesting(t)
-    defer unit_test.SetTesting(nil)
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
-    testStepperReset(t)
-    response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+	testStepperReset(t)
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-    res, cookies := testStepperGetStatus(t, response.Cookies())
-    cookies = testStepperSetManual(t, res.Epoch, cookies)
+	res, cookies := testStepperGetStatus(t, response.Cookies())
+	cookies = testStepperSetManual(t, res.Epoch, cookies)
 
-    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?mode=badChoice"), nil)
-    request.Header.Set("If-Match", "-1")
+	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?mode=badChoice"), nil)
+	request.Header.Set("If-Match", "-1")
 
-    response = doHTTP(request, cookies)
+	response = doHTTP(request, cookies)
 
-    assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
 
-    body, err := getBody(response)
-    assert.Nil(t, err)
-    assert.Equal(t, "CloudChamber: mode \"badChoice\" is invalid.  Supported modes are 'manual' and 'automatic'\n", string(body))
+	body, err := getBody(response)
+	assert.Nil(t, err)
+	assert.Equal(t, "CloudChamber: mode \"badChoice\" is invalid.  Supported modes are 'manual' and 'automatic'\n", string(body))
 
-    res, cookies = testStepperGetStatus(t, response.Cookies())
-    assert.Equal(t, pb.StepperPolicy_Manual, res.Policy, "Unexpected policy")
-    assert.Equal(t, int64(0), res.MeasuredDelay.Seconds, "Unexpected delay")
-    assert.Equal(t, int32(0), res.MeasuredDelay.Nanos, "Unexpected delay")
-    assert.Equal(t, int64(0), res.Now.Ticks, "Unexpected current time")
-    assert.Equal(t, int64(0), res.WaiterCount, "Unexpected active waiter count")
+	res, cookies = testStepperGetStatus(t, response.Cookies())
+	assert.Equal(t, pb.StepperPolicy_Manual, res.Policy, "Unexpected policy")
+	assert.Equal(t, int64(0), res.MeasuredDelay.Seconds, "Unexpected delay")
+	assert.Equal(t, int32(0), res.MeasuredDelay.Nanos, "Unexpected delay")
+	assert.Equal(t, int64(0), res.Now.Ticks, "Unexpected current time")
+	assert.Equal(t, int64(0), res.WaiterCount, "Unexpected active waiter count")
 
-    doLogout(t, randomCase(adminAccountName), cookies)
+	doLogout(t, randomCase(adminAccountName), cookies)
 }
 
 func TestStepperSetModeBadEpoch(t *testing.T) {
-    unit_test.SetTesting(t)
-    defer unit_test.SetTesting(nil)
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
-    testStepperReset(t)
-    response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+	testStepperReset(t)
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-    stat, cookies := testStepperGetStatus(t, response.Cookies())
-    cookies = testStepperSetManual(t, stat.Epoch, cookies)
+	stat, cookies := testStepperGetStatus(t, response.Cookies())
+	cookies = testStepperSetManual(t, stat.Epoch, cookies)
 
-    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?mode=manual"), nil)
-    request.Header.Set("If-Match", fmt.Sprintf("%v", stat.Epoch))
+	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?mode=manual"), nil)
+	request.Header.Set("If-Match", fmt.Sprintf("%v", stat.Epoch))
 
-    response = doHTTP(request, cookies)
+	response = doHTTP(request, cookies)
 
-    assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
 
-    body, err := getBody(response)
-    assert.Nil(t, err)
-    assert.Equal(t, "CloudChamber: Set simulated time policy operation failed\n", string(body))
+	body, err := getBody(response)
+	assert.Nil(t, err)
+	assert.Equal(t, "CloudChamber: Set simulated time policy operation failed\n", string(body))
 
-    res, cookies := testStepperGetStatus(t, response.Cookies())
-    assert.Equal(t, pb.StepperPolicy_Manual, res.Policy, "Unexpected policy")
-    assert.Equal(t, int64(0), res.MeasuredDelay.Seconds, "Unexpected delay")
-    assert.Equal(t, int32(0), res.MeasuredDelay.Nanos, "Unexpected delay")
-    assert.Equal(t, int64(0), res.Now.Ticks, "Unexpected current time")
-    assert.Equal(t, int64(0), res.WaiterCount, "Unexpected active waiter count")
-    assert.Equal(t, stat.Epoch + 1, res.Epoch, "Unexpected epoch")
+	res, cookies := testStepperGetStatus(t, response.Cookies())
+	assert.Equal(t, pb.StepperPolicy_Manual, res.Policy, "Unexpected policy")
+	assert.Equal(t, int64(0), res.MeasuredDelay.Seconds, "Unexpected delay")
+	assert.Equal(t, int32(0), res.MeasuredDelay.Nanos, "Unexpected delay")
+	assert.Equal(t, int64(0), res.Now.Ticks, "Unexpected current time")
+	assert.Equal(t, int64(0), res.WaiterCount, "Unexpected active waiter count")
+	assert.Equal(t, stat.Epoch+1, res.Epoch, "Unexpected epoch")
 
-    doLogout(t, randomCase(adminAccountName), cookies)
+	doLogout(t, randomCase(adminAccountName), cookies)
 }
 
 func TestStepperAdvanceOne(t *testing.T) {
-    unit_test.SetTesting(t)
-    defer unit_test.SetTesting(nil)
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
-    testStepperReset(t)
-    response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+	testStepperReset(t)
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-    stat, cookies := testStepperGetStatus(t, response.Cookies())
-    cookies = testStepperSetManual(t, stat.Epoch, cookies)
+	stat, cookies := testStepperGetStatus(t, response.Cookies())
+	cookies = testStepperSetManual(t, stat.Epoch, cookies)
 
-    res, cookies := testStepperGetNow(t, cookies)
-    assert.Equal(t, int64(0), res.Ticks, "Time expected to be reset, was %d", res.Ticks)
+	res, cookies := testStepperGetNow(t, cookies)
+	assert.Equal(t, int64(0), res.Ticks, "Time expected to be reset, was %d", res.Ticks)
 
-    res2, cookies := testStepperAdvance(t, cookies)
+	res2, cookies := testStepperAdvance(t, cookies)
 
-    assert.Equal(t, int64(1), res2.Ticks - res.Ticks, "time expected to advance by 1, old: %d, new: %d", res.Ticks, res2.Ticks)
+	assert.Equal(t, int64(1), res2.Ticks-res.Ticks, "time expected to advance by 1, old: %d, new: %d", res.Ticks, res2.Ticks)
 
-    doLogout(t, randomCase(adminAccountName), cookies)
+	doLogout(t, randomCase(adminAccountName), cookies)
 }
 
 func TestStepperAdvanceTwo(t *testing.T) {
-    unit_test.SetTesting(t)
-    defer unit_test.SetTesting(nil)
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
-    response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-    status, cookies := testStepperGetStatus(t, response.Cookies())
+	status, cookies := testStepperGetStatus(t, response.Cookies())
 
-    cookies = testStepperSetManual(t, status.Epoch, cookies)
-    res, cookies := testStepperGetNow(t, cookies)
+	cookies = testStepperSetManual(t, status.Epoch, cookies)
+	res, cookies := testStepperGetNow(t, cookies)
 
-    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?advance=2"), nil)
-    response = doHTTP(request, cookies)
-    assert.Equal(t, http.StatusOK, response.StatusCode)
+	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?advance=2"), nil)
+	response = doHTTP(request, cookies)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
 
-    res2 := &common.Timestamp{}
-    err := getJsonBody(response, res2)
+	res2 := &common.Timestamp{}
+	err := getJSONBody(response, res2)
 
-    assert.Nilf(t, err, "Unexpected error, err: %v", err)
+	assert.Nilf(t, err, "Unexpected error, err: %v", err)
 
-    assert.Equal(t, int64(2), res2.Ticks - res.Ticks, "time expected to advance by 1, old: %d, new: %d", res.Ticks, res2.Ticks)
+	assert.Equal(t, int64(2), res2.Ticks-res.Ticks, "time expected to advance by 1, old: %d, new: %d", res.Ticks, res2.Ticks)
 
-    doLogout(t, randomCase(adminAccountName), response.Cookies())
+	doLogout(t, randomCase(adminAccountName), response.Cookies())
 }
 
 func TestStepperAdvanceNotANumber(t *testing.T) {
-    unit_test.SetTesting(t)
-    defer unit_test.SetTesting(nil)
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
-    response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-    stat, cookies := testStepperGetStatus(t, response.Cookies())
-    cookies = testStepperSetManual(t, stat.Epoch, cookies)
+	stat, cookies := testStepperGetStatus(t, response.Cookies())
+	cookies = testStepperSetManual(t, stat.Epoch, cookies)
 
-    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?advance=two"), nil)
-    response = doHTTP(request, cookies)
-    assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?advance=two"), nil)
+	response = doHTTP(request, cookies)
+	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
 
-    body, err := getBody(response)
+	body, err := getBody(response)
 
-    assert.Nil(t, err)
-    assert.Equal(t, "CloudChamber: requested rate \"two\" could not be parsed as a positive decimal number\n", string(body))
+	assert.Nil(t, err)
+	assert.Equal(t, "CloudChamber: requested rate \"two\" could not be parsed as a positive decimal number\n", string(body))
 
-    doLogout(t, randomCase(adminAccountName), response.Cookies())
+	doLogout(t, randomCase(adminAccountName), response.Cookies())
 }
 
 func TestStepperAdvanceMinusOne(t *testing.T) {
-    unit_test.SetTesting(t)
-    defer unit_test.SetTesting(nil)
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
-    response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-    stat, cookies := testStepperGetStatus(t, response.Cookies())
-    cookies = testStepperSetManual(t, stat.Epoch, cookies)
+	stat, cookies := testStepperGetStatus(t, response.Cookies())
+	cookies = testStepperSetManual(t, stat.Epoch, cookies)
 
-    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?advance=-1"), nil)
-    response = doHTTP(request, cookies)
+	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?advance=-1"), nil)
+	response = doHTTP(request, cookies)
 
-    assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
 
-    body, err := getBody(response)
+	body, err := getBody(response)
 
-    assert.Nil(t, err)
-    assert.Equal(t, "CloudChamber: requested rate \"-1\" could not be parsed as a positive decimal number\n", string(body))
+	assert.Nil(t, err)
+	assert.Equal(t, "CloudChamber: requested rate \"-1\" could not be parsed as a positive decimal number\n", string(body))
 
-    doLogout(t, randomCase(adminAccountName), response.Cookies())
+	doLogout(t, randomCase(adminAccountName), response.Cookies())
 }
 
 func TestStepperSetManualBadRate(t *testing.T) {
-    unit_test.SetTesting(t)
-    defer unit_test.SetTesting(nil)
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
-    response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-    request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?mode=manual=10"), nil)
-    response = doHTTP(request, response.Cookies())
+	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", testStepperPath(), "?mode=manual=10"), nil)
+	response = doHTTP(request, response.Cookies())
 
-    assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
 
-    doLogout(t, randomCase(adminAccountName), response.Cookies())
+	doLogout(t, randomCase(adminAccountName), response.Cookies())
 }
 
 func TestStepperAfter(t *testing.T) {
-    var afterHit = false
-    var cookies2 []*http.Cookie
+	var afterHit = false
+	var cookies2 []*http.Cookie
 
-    unit_test.SetTesting(t)
-    defer unit_test.SetTesting(nil)
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
-    response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-    stat, cookies := testStepperGetStatus(t, response.Cookies())
-    cookies = testStepperSetManual(t, stat.Epoch, cookies)
+	stat, cookies := testStepperGetStatus(t, response.Cookies())
+	cookies = testStepperSetManual(t, stat.Epoch, cookies)
 
-    res, cookies := testStepperGetNow(t, cookies)
+	res, cookies := testStepperGetNow(t, cookies)
 
-    go func(after int64, cookies []*http.Cookie) {
-        res, cookies2 = testStepperAfter(t, after, cookies)
+	go func(after int64, cookies []*http.Cookie) {
+		res, cookies2 = testStepperAfter(t, after, cookies)
 
-        assert.Less(t, after, res.Ticks)
-        afterHit = true
-    }(res.Ticks, cookies)
+		assert.Less(t, after, res.Ticks)
+		afterHit = true
+	}(res.Ticks, cookies)
 
-    _, _ = testStepperAdvance(t, cookies)
-    time.Sleep(time.Duration(2) * time.Second)
-    assert.True(t, afterHit)
+	_, _ = testStepperAdvance(t, cookies)
+	time.Sleep(time.Duration(2) * time.Second)
+	assert.True(t, afterHit)
 
-    doLogout(t, randomCase(adminAccountName), cookies2)
+	doLogout(t, randomCase(adminAccountName), cookies2)
 }
 
 func TestStepperAfterBadPastTick(t *testing.T) {
-    unit_test.SetTesting(t)
-    defer unit_test.SetTesting(nil)
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
-    response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-    stat, cookies := testStepperGetStatus(t, response.Cookies())
-    cookies = testStepperSetManual(t, stat.Epoch, cookies)
+	stat, cookies := testStepperGetStatus(t, response.Cookies())
+	cookies = testStepperSetManual(t, stat.Epoch, cookies)
 
-    res, cookies := testStepperGetNow(t, cookies)
-    _, cookies = testStepperAdvance(t, cookies)
+	res, cookies := testStepperGetNow(t, cookies)
+	_, cookies = testStepperAdvance(t, cookies)
 
-    res2, cookies := testStepperAfter(t, res.Ticks, cookies)
-    assert.Less(t, res.Ticks, res2.Ticks)
+	res2, cookies := testStepperAfter(t, res.Ticks, cookies)
+	assert.Less(t, res.Ticks, res2.Ticks)
 
-    doLogout(t, randomCase(adminAccountName), cookies)
+	doLogout(t, randomCase(adminAccountName), cookies)
 }
 
 func TestStepperAfterBadTick(t *testing.T) {
-    unit_test.SetTesting(t)
-    defer unit_test.SetTesting(nil)
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
-    response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-    stat, cookies := testStepperGetStatus(t, response.Cookies())
-    cookies = testStepperSetManual(t, stat.Epoch, cookies)
+	stat, cookies := testStepperGetStatus(t, response.Cookies())
+	cookies = testStepperSetManual(t, stat.Epoch, cookies)
 
-    request := httptest.NewRequest("GET", fmt.Sprintf("%s/now?after=-1", testStepperPath()), nil)
-    response = doHTTP(request, cookies)
+	request := httptest.NewRequest("GET", fmt.Sprintf("%s/now?after=-1", testStepperPath()), nil)
+	response = doHTTP(request, cookies)
 
-    assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
 
-    doLogout(t, randomCase(adminAccountName), response.Cookies())
+	doLogout(t, randomCase(adminAccountName), response.Cookies())
 }
 
 func TestStepperGetNow(t *testing.T) {
-    unit_test.SetTesting(t)
-    defer unit_test.SetTesting(nil)
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
 
-    response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-    res, cookies := testStepperGetNow(t, response.Cookies())
-    t.Log(res.Ticks)
+	res, cookies := testStepperGetNow(t, response.Cookies())
+	t.Log(res.Ticks)
 
-    res2, cookies := testStepperGetNow(t, cookies)
+	res2, cookies := testStepperGetNow(t, cookies)
 
-    assert.Equal(t, res.Ticks, res2.Ticks, "times with no advance do not match, %v != %v", res.Ticks, res2.Ticks)
+	assert.Equal(t, res.Ticks, res2.Ticks, "times with no advance do not match, %v != %v", res.Ticks, res2.Ticks)
 
-    doLogout(t, randomCase(adminAccountName), cookies)
+	doLogout(t, randomCase(adminAccountName), cookies)
 }

--- a/internal/services/frontend/users.go
+++ b/internal/services/frontend/users.go
@@ -26,7 +26,12 @@ const (
 	// InvalidRev is a value that can never be a valid version number
 	InvalidRev = -1
 
-	Login  = "login"
+	// Login is a string used to select and identify the login operation
+	//
+	Login = "login"
+
+	// Logout is a string used to select and identify the logout operation
+	//
 	Logout = "logout"
 )
 

--- a/internal/services/frontend/users_test.go
+++ b/internal/services/frontend/users_test.go
@@ -342,7 +342,7 @@ func TestUsersCreate(t *testing.T) {
 
 	path := baseURI + alice + "2"
 
-	r, err := toJsonReader(aliceDef)
+	r, err := toJSONReader(aliceDef)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
@@ -371,7 +371,7 @@ func TestUsersCreateDup(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
 
-	r, err := toJsonReader(aliceDef)
+	r, err := toJSONReader(aliceDef)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
@@ -429,7 +429,7 @@ func TestUsersCreateNoPriv(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
 
-	r, err := toJsonReader(bobDef)
+	r, err := toJSONReader(bobDef)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	response := doLogin(t, "Alice", alicePassword, nil)
@@ -459,7 +459,7 @@ func TestUsersCreateNoSession(t *testing.T) {
 
 	path := baseURI + alice + "2"
 
-	r, err := toJsonReader(aliceDef)
+	r, err := toJSONReader(aliceDef)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	request := httptest.NewRequest("POST", path, r)
@@ -559,7 +559,7 @@ func TestUsersRead(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.StatusCode, "Handler returned unexpected error: %v", response.StatusCode)
 
 	user := &pb.UserPublic{}
-	err := getJsonBody(response, user)
+	err := getJSONBody(response, user)
 	assert.Nilf(t, err, "Failed to convert body to valid json.  err: %v", err)
 
 	assert.Equal(t, "application/json", strings.ToLower(response.Header.Get("Content-Type")))
@@ -684,7 +684,7 @@ func TestUsersUpdate(t *testing.T) {
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-	r, err := toJsonReader(aliceUpd)
+	r, err := toJSONReader(aliceUpd)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	rev, cookies := ensureAccount(t, "Alice", aliceDef, response.Cookies())
@@ -696,7 +696,7 @@ func TestUsersUpdate(t *testing.T) {
 	assert.Equal(t, "application/json", strings.ToLower(response.Header.Get("Content-Type")))
 
 	user := &pb.UserPublic{}
-	err = getJsonBody(response, user)
+	err = getJSONBody(response, user)
 	assert.Nilf(t, err, "Failed to convert body to valid json.  err: %v", err)
 
 	match, err := strconv.ParseInt(response.Header.Get("ETag"), 10, 64)
@@ -764,7 +764,7 @@ func TestUsersUpdateBadMatch(t *testing.T) {
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-	r, err := toJsonReader(aliceUpd)
+	r, err := toJSONReader(aliceUpd)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	rev, cookies := ensureAccount(t, "Alice", aliceDef, response.Cookies())
@@ -799,7 +799,7 @@ func TestUsersUpdateBadMatchSyntax(t *testing.T) {
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-	r, err := toJsonReader(aliceUpd)
+	r, err := toJSONReader(aliceUpd)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	_, cookies := ensureAccount(t, "Alice", aliceDef, response.Cookies())
@@ -831,7 +831,7 @@ func TestUsersUpdateNoUser(t *testing.T) {
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-	r, err := toJsonReader(upd)
+	r, err := toJSONReader(upd)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", baseURI, userURI+"BadUser"), r)
@@ -865,7 +865,7 @@ func TestUsersUpdateNoPriv(t *testing.T) {
 
 	response = doLogin(t, "Bob", bobPassword, response.Cookies())
 
-	r, err := toJsonReader(aliceUpd)
+	r, err := toJSONReader(aliceUpd)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", baseURI, alice), r)


### PR DESCRIPTION
Removed some redundant tracing in storeapi
Added some intent type trace entries (until "explainer" tracing arrives)
Sorted out a lot of complaints from lint in VsCode, mainly comment starting symbol matching public symbols and the insistence that Json should be all upper-case.

No functional changes. Tested clean.