### PR TITLE
Changes to Makefile to allow parallel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,41 +5,40 @@ PROTO_FILES = \
 	pkg/protos/common/capacity.proto \
 	pkg/protos/common/completion.proto \
 	pkg/protos/common/timestamp.proto \
-    pkg/protos/log/entry.proto \
-    pkg/protos/inventory/actual.proto \
-    pkg/protos/inventory/external.proto \
-    pkg/protos/inventory/internal.proto \
-    pkg/protos/inventory/target.proto \
-    pkg/protos/workload/actual.proto \
-    pkg/protos/workload/external.proto \
-    pkg/protos/workload/internal.proto \
-    pkg/protos/workload/target.proto \
-    pkg/protos/monitor/monitor.proto \
-    pkg/protos/Stepper/stepper.proto
-
+	pkg/protos/log/entry.proto \
+	pkg/protos/inventory/actual.proto \
+	pkg/protos/inventory/external.proto \
+	pkg/protos/inventory/internal.proto \
+	pkg/protos/inventory/target.proto \
+	pkg/protos/workload/actual.proto \
+	pkg/protos/workload/external.proto \
+	pkg/protos/workload/internal.proto \
+	pkg/protos/workload/target.proto \
+	pkg/protos/monitor/monitor.proto \
+	pkg/protos/Stepper/stepper.proto
 
 PROTO_GEN_FILES = \
-	pkg/protos/admin/users.pb.go\
+	pkg/protos/admin/users.pb.go \
 	pkg/protos/common/capacity.pb.go \
 	pkg/protos/common/completion.pb.go \
 	pkg/protos/common/timestamp.pb.go \
-    pkg/protos/log/entry.pb.go \
-    pkg/protos/inventory/actual.pb.go \
-    pkg/protos/inventory/external.pb.go \
-    pkg/protos/inventory/internal.pb.go \
-    pkg/protos/inventory/target.pb.go \
-    pkg/protos/workload/actual.pb.go \
-    pkg/protos/workload/external.pb.go \
-    pkg/protos/workload/internal.pb.go \
-    pkg/protos/workload/target.pb.go \
-    pkg/protos/monitor/monitor.pb.go \
-    pkg/protos/Stepper/stepper.pb.go
+	pkg/protos/log/entry.pb.go \
+	pkg/protos/inventory/actual.pb.go \
+	pkg/protos/inventory/external.pb.go \
+	pkg/protos/inventory/internal.pb.go \
+	pkg/protos/inventory/target.pb.go \
+	pkg/protos/workload/actual.pb.go \
+	pkg/protos/workload/external.pb.go \
+	pkg/protos/workload/internal.pb.go \
+	pkg/protos/workload/target.pb.go \
+	pkg/protos/monitor/monitor.pb.go \
+	pkg/protos/Stepper/stepper.pb.go
 
 SERVICES = \
-	deployments/controllerd.exe \
-	deployments/inventoryd.exe \
-	deployments/sim_supportd.exe \
-	deployments/web_server.exe
+        deployments/controllerd.exe \
+        deployments/inventoryd.exe \
+        deployments/sim_supportd.exe \
+        deployments/web_server.exe
 
 VERSION_MARKER = \
 	pkg/version/generated.go \
@@ -55,6 +54,39 @@ PROTOC = protoc --go_out=$(GOPATH)/src --proto_path=. --proto_path=$(GOPATH)/src
 GRPC_PROTOC = protoc --go_out=plugins=grpc:$(GOPATH)/src --proto_path=. --proto_path=$(GOPATH)/src
 
 CP = cp
+
+
+
+all: build run_tests
+
+build: $(SERVICES) $(ARTIFACTS)
+
+protogen: $(PROTO_GEN_FILES)
+
+version: $(VERSION_MARKER)
+
+service_build: $(SERVICES)
+
+copy_to: $(ARTIFACTS)
+
+run_tests: $(PROTO_GEN_FILES) $(VERSION_MARKER)
+	go test $(PROJECT)/internal/clients/store
+	go test $(PROJECT)/internal/clients/timestamp
+	go test $(PROJECT)/internal/services/frontend
+	go test $(PROJECT)/internal/services/stepper_actor
+
+
+.PHONY : clean
+
+clean:
+	$(RM) $(SERVICES) $(ARTIFACTS) $(PROTO_GEN_FILES) $(VERSION_MARKER)
+
+
+.PHONY : test
+
+test: run_tests
+
+
 
 pkg/protos/admin/users.pb.go : pkg/protos/admin/users.proto
 	$(PROTOC) $(PROJECT)/$<
