### PR TITLE
Cleanup some store tracing and assorted VsCode lint-er complaints

### DIFF
--- a/internal/services/frontend/DBInventory.go
+++ b/internal/services/frontend/DBInventory.go
@@ -17,7 +17,7 @@ import (
 
 // DBInventory is a container used to establish synchronized access to
 // the in-memory set of Racks records.
-
+//
 type DBInventory struct { //A struct for the collection of Racks
 	Mutex sync.Mutex
 	Racks map[string]*pb.ExternalRack
@@ -25,6 +25,13 @@ type DBInventory struct { //A struct for the collection of Racks
 
 var dbInventory *DBInventory
 
+// InitDBInventory initializes the base state for the inventory.
+//
+// At present the primary state is sufficient data in an in-memory db sufficient
+// for testing purposes. Eventually, this will be removed and the calls will be
+// connected to the store in order to persist the inventory read from an external
+// definition file
+//
 func InitDBInventory() error {
 	if dbInventory == nil {
 		dbInventory = &DBInventory{
@@ -94,6 +101,8 @@ func (m *DBInventory) Scan(action func(entry string) error) error {
 	return nil
 }
 
+// Get returns the rack details to match the supplied rackId
+//
 func (m *DBInventory) Get(rackid string) (*pb.ExternalRack, error) {
 
 	m.Mutex.Lock()
@@ -107,6 +116,10 @@ func (m *DBInventory) Get(rackid string) (*pb.ExternalRack, error) {
 
 }
 
+// ScanBladesInRack enumerates over all the blades in a rack of the
+// given rackId, and invokes the supplied action on each discovered
+// bladeId in turn.
+//
 func (m *DBInventory) ScanBladesInRack(rackid string, action func(bladeid int64) error) error {
 	m.Mutex.Lock()
 	defer m.Mutex.Unlock()
@@ -123,6 +136,9 @@ func (m *DBInventory) ScanBladesInRack(rackid string, action func(bladeid int64)
 	return nil
 }
 
+// GetBlade returns the details of a blade matching the
+// supplied rackId and bladeId
+//
 func (m *DBInventory) GetBlade(rackid string, bladeid int64) (*common.BladeCapacity, error) {
 	m.Mutex.Lock()
 	defer m.Mutex.Unlock()

--- a/internal/services/frontend/common_test.go
+++ b/internal/services/frontend/common_test.go
@@ -142,7 +142,7 @@ func bufDialer(_ context.Context, _ string) (net.Conn, error) {
 }
 
 // Convert a proto message into a reader with json-formatted contents
-func toJsonReader(v proto.Message) (io.Reader, error) {
+func toJSONReader(v proto.Message) (io.Reader, error) {
 	var buf bytes.Buffer
 	w := bufio.NewWriter(&buf)
 	p := jsonpb.Marshaler{}
@@ -178,7 +178,7 @@ func getBody(resp *http.Response) ([]byte, error) {
 }
 
 // Get the body of a response, unmarshaled into the supplied message structure
-func getJsonBody(resp *http.Response, v proto.Message) error {
+func getJSONBody(resp *http.Response, v proto.Message) error {
 	defer func() { _ = resp.Body.Close() }()
 	return jsonpb.Unmarshal(resp.Body, v)
 }

--- a/internal/services/frontend/errors.go
+++ b/internal/services/frontend/errors.go
@@ -222,8 +222,8 @@ func NewErrRackNotFound(name string) *HTTPError {
 	}
 }
 
-//BladeNotFound indicates that the rack was found but no blade was found
-
+// NewErrBladeNotFound indicates that the rack was found but no blade was found
+//
 func NewErrBladeNotFound(rackid string, bladeid int64) *HTTPError {
 	return &HTTPError{
 		SC:   http.StatusNotFound,
@@ -231,7 +231,7 @@ func NewErrBladeNotFound(rackid string, bladeid int64) *HTTPError {
 	}
 }
 
-// ErrInvalidStepperMode indicates that an unrecognized simulated policy mode
+// NewErrInvalidStepperMode indicates that an unrecognized simulated policy mode
 // was requested.
 func NewErrInvalidStepperMode(mode string) *HTTPError {
 	return &HTTPError{

--- a/internal/services/frontend/inventory_test.go
+++ b/internal/services/frontend/inventory_test.go
@@ -52,7 +52,7 @@ func TestInventoryRackRead(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.StatusCode, "Handler returned unexpected error: %v", response.StatusCode)
 
 	rack := &pb.ExternalRack{}
-	err := getJsonBody(response, rack)
+	err := getJSONBody(response, rack)
 	assert.Nilf(t, err, "Failed to convert body to valid json.  err: %v", err)
 
 	assert.Equal(t, "application/json", strings.ToLower(response.Header.Get("Content-Type")))
@@ -157,7 +157,7 @@ func TestInventoryBladeRead(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.StatusCode, "Handler returned the Blade: %v", response.StatusCode)
 
 	blade := &common.BladeCapacity{}
-	err := getJsonBody(response, blade)
+	err := getJSONBody(response, blade)
 	assert.Nilf(t, err, "Failed to convert body to valid json.  err: %v", err)
 
 	assert.Equal(t, "application/json", strings.ToLower(response.Header.Get("Content-Type")))
@@ -180,7 +180,7 @@ func TestInventoryBlade2Read(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.StatusCode, "Handler returned the Blade: %v", response.StatusCode)
 
 	blade := &common.BladeCapacity{}
-	err := getJsonBody(response, blade)
+	err := getJSONBody(response, blade)
 	assert.Nilf(t, err, "Failed to convert body to valid json.  err: %v", err)
 
 	assert.Equal(t, "application/json", strings.ToLower(response.Header.Get("Content-Type")))

--- a/internal/services/frontend/stepper_test.go
+++ b/internal/services/frontend/stepper_test.go
@@ -45,7 +45,7 @@ func testStepperGetNow(t *testing.T, cookies []*http.Cookie) (*common.Timestamp,
     assert.Equal(t, http.StatusOK, response.StatusCode)
 
     res := &common.Timestamp{}
-    err := getJsonBody(response, res)
+    err := getJSONBody(response, res)
 
     assert.Nilf(t, err, "Unexpected error, err: %v", err)
 
@@ -59,7 +59,7 @@ func testStepperGetStatus(t *testing.T, cookies []*http.Cookie) (*pb.StatusRespo
     assert.Equal(t, http.StatusOK, response.StatusCode)
 
     res := &pb.StatusResponse{}
-    err := getJsonBody(response, res)
+    err := getJSONBody(response, res)
 
     assert.Nilf(t, err, "Unexpected error, err: %v", err)
 
@@ -72,7 +72,7 @@ func testStepperAdvance(t *testing.T, cookies []*http.Cookie) (*common.Timestamp
     assert.Equal(t, http.StatusOK, response.StatusCode)
 
     res := &common.Timestamp{}
-    err := getJsonBody(response, res)
+    err := getJSONBody(response, res)
 
     assert.Nilf(t, err, "Unexpected error, err: %v", err)
 
@@ -86,7 +86,7 @@ func testStepperAfter(t *testing.T, after int64, cookies []*http.Cookie) (*commo
     assert.Equal(t, http.StatusOK, response.StatusCode)
 
     res := &common.Timestamp{}
-    err := getJsonBody(response, res)
+    err := getJSONBody(response, res)
 
     assert.Nilf(t, err, "Unexpected error, err: %v", err)
 
@@ -225,7 +225,7 @@ func TestStepperAdvanceTwo(t *testing.T) {
     assert.Equal(t, http.StatusOK, response.StatusCode)
 
     res2 := &common.Timestamp{}
-    err := getJsonBody(response, res2)
+    err := getJSONBody(response, res2)
 
     assert.Nilf(t, err, "Unexpected error, err: %v", err)
 

--- a/internal/services/frontend/users.go
+++ b/internal/services/frontend/users.go
@@ -26,7 +26,12 @@ const (
 	// InvalidRev is a value that can never be a valid version number
 	InvalidRev = -1
 
-	Login  = "login"
+	// Login is a string used to select and identify the login operation
+	//
+	Login = "login"
+
+	// Logout is a string used to select and identify the logout operation
+	//
 	Logout = "logout"
 )
 

--- a/internal/services/frontend/users_test.go
+++ b/internal/services/frontend/users_test.go
@@ -109,7 +109,7 @@ func testUserRead(t *testing.T, path string, cookies []*http.Cookie) (*http.Resp
 	assert.Equal(t, http.StatusOK, response.StatusCode, "Handler returned unexpected error: %v", response.StatusCode)
 
 	user := &pb.UserPublic{}
-	err := getJsonBody(response, user)
+	err := getJSONBody(response, user)
 	assert.Nilf(t, err, "Failed to convert body to valid json.  err: %v", err)
 
 	assert.Equal(t, "application/json", strings.ToLower(response.Header.Get("Content-Type")))
@@ -118,7 +118,7 @@ func testUserRead(t *testing.T, path string, cookies []*http.Cookie) (*http.Resp
 }
 
 func testUserSetPassword(t *testing.T, name string, upd *pb.UserPassword, rev int64, cookies []*http.Cookie) (*http.Response, int64) {
-	r, err := toJsonReader(upd)
+	r, err := toJSONReader(upd)
 	assert.Nilf(t, err, "Failed to format UserPassword, err = %v", err)
 
 	path := baseURI + userURI + name + "?password"
@@ -378,7 +378,7 @@ func TestUsersCreate(t *testing.T) {
 
 	path := baseURI + alice + "2"
 
-	r, err := toJsonReader(aliceDef)
+	r, err := toJSONReader(aliceDef)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
@@ -407,7 +407,7 @@ func TestUsersCreateDup(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
 
-	r, err := toJsonReader(aliceDef)
+	r, err := toJSONReader(aliceDef)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
@@ -465,7 +465,7 @@ func TestUsersCreateNoPriv(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
 
-	r, err := toJsonReader(bobDef)
+	r, err := toJSONReader(bobDef)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	response := doLogin(t, "Alice", alicePassword, nil)
@@ -495,7 +495,7 @@ func TestUsersCreateNoSession(t *testing.T) {
 
 	path := baseURI + alice + "2"
 
-	r, err := toJsonReader(aliceDef)
+	r, err := toJSONReader(aliceDef)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	request := httptest.NewRequest("POST", path, r)
@@ -595,7 +595,7 @@ func TestUsersRead(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.StatusCode, "Handler returned unexpected error: %v", response.StatusCode)
 
 	user := &pb.UserPublic{}
-	err := getJsonBody(response, user)
+	err := getJSONBody(response, user)
 	assert.Nilf(t, err, "Failed to convert body to valid json.  err: %v", err)
 
 	assert.Equal(t, "application/json", strings.ToLower(response.Header.Get("Content-Type")))
@@ -719,7 +719,7 @@ func TestUsersUpdate(t *testing.T) {
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-	r, err := toJsonReader(aliceUpd)
+	r, err := toJSONReader(aliceUpd)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	rev, cookies := ensureAccount(t, "Alice", aliceDef, response.Cookies())
@@ -731,7 +731,7 @@ func TestUsersUpdate(t *testing.T) {
 	assert.Equal(t, "application/json", strings.ToLower(response.Header.Get("Content-Type")))
 
 	user := &pb.UserPublic{}
-	err = getJsonBody(response, user)
+	err = getJSONBody(response, user)
 	assert.Nilf(t, err, "Failed to convert body to valid json.  err: %v", err)
 
 	match, err := strconv.ParseInt(response.Header.Get("ETag"), 10, 64)
@@ -798,7 +798,7 @@ func TestUsersUpdateBadMatch(t *testing.T) {
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-	r, err := toJsonReader(aliceUpd)
+	r, err := toJSONReader(aliceUpd)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	rev, cookies := ensureAccount(t, "Alice", aliceDef, response.Cookies())
@@ -833,7 +833,7 @@ func TestUsersUpdateBadMatchSyntax(t *testing.T) {
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-	r, err := toJsonReader(aliceUpd)
+	r, err := toJSONReader(aliceUpd)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	_, cookies := ensureAccount(t, "Alice", aliceDef, response.Cookies())
@@ -864,7 +864,7 @@ func TestUsersUpdateNoUser(t *testing.T) {
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
 
-	r, err := toJsonReader(upd)
+	r, err := toJSONReader(upd)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", baseURI, userURI+"BadUser"), r)
@@ -897,7 +897,7 @@ func TestUsersUpdateNoPriv(t *testing.T) {
 
 	response = doLogin(t, "Bob", bobPassword, response.Cookies())
 
-	r, err := toJsonReader(aliceUpd)
+	r, err := toJSONReader(aliceUpd)
 	assert.Nilf(t, err, "Failed to format UserDefinition, err = %v", err)
 
 	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", baseURI, alice), r)
@@ -915,7 +915,7 @@ func TestUsersUpdateNoPriv(t *testing.T) {
 }
 
 func testUsersUpdate(t *testing.T, path string, upd *pb.UserUpdate, rev int64, cookies []*http.Cookie) (*http.Response, int64) {
-	r, err := toJsonReader(upd)
+	r, err := toJSONReader(upd)
 	assert.Nilf(t, err, "Failed to format UserUpdate, err = %v", err)
 
 	request := httptest.NewRequest("PUT", path, r)
@@ -939,7 +939,7 @@ func TestUsersUpdateExpandRights(t *testing.T) {
 	}
 
 	aliceOriginal := &pb.UserUpdate{
-		Enabled: 		   true,
+		Enabled:           true,
 		CanManageAccounts: false,
 	}
 
@@ -959,7 +959,7 @@ func TestUsersUpdateExpandRights(t *testing.T) {
 
 	response = doLogin(t, "Alice", alicePassword, response.Cookies())
 
-	r, err := toJsonReader(aliceUpd)
+	r, err := toJSONReader(aliceUpd)
 	assert.Nilf(t, err, "Failed to format UserUpdate, err = %v", err)
 
 	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", baseURI, alice), r)
@@ -1099,7 +1099,7 @@ func TestUsersSetPassword(t *testing.T) {
 	aliceRevert := &pb.UserPassword{
 		OldPassword: alicePassword + "xxx",
 		NewPassword: alicePassword,
-		Force:		 true,
+		Force:       true,
 	}
 
 	unit_test.SetTesting(t)
@@ -1145,7 +1145,7 @@ func TestUsersSetPasswordForce(t *testing.T) {
 	aliceRevert := &pb.UserPassword{
 		OldPassword: alicePassword + "xxx",
 		NewPassword: alicePassword,
-		Force:		 true,
+		Force:       true,
 	}
 
 	unit_test.SetTesting(t)
@@ -1195,7 +1195,7 @@ func TestUsersSetPasswordBadPassword(t *testing.T) {
 
 	rev, cookies := ensureAccount(t, "Alice", aliceDef, response.Cookies())
 
-	r, err := toJsonReader(aliceUpd)
+	r, err := toJSONReader(aliceUpd)
 	assert.Nilf(t, err, "Failed to format UserPassword, err = %v", err)
 
 	path := baseURI + alice + "?password"
@@ -1233,7 +1233,7 @@ func TestUsersSetPasswordNoPriv(t *testing.T) {
 
 	response = doLogin(t, "Alice", alicePassword, response.Cookies())
 
-	r, err := toJsonReader(adminUpd)
+	r, err := toJSONReader(adminUpd)
 	assert.Nilf(t, err, "Failed to format UserPassword, err = %v", err)
 
 	path := baseURI + admin + "?password"


### PR DESCRIPTION
Second attempt at this change to deal with some VsCode obnoxiousness because IT DOESN"T LISTEN

As a result, this completely replaces the earlier attempt in branch mj-cleanup-1

Removed some redundant tracing in storeapi
Added some intent type trace entries (until "explainer" tracing arrives)
Sorted out a lot of complaints from lint in VsCode, mainly comment starting symbol matching public symbols and the insistence that Json should be all upper-case.

No functional changes. Tested clean.
