### PR TITLE
Prepare rack list for UI integration

### DIFF
--- a/internal/services/frontend/inventory.go
+++ b/internal/services/frontend/inventory.go
@@ -1,4 +1,4 @@
-// This module containes the routines etc to implement the frontend handlers for the inventory operators
+// This module contains the routines etc to implement the frontend handlers for the inventory operators
 // part of the API
 //
 
@@ -10,59 +10,38 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/gorilla/sessions"
 
-	"github.com/Jim3Things/CloudChamber/internal/tracing"
-	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/gorilla/mux"
-)
 
-// Inventory is a representation of a specific inventory operators
-//
-//TODO This is just a placeholder until we have proper inventory definitions
-//     held in a persisted store (Etcd)
-//
-type Inventory struct {
-	Name            string
-	TimeCreation    time.Time
-	TimeLasteUpdate time.Time
-	TimeLastStep    time.Time
-	StepCount       uint64
-	Enabled         bool
-}
+	"github.com/Jim3Things/CloudChamber/internal/tracing"
+	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+	"github.com/Jim3Things/CloudChamber/pkg/protos/common"
+	pb "github.com/Jim3Things/CloudChamber/pkg/protos/inventory"
+)
 
 func inventoryAddRoutes(routeBase *mux.Router) {
 
-	routeRacks := routeBase.PathPrefix("/racks").Subrouter() //api/racks/rackid/ declared the path prefix
+	routeRacks := routeBase.PathPrefix("/racks").Subrouter()
 
-	routeRacks.HandleFunc("", handlerRacksList).Methods("GET") //handler rack list function is called for the Get method
+	routeRacks.HandleFunc("", handlerRacksList).Methods("GET")
 	routeRacks.HandleFunc("/", handlerRacksList).Methods("GET")
 
 	// In the following, the "GET" method is allowed just for the purposes of test and
-	// evaluation. At somepoint, it will need to be removed, but in the meantime, leaving
+	// evaluation. At some point, it will need to be removed, but in the meantime, leaving
 	// it there allows simple experimentation with just a browser.
 	//
 	// As a reminder,
-	//	 PUT is idempotent so translates to UPDATE in the CRUD methodolgy
-	//   POST is NOT idempotent so translates to CREATE in the CRUD methodolgy
+	//	 PUT is idempotent so translates to UPDATE in the CRUD methodology
+	//   POST is NOT idempotent so translates to CREATE in the CRUD methodology
 	//
-	//routeRacks.HandleFunc("/racks/{rackid}", handlerRacksCreate).Methods("POST", "GET") // May be only GET
-	routeRacks.HandleFunc("/{rackid}", handlerRackRead).Methods("GET")
-	routeRacks.HandleFunc("/{rackid}/blades", handlerBladesList).Methods("GET")
-	routeRacks.HandleFunc("/{rackid}/blades/{bladeid}", handlerBladeRead).Methods("GET")
-	//routeRacks.HandleFunc("/racks/{rackid}", handlerRacksDelete).Methods("DELETE", "GET")
-}
-
-func racksDisplayArguments(w http.ResponseWriter, r *http.Request, command string) {
-
-	vars := mux.Vars(r)
-
-	racks := vars["rackid"]
-
-	fmt.Fprintf(w, "racks: %v command: %v", racks, command)
+	// routeRacks.HandleFunc("/racks/{rackID}", handlerRacksCreate).Methods("POST", "GET") // May be only GET
+	routeRacks.HandleFunc("/{rackID}", handlerRackRead).Methods("GET")
+	routeRacks.HandleFunc("/{rackID}/blades", handlerBladesList).Methods("GET")
+	routeRacks.HandleFunc("/{rackID}/blades/{bladeID}", handlerBladeRead).Methods("GET")
+	// routeRacks.HandleFunc("/racks/{rackID}", handlerRacksDelete).Methods("DELETE", "GET")
 }
 
 func handlerRacksList(w http.ResponseWriter, r *http.Request) {
@@ -75,29 +54,49 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 			return httpError(ctx, w, err)
 		}
 
