### PR TITLE
Bugfixes and span propagation

### DIFF
--- a/internal/services/stepper_actor/actor.go
+++ b/internal/services/stepper_actor/actor.go
@@ -62,7 +62,7 @@ func Register(svc *grpc.Server, p pb.StepperPolicy) (err error) {
 
     // Finally, if there is a default policy provided, set it now.
     if p != pb.StepperPolicy_Invalid {
-        if err := act.adapter.SetDefaultPolicy(p); err != nil {
+        if err = act.adapter.SetDefaultPolicy(p); err != nil {
             return err
         }
     }

--- a/internal/services/tracing_sink/sink.go
+++ b/internal/services/tracing_sink/sink.go
@@ -9,6 +9,7 @@ import (
     "context"
     "fmt"
     "sync"
+    "time"
 
     "google.golang.org/grpc"
 
@@ -97,7 +98,7 @@ func (s *server) addEntry(entry *log.Entry) {
         s.firstId = s.entries.Front().Value.(listEntry).id
     }
 
-    fmt.Printf("%d(%d): %v\n\n", s.lastId, s.entries.Len(), entry)
+    fmt.Printf("%s: %d(%d): %v\n\n", time.Now().Format(time.RFC822), s.lastId, s.entries.Len(), entry)
     s.lastId++
 }
 

--- a/internal/tracing/client/tracing.go
+++ b/internal/tracing/client/tracing.go
@@ -25,12 +25,12 @@ func Interceptor(ctx context.Context, method string, req, reply interface{}, cc 
 	ctx = metadata.NewOutgoingContext(ctx, metadataCopy)
 
 	err := invoker(ctx, method, req, reply, cc, opts...)
-	setTraceStatus(span, err)
+	setTraceStatus(ctx, span, err)
 
 	return err
 }
 
-func setTraceStatus(span trace.Span, err error) {
+func setTraceStatus(ctx context.Context, span trace.Span, err error) {
 	// Spans assume a status of "OK", so we only need to update the
 	// status if it is an error.
 	if err != nil {
@@ -41,7 +41,7 @@ func setTraceStatus(span trace.Span, err error) {
 			code = codes.InvalidArgument
 		}
 
-		span.SetStatus(code, "returned error")
+		span.RecordError(ctx, err, trace.WithErrorStatus(code))
 	} else {
 		span.SetStatus(codes.OK, "OK")
 	}

--- a/internal/tracing/constants.go
+++ b/internal/tracing/constants.go
@@ -8,5 +8,10 @@ const (
 	SeverityKey     = "cc-severity"
 
 	// Header keys, used to add context on the way to the actor
-	LinkingSpanID = "cc-link-to"
+	LinkingSpanID   = "cc-link-to"
+
+	// Envelope keys
+	SourceTraceID   = "cc-starting-span-trace-id"
+	SourceSpanID    = "cc-starting-span-span-id"
+	SourceTraceFlgs = "cc-starting-span-trace-flags"
 )

--- a/internal/tracing/exporters/io_writer/exporter.go
+++ b/internal/tracing/exporters/io_writer/exporter.go
@@ -58,7 +58,7 @@ var (
 // SetLogFileWriter establishes the IO writer to use to output the trace entries.
 // Any deferred trace entries are written at this time.
 func SetLogFileWriter(writer io.Writer) error {
-	if state == notInitialized {
+	if state == noExporterRequested {
 		// This trace exporter has not been chosen, ignore this call
 		return nil
 	}


### PR DESCRIPTION
- IO Writer trace exporter was not writing to the output file due to a bad state check
- Temporary trace writing in the trace sink now has the timestamp of when the entry was written to stdout
- Span contexts are now propagated from the grpc adaptor to the stepper actor.