@@ -102,16 +134,16 @@ pkg/protos/Stepper/stepper.pb.go: pkg/protos/Stepper/stepper.proto
 	$(GRPC_PROTOC) $(PROJECT)/$<
 
 
-deployments/controllerd.exe: cmd/controllerd/main.go
+deployments/controllerd.exe: cmd/controllerd/main.go   $(PROTO_GEN_FILES) $(VERSION_MARKER)
 	go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
-deployments/inventoryd.exe: cmd/inventoryd/main.go
+deployments/inventoryd.exe: cmd/inventoryd/main.go     $(PROTO_GEN_FILES) $(VERSION_MARKER)
 	go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
-deployments/sim_supportd.exe: cmd/sim_supportd/main.go
+deployments/sim_supportd.exe: cmd/sim_supportd/main.go $(PROTO_GEN_FILES) $(VERSION_MARKER)
 	go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
-deployments/web_server.exe: cmd/web_server/main.go
+deployments/web_server.exe: cmd/web_server/main.go     $(PROTO_GEN_FILES) $(VERSION_MARKER)
 	go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
 deployments/readme.md: pkg/version/version_stamp.md
@@ -126,38 +158,8 @@ deployments/start_cloud_chamber.cmd: scripts/start_cloud_chamber.cmd
 deployments/startetcd.cmd: scripts/startetcd.cmd
 	$(CP) $(PROJECT)/$< $(PROJECT)/$@
 
-all: \
-	clean \
-	build \
-	run_tests
 
-build: \
-	protogen \
-	version \
-	service_build \
-	copy_to
+$(VERSION_MARKER) &: pkg/version/version.go
+	go generate $(PROJECT)/$<
 
-protogen: $(PROTO_GEN_FILES)
 