-		if _, err := fmt.Fprintln(w, "Racks (List)"); err != nil {
-			return httpError(ctx, w, err)
+		w.Header().Set("Content-Type", "application/json")
+
+		maxBlades, maxCapacity := dbInventory.GetMemoData()
+		res := &pb.ExternalZoneSummary{
+			Racks:         make(map[string]*pb.ExternalRackSummary),
+			MaxBladeCount: maxBlades,
+			MaxCapacity:   maxCapacity,
 		}
+
+		st.Infof(
+			ctx,
+			tick(),
+			"Listing all %d racks, max blades/rack=%d, max blade capacity=%v",
+			len(res.Racks),
+			res.MaxBladeCount,
+			res.MaxCapacity)
 
 		b := r.URL.String()
 		if !strings.HasSuffix(b, "/") {
 			b += "/"
 		}
 
-		return dbInventory.Scan(func(name string) (err error) {
+		err = dbInventory.Scan(func(name string, memo *common.BladeCapacity) (err error) {
 			target := fmt.Sprintf("%s%s", b, name)
 
-			st.Infof(ctx, -1, "   Listing rack '%s' at '%s'", name, target)
-
-			if _, err = fmt.Fprintln(w, target); err != nil {
-				return httpError(ctx, w, err)
+			res.Racks[name] = &pb.ExternalRackSummary{
+				Name: name,
+				Uri:  target,
 			}
+
+			st.Infof(ctx, tick(), "   Listing rack %q at %q", name, target)
 
 			return nil
 		})
-	})
+		if err != nil {
+			return httpError(ctx, w, err)
+		}
 
+		p := jsonpb.Marshaler{}
+		return p.Marshal(w, res)
+	})
 }
