### PR TITLE
Streamline the memo state

### DIFF
--- a/internal/services/frontend/DBInventory.go
+++ b/internal/services/frontend/DBInventory.go
@@ -26,6 +26,8 @@ import (
 type DBInventory struct {
 	Mutex sync.Mutex
 	Zone *pb.ExternalZone
+	MaxBladeCount int64
+	MaxCapacity *common.BladeCapacity
 }
 
 var dbInventory *DBInventory
@@ -42,9 +44,10 @@ func InitDBInventory() error {
 		dbInventory = &DBInventory{
 			Mutex: sync.Mutex{},
 			Zone: &pb.ExternalZone{
-				Racks:         make(map[string]*pb.ExternalRack),
-				MaxCapacity: &common.BladeCapacity{},
+				Racks:       make(map[string]*pb.ExternalRack),
 			},
+			MaxBladeCount: 0,
+			MaxCapacity: &common.BladeCapacity{},
 		}
 
 		dbInventory.Zone.Racks["rack1"] = &pb.ExternalRack{
@@ -107,17 +110,17 @@ func (m *DBInventory) GetMemoData() (int64, *common.BladeCapacity) {
 	m.Mutex.Lock()
 	defer m.Mutex.Unlock()
 
-	return m.Zone.MaxBladeCount, m.Zone.MaxCapacity
+	return m.MaxBladeCount, m.MaxCapacity
 }
 
 // Scan the set of known blades the store, invoking the supplied
 // function with each entry.
-func (m *DBInventory) Scan(action func(entry string, memo *common.BladeCapacity) error) error {
+func (m *DBInventory) Scan(action func(entry string) error) error {
 	m.Mutex.Lock()
 	defer m.Mutex.Unlock()
 
-	for name, rack := range dbInventory.Zone.Racks {
-		if err := action(name, rack.MaxBladeCapacity); err != nil {
+	for name := range dbInventory.Zone.Racks {
+		if err := action(name); err != nil {
 			return err
 		}
 	}
@@ -181,11 +184,10 @@ func (m *DBInventory) GetBlade(rackID string, bladeID int64) (*common.BladeCapac
 // buildSummary constructs the memo-ed summary data for the zone.  This should
 // be called whenever the configured inventory changes.
 func (m *DBInventory) buildSummary() {
-	m.Zone.MaxBladeCount = 0
+	m.MaxBladeCount = 0
 
 	memo := &common.BladeCapacity{}
 	for _, rack := range m.Zone.Racks {
-
 		for _, blade := range rack.Blades {
 			memo.Cores = maxInt64(memo.Cores, blade.Cores)
 			memo.DiskInGb = maxInt64(memo.DiskInGb, blade.DiskInGb)
@@ -195,13 +197,12 @@ func (m *DBInventory) buildSummary() {
 				blade.NetworkBandwidthInMbps)
 		}
 
-		m.Zone.MaxCapacity = memo
-		m.Zone.MaxBladeCount = maxInt64(
-			m.Zone.MaxBladeCount,
+		m.MaxBladeCount = maxInt64(
+			m.MaxBladeCount,
 			int64(len(rack.Blades)))
-
-		rack.MaxBladeCapacity = memo
 	}
+
+	m.MaxCapacity = memo
 }
 
 // maxInt64 is a helper function to return the maximum of two int64 values

--- a/internal/services/frontend/inventory.go
+++ b/internal/services/frontend/inventory.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/Jim3Things/CloudChamber/internal/tracing"
 	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
-	"github.com/Jim3Things/CloudChamber/pkg/protos/common"
 	pb "github.com/Jim3Things/CloudChamber/pkg/protos/inventory"
 )
 
@@ -76,13 +75,10 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 			b += "/"
 		}
 
-		err = dbInventory.Scan(func(name string, memo *common.BladeCapacity) (err error) {
+		err = dbInventory.Scan(func(name string) (err error) {
 			target := fmt.Sprintf("%s%s", b, name)
 
-			res.Racks[name] = &pb.ExternalRackSummary{
-				Name: name,
-				Uri:  target,
-			}
+			res.Racks[name] = &pb.ExternalRackSummary{ Uri:  target	}
 
 			st.Infof(ctx, tick(), "   Listing rack %q at %q", name, target)
 

--- a/internal/services/frontend/inventory_test.go
+++ b/internal/services/frontend/inventory_test.go
@@ -44,12 +44,10 @@ func TestInventoryListRacks(t *testing.T) {
 
 	r, ok := list.Racks["rack1"]
 	assert.True(t, ok)
-	assert.Equal(t, "rack1", r.Name)
 	assert.Equal(t, "/api/racks/rack1", r.Uri)
 
 	r, ok = list.Racks["rack2"]
 	assert.True(t, ok)
-	assert.Equal(t, "rack2", r.Name)
 	assert.Equal(t, "/api/racks/rack2", r.Uri)
 
 	doLogout(t, randomCase(adminAccountName), response.Cookies())

--- a/pkg/protos/inventory/external.proto
+++ b/pkg/protos/inventory/external.proto
@@ -38,18 +38,11 @@ message external {
         // specify the blades in the rack.  Each blade is defined by an integer index within that rack, which is used
         // here as the key.
         map<int64, common.blade_capacity> blades = 3;
-
-        // max_blade_capacity is a cached summary of the maximum values for
-        // each of the blade capacity values.  This can be used to size any
-        // collective values, such as having the UI frame the zone visually
-        common.blade_capacity max_blade_capacity = 4;
     }
 
     // Finally, a zone is a collection of racks.  Each rack has a name, which is used as a key in the map below.
     message zone {
         map<string, rack> racks = 1;
-        int64 max_blade_count = 2;
-        common.blade_capacity max_capacity = 3;
     }
 
     // The following messages are used to format JSON strings for use by
@@ -58,11 +51,8 @@ message external {
 
     // Rack list entry item
     message rack_summary {
-        // Friendly name for the rack
-        string name = 1;
-
         // host relative URI that can be used to retrieve its details
-        string uri = 2;
+        string uri = 1;
     }
 
     // Summary of the full inventory


### PR DESCRIPTION
- Removed the stale memo state entries from the ExternalRack message
- Removed the redundant rack name from the ExternalRackSummary message (the name is held as the key in the map).  Retained the ExternalRackSummary struct for future expansion.
- Moved the Zone memo fields out of the proto and into the DBInventory struct definition.  This reflects that the memo data is purely internal and in-memory, so there is no need for it to be in the proto.