-version:
-	go generate $(PROJECT)/pkg/version/version.go
-
-service_build: $(SERVICES)
-
-copy_to: $(ARTIFACTS)
-
-run_tests:
-	go test $(PROJECT)/internal/clients/store
-	go test $(PROJECT)/internal/clients/timestamp
-	go test $(PROJECT)/internal/services/frontend
-	go test $(PROJECT)/internal/services/stepper_actor
-
-clean:
-	$(RM) deployments/*
-	$(RM) $(PROTO_GEN_FILES)
-	$(RM) $(VERSION_MARKER)
-
-test: \
-	protogen \
-	version \
-	run_tests

--- a/Makefile
+++ b/Makefile
@@ -1,54 +1,54 @@
 PROJECT = $(GOPATH)/src/github.com/Jim3Things/CloudChamber
 
 PROTO_FILES = \
-	pkg/protos/admin/users.proto \
-	pkg/protos/common/capacity.proto \
-	pkg/protos/common/completion.proto \
-	pkg/protos/common/timestamp.proto \
-	pkg/protos/log/entry.proto \
-	pkg/protos/inventory/actual.proto \
-	pkg/protos/inventory/external.proto \
-	pkg/protos/inventory/internal.proto \
-	pkg/protos/inventory/target.proto \
-	pkg/protos/workload/actual.proto \
-	pkg/protos/workload/external.proto \
-	pkg/protos/workload/internal.proto \
-	pkg/protos/workload/target.proto \
-	pkg/protos/monitor/monitor.proto \
-	pkg/protos/Stepper/stepper.proto
+    pkg/protos/admin/users.proto \
+    pkg/protos/common/capacity.proto \
+    pkg/protos/common/completion.proto \
+    pkg/protos/common/timestamp.proto \
+    pkg/protos/log/entry.proto \
+    pkg/protos/inventory/actual.proto \
+    pkg/protos/inventory/external.proto \
+    pkg/protos/inventory/internal.proto \
+    pkg/protos/inventory/target.proto \
+    pkg/protos/workload/actual.proto \
+    pkg/protos/workload/external.proto \
+    pkg/protos/workload/internal.proto \
+    pkg/protos/workload/target.proto \
+    pkg/protos/monitor/monitor.proto \
+    pkg/protos/Stepper/stepper.proto
 
 PROTO_GEN_FILES = \
-	pkg/protos/admin/users.pb.go \
-	pkg/protos/common/capacity.pb.go \
-	pkg/protos/common/completion.pb.go \
-	pkg/protos/common/timestamp.pb.go \
-	pkg/protos/log/entry.pb.go \
-	pkg/protos/inventory/actual.pb.go \
-	pkg/protos/inventory/external.pb.go \
-	pkg/protos/inventory/internal.pb.go \
-	pkg/protos/inventory/target.pb.go \
-	pkg/protos/workload/actual.pb.go \
-	pkg/protos/workload/external.pb.go \
-	pkg/protos/workload/internal.pb.go \
-	pkg/protos/workload/target.pb.go \
-	pkg/protos/monitor/monitor.pb.go \
-	pkg/protos/Stepper/stepper.pb.go
+    pkg/protos/admin/users.pb.go \
+    pkg/protos/common/capacity.pb.go \
+    pkg/protos/common/completion.pb.go \
+    pkg/protos/common/timestamp.pb.go \
+    pkg/protos/log/entry.pb.go \
+    pkg/protos/inventory/actual.pb.go \
+    pkg/protos/inventory/external.pb.go \
+    pkg/protos/inventory/internal.pb.go \
+    pkg/protos/inventory/target.pb.go \
+    pkg/protos/workload/actual.pb.go \
+    pkg/protos/workload/external.pb.go \
+    pkg/protos/workload/internal.pb.go \
+    pkg/protos/workload/target.pb.go \
+    pkg/protos/monitor/monitor.pb.go \
+    pkg/protos/Stepper/stepper.pb.go
 
 SERVICES = \
-        deployments/controllerd.exe \
-        deployments/inventoryd.exe \
-        deployments/sim_supportd.exe \
-        deployments/web_server.exe
+    deployments/controllerd.exe \
+    deployments/inventoryd.exe \
+    deployments/sim_supportd.exe \
+    deployments/web_server.exe
 
 VERSION_MARKER = \
-	pkg/version/generated.go \
-	pkg/version/version_stamp.md
+    pkg/version/generated.go \
+    pkg/version/version_stamp.md
 
 ARTIFACTS = \
-	deployments/readme.md \
-	deployments/cloudchamber.yaml \
-	deployments/start_cloud_chamber.cmd \
-	deployments/startetcd.cmd
+    deployments/readme.md \
+    deployments/cloudchamber.yaml \
+    deployments/start_cloud_chamber.cmd \
+    deployments/startetcd.cmd
 
 PROTOC = protoc --go_out=$(GOPATH)/src --proto_path=. --proto_path=$(GOPATH)/src
 GRPC_PROTOC = protoc --go_out=plugins=grpc:$(GOPATH)/src --proto_path=. --proto_path=$(GOPATH)/src
@@ -70,16 +70,16 @@ service_build: $(SERVICES)
 copy_to: $(ARTIFACTS)
 
 run_tests: $(PROTO_GEN_FILES) $(VERSION_MARKER)
-	go test $(PROJECT)/internal/clients/store
-	go test $(PROJECT)/internal/clients/timestamp
-	go test $(PROJECT)/internal/services/frontend
-	go test $(PROJECT)/internal/services/stepper_actor
+    go test $(PROJECT)/internal/clients/store
+    go test $(PROJECT)/internal/clients/timestamp
+    go test $(PROJECT)/internal/services/frontend
+    go test $(PROJECT)/internal/services/stepper_actor
 
 
 .PHONY : clean
 
 clean:
-	$(RM) $(SERVICES) $(ARTIFACTS) $(PROTO_GEN_FILES) $(VERSION_MARKER)
+    $(RM) $(SERVICES) $(ARTIFACTS) $(PROTO_GEN_FILES) $(VERSION_MARKER)
 
 
 .PHONY : test
@@ -88,43 +88,43 @@ test: run_tests
 
 
 %.pb.go : %.proto
-	$(PROTOC) $(PROJECT)/$<
+    $(PROTOC) $(PROJECT)/$<
 
 
 pkg/protos/monitor/monitor.pb.go: pkg/protos/monitor/monitor.proto
-	$(GRPC_PROTOC) $(PROJECT)/$<
+    $(GRPC_PROTOC) $(PROJECT)/$<
 
 pkg/protos/Stepper/stepper.pb.go: pkg/protos/Stepper/stepper.proto
-	$(GRPC_PROTOC) $(PROJECT)/$<
+    $(GRPC_PROTOC) $(PROJECT)/$<
 
 
 
 $(VERSION_MARKER) &: pkg/version/version.go
-	go generate $(PROJECT)/$<
+    go generate $(PROJECT)/$<
 
 deployments/controllerd.exe: cmd/controllerd/main.go   $(PROTO_GEN_FILES) $(VERSION_MARKER)
-	go build -o $(PROJECT)/$@ $(PROJECT)/$<
+    go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
 deployments/inventoryd.exe: cmd/inventoryd/main.go     $(PROTO_GEN_FILES) $(VERSION_MARKER)
-	go build -o $(PROJECT)/$@ $(PROJECT)/$<
+    go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
 deployments/sim_supportd.exe: cmd/sim_supportd/main.go $(PROTO_GEN_FILES) $(VERSION_MARKER)
-	go build -o $(PROJECT)/$@ $(PROJECT)/$<
+    go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
 deployments/web_server.exe: cmd/web_server/main.go     $(PROTO_GEN_FILES) $(VERSION_MARKER)
-	go build -o $(PROJECT)/$@ $(PROJECT)/$<
+    go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
 deployments/readme.md: pkg/version/version_stamp.md
-	$(CP) $(PROJECT)/$< $(PROJECT)/$@
+    $(CP) $(PROJECT)/$< $(PROJECT)/$@
 
 deployments/cloudchamber.yaml: Configs/cloudchamber.yaml
-	$(CP) $(PROJECT)/$< $(PROJECT)/$@
+    $(CP) $(PROJECT)/$< $(PROJECT)/$@
 
 deployments/start_cloud_chamber.cmd: scripts/start_cloud_chamber.cmd
-	$(CP) $(PROJECT)/$< $(PROJECT)/$@
+    $(CP) $(PROJECT)/$< $(PROJECT)/$@
 
 deployments/startetcd.cmd: scripts/startetcd.cmd
-	$(CP) $(PROJECT)/$< $(PROJECT)/$@
+    $(CP) $(PROJECT)/$< $(PROJECT)/$@
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -70,16 +70,16 @@ service_build: $(SERVICES)
 copy_to: $(ARTIFACTS)
 
 run_tests: $(PROTO_GEN_FILES) $(VERSION_MARKER)
-    go test $(PROJECT)/internal/clients/store
-    go test $(PROJECT)/internal/clients/timestamp
-    go test $(PROJECT)/internal/services/frontend
-    go test $(PROJECT)/internal/services/stepper_actor
+	go test $(PROJECT)/internal/clients/store
+	go test $(PROJECT)/internal/clients/timestamp
+	go test $(PROJECT)/internal/services/frontend
+	go test $(PROJECT)/internal/services/stepper_actor
 
 
 .PHONY : clean
 
 clean:
-    $(RM) $(SERVICES) $(ARTIFACTS) $(PROTO_GEN_FILES) $(VERSION_MARKER)
+	$(RM) $(SERVICES) $(ARTIFACTS) $(PROTO_GEN_FILES) $(VERSION_MARKER)
 
 
 .PHONY : test
@@ -88,43 +88,40 @@ test: run_tests
 
 
 %.pb.go : %.proto
-    $(PROTOC) $(PROJECT)/$<
+	$(PROTOC) $(PROJECT)/$<
 
 
 pkg/protos/monitor/monitor.pb.go: pkg/protos/monitor/monitor.proto
-    $(GRPC_PROTOC) $(PROJECT)/$<
+	$(GRPC_PROTOC) $(PROJECT)/$<
 
 pkg/protos/Stepper/stepper.pb.go: pkg/protos/Stepper/stepper.proto
-    $(GRPC_PROTOC) $(PROJECT)/$<
+	$(GRPC_PROTOC) $(PROJECT)/$<
 
 
 
 $(VERSION_MARKER) &: pkg/version/version.go
-    go generate $(PROJECT)/$<
+	go generate $(PROJECT)/$<
 
 deployments/controllerd.exe: cmd/controllerd/main.go   $(PROTO_GEN_FILES) $(VERSION_MARKER)
-    go build -o $(PROJECT)/$@ $(PROJECT)/$<
+	go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
 deployments/inventoryd.exe: cmd/inventoryd/main.go     $(PROTO_GEN_FILES) $(VERSION_MARKER)
-    go build -o $(PROJECT)/$@ $(PROJECT)/$<
+	go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
 deployments/sim_supportd.exe: cmd/sim_supportd/main.go $(PROTO_GEN_FILES) $(VERSION_MARKER)
-    go build -o $(PROJECT)/$@ $(PROJECT)/$<
+	go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
 deployments/web_server.exe: cmd/web_server/main.go     $(PROTO_GEN_FILES) $(VERSION_MARKER)
-    go build -o $(PROJECT)/$@ $(PROJECT)/$<
+	go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
 deployments/readme.md: pkg/version/version_stamp.md
-    $(CP) $(PROJECT)/$< $(PROJECT)/$@
+	$(CP) $(PROJECT)/$< $(PROJECT)/$@
 
 deployments/cloudchamber.yaml: configs/cloudchamber.yaml
-    $(CP) $(PROJECT)/$< $(PROJECT)/$@
+	$(CP) $(PROJECT)/$< $(PROJECT)/$@
 
 deployments/start_cloud_chamber.cmd: scripts/start_cloud_chamber.cmd
-    $(CP) $(PROJECT)/$< $(PROJECT)/$@
+	$(CP) $(PROJECT)/$< $(PROJECT)/$@
 
 deployments/startetcd.cmd: scripts/startetcd.cmd
-    $(CP) $(PROJECT)/$< $(PROJECT)/$@
-
-
-
+	$(CP) $(PROJECT)/$< $(PROJECT)/$@

--- a/Makefile
+++ b/Makefile
@@ -87,45 +87,9 @@ clean:
 test: run_tests
 
 
-
-pkg/protos/admin/users.pb.go : pkg/protos/admin/users.proto
+%.pb.go : %.proto
 	$(PROTOC) $(PROJECT)/$<
 
-pkg/protos/common/capacity.pb.go : pkg/protos/common/capacity.proto
-	$(PROTOC) $(PROJECT)/$<
-
-pkg/protos/common/completion.pb.go : pkg/protos/common/completion.proto
-	$(PROTOC) $(PROJECT)/$<
-
-pkg/protos/common/timestamp.pb.go : pkg/protos/common/timestamp.proto
-	$(PROTOC) $(PROJECT)/$<
-
-pkg/protos/log/entry.pb.go: pkg/protos/log/entry.proto
-	$(PROTOC) $(PROJECT)/$<
-
-pkg/protos/inventory/actual.pb.go: pkg/protos/inventory/actual.proto
-	$(PROTOC) $(PROJECT)/$<
-
-pkg/protos/inventory/external.pb.go: pkg/protos/inventory/external.proto
-	$(PROTOC) $(PROJECT)/$<
-
-pkg/protos/inventory/internal.pb.go: pkg/protos/inventory/internal.proto
-	$(PROTOC) $(PROJECT)/$<
-
-pkg/protos/inventory/target.pb.go: pkg/protos/inventory/target.proto
-	$(PROTOC) $(PROJECT)/$<
-
-pkg/protos/workload/actual.pb.go: pkg/protos/workload/actual.proto
-	$(PROTOC) $(PROJECT)/$<
-
-pkg/protos/workload/external.pb.go: pkg/protos/workload/external.proto
-	$(PROTOC) $(PROJECT)/$<
-
-pkg/protos/workload/internal.pb.go: pkg/protos/workload/internal.proto
-	$(PROTOC) $(PROJECT)/$<
-
-pkg/protos/workload/target.pb.go: pkg/protos/workload/target.proto
-	$(PROTOC) $(PROJECT)/$<
 
 pkg/protos/monitor/monitor.pb.go: pkg/protos/monitor/monitor.proto
 	$(GRPC_PROTOC) $(PROJECT)/$<
@@ -133,6 +97,10 @@ pkg/protos/monitor/monitor.pb.go: pkg/protos/monitor/monitor.proto
 pkg/protos/Stepper/stepper.pb.go: pkg/protos/Stepper/stepper.proto
 	$(GRPC_PROTOC) $(PROJECT)/$<
 
+
+
+$(VERSION_MARKER) &: pkg/version/version.go
+	go generate $(PROJECT)/$<
 
 deployments/controllerd.exe: cmd/controllerd/main.go   $(PROTO_GEN_FILES) $(VERSION_MARKER)
 	go build -o $(PROJECT)/$@ $(PROJECT)/$<
@@ -158,8 +126,5 @@ deployments/start_cloud_chamber.cmd: scripts/start_cloud_chamber.cmd
 deployments/startetcd.cmd: scripts/startetcd.cmd
 	$(CP) $(PROJECT)/$< $(PROJECT)/$@
 
-
-$(VERSION_MARKER) &: pkg/version/version.go
-	go generate $(PROJECT)/$<
 
 


### PR DESCRIPTION
Updates to the Makefile to allow the standard make "-j [<n>]" flag to enable parallel builds where possible. Mainly achieved through exhaustive dependency statements.

Removes "clean" dependency from "all" target to prevent clashes between "clean" and "build" dependencies.

Added implicit rule for protobuf compilations.

Ensures all actions have leading hard tab

Moved primary targets, such as "all" to make that the default if "make" is run without an explicit target.


So now we can build everything utilizing parallel builds, which approximately halve the build time using something like

make clean && make -j

which starts by cleaning out all the generated files and then uses the default "all" target to build everything and then run the tests.

Works on both Windows and Linux