+
 func handlerRackRead(w http.ResponseWriter, r *http.Request) {
 	_ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
 		err = doSessionHeader(ctx, w, r, func(_ context.Context, session *sessions.Session) error {
@@ -108,24 +107,24 @@ func handlerRackRead(w http.ResponseWriter, r *http.Request) {
 		}
 
 		vars := mux.Vars(r)
-		rackid := vars["rackid"]
+		rackID := vars["rackID"]
 
-		u, err := dbInventory.Get(rackid)
+		u, err := dbInventory.Get(rackID)
 		if err != nil {
 			return httpError(ctx, w, err)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 
-		st.Infof(ctx, -1, "Returning details for rack %q: %v", rackid, u)
+		st.Infof(ctx, tick(), "Returning details for rack %q: %v", rackID, u)
 
 		// Get the user entry, and serialize it to json
 		// (export userPublic to json and return that as the body)
 		p := jsonpb.Marshaler{}
 		return p.Marshal(w, u)
-
 	})
 }
+
 func handlerBladesList(w http.ResponseWriter, r *http.Request) {
 	_ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
 		err = doSessionHeader(ctx, w, r, func(_ context.Context, session *sessions.Session) error {
@@ -136,28 +135,28 @@ func handlerBladesList(w http.ResponseWriter, r *http.Request) {
 		}
 
 		vars := mux.Vars(r)
-		rackid := vars["rackid"] // captured the key value in rackid variable
+		rackID := vars["rackID"] // captured the key value in rackID variable
 
-		if _, err := fmt.Fprintf(w, "Blades in %q (List)\n", rackid); err != nil {
+		if _, err = fmt.Fprintf(w, "Blades in %q (List)\n", rackID); err != nil {
 			return httpError(ctx, w, err)
 		}
 		b := r.URL.String()
 		if !strings.HasSuffix(b, "/") {
 			b += "/"
 		}
-		return dbInventory.ScanBladesInRack(rackid, func(bladeid int64) error {
+		return dbInventory.ScanBladesInRack(rackID, func(bladeID int64) error {
 
-			target := fmt.Sprintf("%s%d", b, bladeid)
-			st.Infof(ctx, -1, " Listing blades '%d' at %q", bladeid, target)
+			target := fmt.Sprintf("%s%d", b, bladeID)
+			st.Infof(ctx, tick(), " Listing blades '%d' at %q", bladeID, target)
 
 			if _, err = fmt.Fprintln(w, target); err != nil {
 				return httpError(ctx, w, err)
 			}
 			return nil
 		})
-
 	})
 }
+
 func handlerBladeRead(w http.ResponseWriter, r *http.Request) {
 	_ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
 		err = doSessionHeader(ctx, w, r, func(_ context.Context, session *sessions.Session) error {
@@ -168,26 +167,25 @@ func handlerBladeRead(w http.ResponseWriter, r *http.Request) {
 		}
 
 		vars := mux.Vars(r)
-		rackid := vars["rackid"]
-		bladeName := vars["bladeid"]
+		rackID := vars["rackID"]
+		bladeName := vars["bladeID"]
 
 		w.Header().Set("Content-Type", "application/json")
 
-		bladeid, err := strconv.ParseInt(bladeName, 10, 64)
+		bladeID, err := strconv.ParseInt(bladeName, 10, 64)
 		if err != nil {
 			return httpError(ctx, w, &HTTPError{
 				SC:   http.StatusBadRequest,
 				Base: err,
 			})
 		}
-		blade, err := dbInventory.GetBlade(rackid, bladeid)
+		blade, err := dbInventory.GetBlade(rackID, bladeID)
 		if err != nil {
 			return httpError(ctx, w, err)
 		}
-		st.Infof(ctx, -1, "Returning details for blade %d  in rack %q:  %v", bladeid, rackid, blade)
+		st.Infof(ctx, tick(), "Returning details for blade %d  in rack %q:  %v", bladeID, rackID, blade)
 
 		p := jsonpb.Marshaler{}
 		return p.Marshal(w, blade)
 	})
-
 }

--- a/pkg/protos/inventory/external.proto
+++ b/pkg/protos/inventory/external.proto
@@ -38,10 +38,42 @@ message external {
         // specify the blades in the rack.  Each blade is defined by an integer index within that rack, which is used
         // here as the key.
         map<int64, common.blade_capacity> blades = 3;
+
+        // max_blade_capacity is a cached summary of the maximum values for
+        // each of the blade capacity values.  This can be used to size any
+        // collective values, such as having the UI frame the zone visually
+        common.blade_capacity max_blade_capacity = 4;
     }
 
     // Finally, a zone is a collection of racks.  Each rack has a name, which is used as a key in the map below.
     message zone {
         map<string, rack> racks = 1;
+        int64 max_blade_count = 2;
+        common.blade_capacity max_capacity = 3;
+    }
+
+    // The following messages are used to format JSON strings for use by
+    // external callers.  These contain memoized calculations that are likely
+    // to be needed by the common callers.
+
+    // Rack list entry item
+    message rack_summary {
+        // Friendly name for the rack
+        string name = 1;
+
+        // host relative URI that can be used to retrieve its details
+        string uri = 2;
+    }
+
+    // Summary of the full inventory
+    message zone_summary {
+        // Summary information about all known racks
+        map<string, rack_summary> racks = 1;
+
+        // The largest number of blades held in any rack
+        int64 max_blade_count = 2;
+
+        // The largest capacity values found in any blade
+        common.blade_capacity max_capacity = 3;
     }
 }


### PR DESCRIPTION
This changes the way that rack list works so that the UI has more information to go on early in the process to determine overall graph size and suchlike.

Manpreet, can you look this over and see if it makes sense to you?  Thanks.

Add memoized summary information to rack list
Convert rack list results to json
Add actual tick count to trace entries
Dead code removal
Unit and E2E test update