### PR TITLE
linter/inspection changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+indent_size = 4
+max_line_length = 120
+tab_width = 4
+
+[*.{less, yml}]
+indent_style = space
+indent_size = 2

--- a/internal/clients/store/store.go
+++ b/internal/clients/store/store.go
@@ -67,23 +67,23 @@
 package store
 
 import (
-	"context"
-	"fmt"
-	"log"
-	"strings"
-	"sync"
-	"time"
+    "context"
+    "fmt"
+    "log"
+    "strings"
+    "sync"
+    "time"
 
-	"github.com/Jim3Things/CloudChamber/internal/config"
-	"github.com/Jim3Things/CloudChamber/internal/tracing"
-	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+    "github.com/Jim3Things/CloudChamber/internal/config"
+    "github.com/Jim3Things/CloudChamber/internal/tracing"
+    st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 
-	"go.etcd.io/etcd/clientv3"
-	"go.etcd.io/etcd/clientv3/concurrency"
-	ns "go.etcd.io/etcd/clientv3/namespace"
-	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+    "go.etcd.io/etcd/clientv3"
+    "go.etcd.io/etcd/clientv3/concurrency"
+    ns "go.etcd.io/etcd/clientv3/namespace"
+    "go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
+    "google.golang.org/grpc/codes"
+    "google.golang.org/grpc/status"
 )
 
 // All CloudChamber key-value pairs are stored under a common namespace root.
@@ -94,9 +94,9 @@ import (
 // At no time can the root namespace be removed.
 //
 const (
-	slash                 = "/"
-	cloudChamberNamespace = string("/CloudChamber/v0.1")
-	testNamespaceSuffix   = string("Test")
+    slash                 = "/"
+    cloudChamberNamespace = string("/CloudChamber/v0.1")
+    testNamespaceSuffix   = string("Test")
 )
 
 // TraceFlags is the type used when setting of fetching the relevant flags
@@ -104,47 +104,47 @@ const (
 type TraceFlags uint
 
 const (
-	traceFlagEnabled TraceFlags = 1 << iota
-	traceFlagExpandResults
-	traceFlagTraceKey
-	traceFlagTraceKeyAndValue
-	traceFlagExpandResultsInTest
+    traceFlagEnabled TraceFlags = 1 << iota
+    traceFlagExpandResults
+    traceFlagTraceKey
+    traceFlagTraceKeyAndValue
+    traceFlagExpandResultsInTest
 )
 
 type global struct {
-	Stores     map[string]Store
-	StoreMutex sync.Mutex
+    Stores     map[string]Store
+    StoreMutex sync.Mutex
 
-	DefaultTimeoutConnect  time.Duration
-	DefaultTimeoutRequest  time.Duration
-	DefaultEndpoints       []string
-	DefaultTraceFlags      TraceFlags
-	DefaultNamespaceSuffix string
+    DefaultTimeoutConnect  time.Duration
+    DefaultTimeoutRequest  time.Duration
+    DefaultEndpoints       []string
+    DefaultTraceFlags      TraceFlags
+    DefaultNamespaceSuffix string
 }
 
 // Store is a struct used to collect all the interesting state values associated with
 // communicating with an instance of the store
 //
 type Store struct {
-	Endpoints         []string
-	TimeoutConnect    time.Duration
-	TimeoutRequest    time.Duration
-	Mutex             sync.Mutex
-	Client            *clientv3.Client
-	UnprefixedKV      clientv3.KV
-	UnprefixedWatcher clientv3.Watcher
-	UnprefixedLease   clientv3.Lease
-	Namespace         string
-	NamespaceSuffix   string
-	TraceFlags        TraceFlags
+    Endpoints         []string
+    TimeoutConnect    time.Duration
+    TimeoutRequest    time.Duration
+    Mutex             sync.Mutex
+    Client            *clientv3.Client
+    UnprefixedKV      clientv3.KV
+    UnprefixedWatcher clientv3.Watcher
+    UnprefixedLease   clientv3.Lease
+    Namespace         string
+    NamespaceSuffix   string
+    TraceFlags        TraceFlags
 }
 
 // KeyValueArg is a struct used to describe one or more key/value pairs supplied
 // to a call such as WriteMultiple()
 //
 type KeyValueArg struct {
-	key   string
-	value string
+    key   string
+    value string
 }
 
 // KeyValueResponse is a struct used to describe one or more key/value pairs
@@ -152,109 +152,109 @@ type KeyValueArg struct {
 // call.
 //
 type KeyValueResponse struct {
-	key   string
-	value []byte
+    key   string
+    value []byte
 }
 
 var (
-	storeRoot global
+    storeRoot global
 )
 
 func (store *Store) traceEnabled() bool { return store.TraceFlags != 0 }
 
 func (store *Store) trace(v TraceFlags) (result bool) {
 
-	if v&traceFlagEnabled == traceFlagEnabled {
-		return store.traceEnabled()
-	}
+    if v&traceFlagEnabled == traceFlagEnabled {
+        return store.traceEnabled()
+    }
 
-	if v&store.TraceFlags != 0 {
-		return true
-	}
+    if v&store.TraceFlags != 0 {
+        return true
+    }
 
-	return false
+    return false
 }
 
 func getDefaultEndpoints() []string {
-	return storeRoot.DefaultEndpoints
+    return storeRoot.DefaultEndpoints
 }
 
 func getDefaultTimeoutConnect() time.Duration {
-	return storeRoot.DefaultTimeoutConnect
+    return storeRoot.DefaultTimeoutConnect
 }
 
 func getDefaultTimeoutRequest() time.Duration {
-	return storeRoot.DefaultTimeoutRequest
+    return storeRoot.DefaultTimeoutRequest
 }
 
 func getDefaultTraceFlags() TraceFlags {
-	return storeRoot.DefaultTraceFlags
+    return storeRoot.DefaultTraceFlags
 }
 
 func getDefaultNamespaceSuffix() string {
-	return storeRoot.DefaultNamespaceSuffix
+    return storeRoot.DefaultNamespaceSuffix
 }
 
 func setDefaultNamespaceSuffix(suffix string) {
-	storeRoot.DefaultNamespaceSuffix = suffix
+    storeRoot.DefaultNamespaceSuffix = suffix
 }
 
 func (store *Store) connected(ctx context.Context) error {
 
-	if nil != store.Client {
-		err := ErrStoreConnected
-		_ = st.Errorf(ctx, -1, "unable to perform operation - store is connected - error: %v", err)
-		return err
-	}
+    if nil != store.Client {
+        err := ErrStoreConnected
+        _ = st.Errorf(ctx, -1, "unable to perform operation - store is connected - error: %v", err)
+        return err
+    }
 
-	return nil
+    return nil
 }
 
 func (store *Store) disconnected(ctx context.Context) error {
 
-	if nil == store.Client {
-		err := ErrStoreNotConnected
-		_ = st.Errorf(ctx, -1, "unable to perform operation - no current connection - error: %v", err)
-		return err
-	}
+    if nil == store.Client {
+        err := ErrStoreNotConnected
+        _ = st.Errorf(ctx, -1, "unable to perform operation - no current connection - error: %v", err)
+        return err
+    }
 
-	return nil
+    return nil
 }
 
 // Initialize is a method used to initialise the basic global state used to access
 // the back-end db service.
 //
 func Initialize(cfg *config.GlobalConfig) {
-	_ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		storeRoot.DefaultEndpoints = []string {
-			fmt.Sprintf("%s:%d", cfg.Store.EtcdService.Hostname, cfg.Store.EtcdService.Port),
-		}
+    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        storeRoot.DefaultEndpoints = []string {
+            fmt.Sprintf("%s:%d", cfg.Store.EtcdService.Hostname, cfg.Store.EtcdService.Port),
+        }
 
-		storeRoot.DefaultTimeoutConnect = time.Duration(cfg.Store.ConnectTimeout) * time.Second
-		storeRoot.DefaultTimeoutRequest = time.Duration(cfg.Store.RequestTimeout) * time.Second
-		storeRoot.DefaultTraceFlags = TraceFlags(cfg.Store.TraceLevel)
-		storeRoot.DefaultNamespaceSuffix = ""
+        storeRoot.DefaultTimeoutConnect = time.Duration(cfg.Store.ConnectTimeout) * time.Second
+        storeRoot.DefaultTimeoutRequest = time.Duration(cfg.Store.RequestTimeout) * time.Second
+        storeRoot.DefaultTraceFlags = TraceFlags(cfg.Store.TraceLevel)
+        storeRoot.DefaultNamespaceSuffix = ""
 
-		st.Infof(
-			ctx,
-			-1,
-			"EP: %v TimeoutConnect: %v TimeoutRequest: %v DefTrcFlags: %v NsSuffix: %v",
-			storeRoot.DefaultEndpoints,
-			storeRoot.DefaultTimeoutConnect,
-			storeRoot.DefaultTimeoutRequest,
-			storeRoot.DefaultTraceFlags,
-			storeRoot.DefaultNamespaceSuffix)
+        st.Infof(
+            ctx,
+            -1,
+            "EP: %v TimeoutConnect: %v TimeoutRequest: %v DefTrcFlags: %v NsSuffix: %v",
+            storeRoot.DefaultEndpoints,
+            storeRoot.DefaultTimeoutConnect,
+            storeRoot.DefaultTimeoutRequest,
+            storeRoot.DefaultTraceFlags,
+            storeRoot.DefaultNamespaceSuffix)
 
-		// See if any part of the test namespace requires initialization and optionally cleaning.
-		//
-		// NOTE: This only affects the test namespace, not the production namespace. Ideally it
-		//       would not be here but the store is used by other services as part of their test
-		//       operation and so this feature needs to be in common code.
-		//
-		PrepareTestNamespace(ctx, cfg)
+        // See if any part of the test namespace requires initialization and optionally cleaning.
+        //
+        // NOTE: This only affects the test namespace, not the production namespace. Ideally it
+        //       would not be here but the store is used by other services as part of their test
+        //       operation and so this feature needs to be in common code.
+        //
+        PrepareTestNamespace(ctx, cfg)
 
-		return nil
-	})
+        return nil
+    })
 }
 
 // PrepareTestNamespace will prepare the store to be used for test purposes. Optionally, this will
@@ -265,70 +265,71 @@ func Initialize(cfg *config.GlobalConfig) {
 //       data related operations have taken place.
 //
 func PrepareTestNamespace(ctx context.Context, cfg *config.GlobalConfig) {
-	if !cfg.Store.Test.UseTestNamespace {
-		return
-	}
+    if !cfg.Store.Test.UseTestNamespace {
+        return
+    }
 
-	// It is meaningless to have both a unique per-instance test namespace
-	// and to clean the store before the tests are run
-	//
-	if cfg.Store.Test.UseUniqueInstance && cfg.Store.Test.PreCleanStore {
-		log.Fatalf("invalid configuration: : %v",
-			ErrStoreInvalidConfiguration("both UseUniqueInstance and PreCleanStore are enabled"))
-	}
+    // It is meaningless to have both a unique per-instance test namespace
+    // and to clean the store before the tests are run
+    //
+    if cfg.Store.Test.UseUniqueInstance && cfg.Store.Test.PreCleanStore {
+        st.Fatalf(ctx, -1,
+            "invalid configuration: : %v",
+            ErrStoreInvalidConfiguration("both UseUniqueInstance and PreCleanStore are enabled"))
+    }
 
-	// For test purposes, need to set an alternate namespace rather than
-	// rely on the standard. From the configuration, we can either use the
-	// standard, fixed, well-known prefix, or we can use a per-instance
-	// unique prefix derived from the current time
-	//
-	testNamespace := testNamespaceSuffix
+    // For test purposes, need to set an alternate namespace rather than
+    // rely on the standard. From the configuration, we can either use the
+    // standard, fixed, well-known prefix, or we can use a per-instance
+    // unique prefix derived from the current time
+    //
+    testNamespace := testNamespaceSuffix
 
-	if cfg.Store.Test.UseUniqueInstance {
-		testNamespace += fmt.Sprintf("/%s", time.Now().Format(time.RFC3339Nano))
-	} else {
-		testNamespace += "/Standard"
-	}
+    if cfg.Store.Test.UseUniqueInstance {
+        testNamespace += fmt.Sprintf("/%s", time.Now().Format(time.RFC3339Nano))
+    } else {
+        testNamespace += "/Standard"
+    }
 
-	st.Infof(ctx, -1, "Configured to use test namespace %q", testNamespace)
+    st.Infof(ctx, -1, "Configured to use test namespace %q", testNamespace)
 
-	if cfg.Store.Test.PreCleanStore {
+    if cfg.Store.Test.PreCleanStore {
 
-		st.Infof(ctx, -1, "Starting store pre-clean of namespace %q", testNamespace)
+        st.Infof(ctx, -1, "Starting store pre-clean of namespace %q", testNamespace)
 
-		if err := cleanNamespace(testNamespace); err != nil {
-			msg := fmt.Sprintf("failed to pre-clean the store as requested - namespace: %s err: %v", testNamespace, err)
+        if err := cleanNamespace(testNamespace); err != nil {
+            st.Fatalf(
+                ctx, -1,
+                "failed to pre-clean the store as requested - namespace: %s err: %v",
+                testNamespace, err)
+        }
+    }
 
-			_ = st.Errorf(ctx, -1, msg)
-			log.Fatalf(msg)
-		}
-	}
-
-	setDefaultNamespaceSuffix(testNamespace)
+    setDefaultNamespaceSuffix(testNamespace)
 }
 
 func cleanNamespace(testNamespace string) error {
-	store := NewStore()
+    store := NewStore()
 
-	if store == nil {
-		log.Fatalf("unable to allocate store context for pre-cleanup")
-	}
+    if store == nil {
+        log.Fatal("unable to allocate store context for pre-cleanup")
+    }
 
-	if err := store.SetNamespaceSuffix(""); err != nil {
-		return err
-	}
+    if err := store.SetNamespaceSuffix(""); err != nil {
+        return err
+    }
 
-	if err := store.Connect(); err != nil {
-		return err
-	}
+    if err := store.Connect(); err != nil {
+        return err
+    }
 
-	if err := store.DeleteWithPrefix(testNamespace); err != nil {
-		return err
-	}
+    if err := store.DeleteWithPrefix(testNamespace); err != nil {
+        return err
+    }
 
-	store.Disconnect()
+    store.Disconnect()
 
-	return nil
+    return nil
 }
 
 // NewStore is a method to allocate a new Store struct using the
@@ -341,13 +342,13 @@ func cleanNamespace(testNamespace string) error {
 // providing the store has not yet connected to the back-end db service.
 //
 func NewStore() *Store {
-	return New(
-		getDefaultEndpoints(),
-		getDefaultTimeoutConnect(),
-		getDefaultTimeoutRequest(),
-		getDefaultTraceFlags(),
-		getDefaultNamespaceSuffix(),
-	)
+    return New(
+        getDefaultEndpoints(),
+        getDefaultTimeoutConnect(),
+        getDefaultTimeoutRequest(),
+        getDefaultTraceFlags(),
+        getDefaultNamespaceSuffix(),
+    )
 }
 
 // New is a method supplied values. These values can later be overridden with
@@ -359,85 +360,85 @@ func NewStore() *Store {
 // providing the store has not yet connected to the back-end db service.
 //
 func New(
-		endpoints []string,
-		timeoutConnect time.Duration,
-		timeoutRequest time.Duration,
-		traceFlags TraceFlags,
-		namespace string) *Store {
-	store := &Store{
-		Endpoints:       endpoints,
-		TimeoutConnect:  timeoutConnect,
-		TimeoutRequest:  timeoutRequest,
-		TraceFlags:      traceFlags,
-		NamespaceSuffix: namespace,
-	}
+        endpoints []string,
+        timeoutConnect time.Duration,
+        timeoutRequest time.Duration,
+        traceFlags TraceFlags,
+        namespace string) *Store {
+    store := &Store{
+        Endpoints:       endpoints,
+        TimeoutConnect:  timeoutConnect,
+        TimeoutRequest:  timeoutRequest,
+        TraceFlags:      traceFlags,
+        NamespaceSuffix: namespace,
+    }
 
-	return store
+    return store
 }
 
 // Initialize is a method used to initialize a specific instance of a Store struct.
 //
 func (store *Store) Initialize(
-		endpoints []string,
-		timeoutConnect time.Duration,
-		timeoutRequest time.Duration,
-		traceFlags TraceFlags,
-		namespaceSuffix string) error {
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		if err = store.connected(ctx); err != nil {
-			return err
-		}
+        endpoints []string,
+        timeoutConnect time.Duration,
+        timeoutRequest time.Duration,
+        traceFlags TraceFlags,
+        namespaceSuffix string) error {
+    return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.connected(ctx); err != nil {
+            return err
+        }
 
-		if err = store.SetAddress(endpoints); err != nil {
-			return err
-		}
+        if err = store.SetAddress(endpoints); err != nil {
+            return err
+        }
 
-		if err = store.SetTimeoutConnect(timeoutConnect); err != nil {
-			return err
-		}
+        if err = store.SetTimeoutConnect(timeoutConnect); err != nil {
+            return err
+        }
 
-		if err = store.SetTimeoutRequest(timeoutRequest); err != nil {
-			return err
-		}
+        if err = store.SetTimeoutRequest(timeoutRequest); err != nil {
+            return err
+        }
 
-		store.SetTraceFlags(traceFlags)
+        store.SetTraceFlags(traceFlags)
 
-		if err = store.SetNamespaceSuffix(namespaceSuffix); err != nil {
-			return err
-		}
+        if err = store.SetNamespaceSuffix(namespaceSuffix); err != nil {
+            return err
+        }
 
 
-		store.Client = nil
-		return nil
-	})
+        store.Client = nil
+        return nil
+    })
 }
 
 func (store *Store) logEtcdResponseError(ctx context.Context, err error) {
-	if store.traceEnabled() {
-		switch err {
-		case context.Canceled:
-			_ = st.Errorf(ctx, -1, "ctx is canceled by another routine: %v", err)
+    if store.traceEnabled() {
+        switch err {
+        case context.Canceled:
+            _ = st.Errorf(ctx, -1, "ctx is canceled by another routine: %v", err)
 
-		case context.DeadlineExceeded:
-			_ = st.Errorf(ctx, -1, "ctx is attached with a deadline is exceeded: %v", err)
+        case context.DeadlineExceeded:
+            _ = st.Errorf(ctx, -1, "ctx is attached with a deadline is exceeded: %v", err)
 
-		case rpctypes.ErrEmptyKey:
-			_ = st.Errorf(ctx, -1, "client-side error: %v", err)
+        case rpctypes.ErrEmptyKey:
+            _ = st.Errorf(ctx, -1, "client-side error: %v", err)
 
-		default:
-			if ev, ok := status.FromError(err); ok {
-				code := ev.Code()
-				if code == codes.DeadlineExceeded {
-					// server-side context might have timed-out first (due to clock skew)
-					// while original client-side context is not timed-out yet
-					//
-					_ = st.Errorf(ctx, -1, "server-side deadline is exceeded: %v", code)
-				}
-			} else {
-				_ = st.Errorf(ctx, -1, "bad cluster endpoints, which are not etcd servers: %v", err)
-			}
-		}
-	}
+        default:
+            if ev, ok := status.FromError(err); ok {
+                code := ev.Code()
+                if code == codes.DeadlineExceeded {
+                    // server-side context might have timed-out first (due to clock skew)
+                    // while original client-side context is not timed-out yet
+                    //
+                    _ = st.Errorf(ctx, -1, "server-side deadline is exceeded: %v", code)
+                }
+            } else {
+                _ = st.Errorf(ctx, -1, "bad cluster endpoints, which are not etcd servers: %v", err)
+            }
+        }
+    }
 }
 
 // SetTraceFlags is a method that can be used to change the verbosity of the tracing.
@@ -446,11 +447,11 @@ func (store *Store) logEtcdResponseError(ctx context.Context, err error) {
 // store object.
 //
 func (store *Store) SetTraceFlags(traceLevel TraceFlags) {
-	_ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
-		store.TraceFlags = traceLevel
-		st.Infof(ctx, -1, "TraceFlags: %v", store.GetTraceFlags())
-		return nil
-	})
+    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
+        store.TraceFlags = traceLevel
+        st.Infof(ctx, -1, "TraceFlags: %v", store.GetTraceFlags())
+        return nil
+    })
 }
 
 // GetTraceFlags is a method to retrieve the current trace flags value.
@@ -463,16 +464,16 @@ func (store *Store) GetTraceFlags() TraceFlags { return store.TraceFlags }
 // This method can only be used when the store object is not connected.
 //
 func (store *Store) SetAddress(endpoints []string) error {
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
-		if err := store.connected(ctx); err != nil {
-			return err
-		}
+    return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
+        if err := store.connected(ctx); err != nil {
+            return err
+        }
 
-		store.Endpoints = endpoints
+        store.Endpoints = endpoints
 
-		st.Infof(ctx, -1, "EP: %v", store.GetAddress())
-		return nil
-	})
+        st.Infof(ctx, -1, "EP: %v", store.GetAddress())
+        return nil
+    })
 }
 
 // GetAddress is a method to retrieve the current set of addresses used to connect to
@@ -486,16 +487,16 @@ func (store *Store) GetAddress() []string { return store.Endpoints }
 // This method can only be used when the store object is not connected.
 //
 func (store *Store) SetTimeoutConnect(timeout time.Duration) error {
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
-		if err := store.connected(ctx); err != nil {
-			return err
-		}
+    return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
+        if err := store.connected(ctx); err != nil {
+            return err
+        }
 
-		store.TimeoutConnect = timeout
+        store.TimeoutConnect = timeout
 
-		st.Infof(ctx, -1, "TimeoutConnect: %v", store.GetTimeoutConnect())
-		return nil
-	})
+        st.Infof(ctx, -1, "TimeoutConnect: %v", store.GetTimeoutConnect())
+        return nil
+    })
 }
 
 // GetTimeoutConnect is a method which can be used to query the current timeout being
@@ -510,12 +511,12 @@ func (store *Store) GetTimeoutConnect() time.Duration { return store.TimeoutConn
 // store object, although it will only affect IO initiated after the method has returned.
 //
 func (store *Store) SetTimeoutRequest(timeout time.Duration) error {
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
-		store.TimeoutRequest = timeout
+    return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
+        store.TimeoutRequest = timeout
 
-		st.Infof(ctx, -1, "TimeoutRequest: %v", store.GetTimeoutRequest())
-		return nil
-	})
+        st.Infof(ctx, -1, "TimeoutRequest: %v", store.GetTimeoutRequest())
+        return nil
+    })
 }
 
 // GetTimeoutRequest is a method which can be used to query the current timeout being
@@ -530,18 +531,18 @@ func (store *Store) GetTimeoutRequest() time.Duration { return store.TimeoutRequ
 // old temporary test data.
 //
 func (store *Store) SetNamespaceSuffix(suffix string) error {
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
-		if err := store.connected(ctx); err != nil {
-			return err
-		}
+    return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
+        if err := store.connected(ctx); err != nil {
+            return err
+        }
 
-		// remove any leading, or trailing "/" characters regardless of how many there might be.
-		//
-		store.NamespaceSuffix = strings.Trim(suffix, slash)
+        // remove any leading, or trailing "/" characters regardless of how many there might be.
+        //
+        store.NamespaceSuffix = strings.Trim(suffix, slash)
 
-		st.Infof(ctx, -1, "NamespaceSuffix: %v", store.GetNamespaceSuffix())
-		return nil
-	})
+        st.Infof(ctx, -1, "NamespaceSuffix: %v", store.GetNamespaceSuffix())
+        return nil
+    })
 }
 
 // GetNamespaceSuffix is a method which can be used to query the current namespace prefix
@@ -554,46 +555,44 @@ func (store *Store) GetNamespaceSuffix() string { return store.NamespaceSuffix }
 // attempted.
 //
 func (store *Store) Connect() error {
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		var cli *clientv3.Client
+    return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.connected(ctx); err != nil {
+            return err
+        }
 
-		if err = store.connected(ctx); err != nil {
-			return err
-		}
+        cli, err := clientv3.New(clientv3.Config{
+            Endpoints:   store.GetAddress(),
+            DialTimeout: store.GetTimeoutConnect(),
+        })
 
-		cli, err = clientv3.New(clientv3.Config{
-			Endpoints:   store.GetAddress(),
-			DialTimeout: store.GetTimeoutConnect(),
-		})
+        if err != nil {
+            _ = st.Errorf(ctx, -1, "Failed to establish connection to store - error: %v", err)
+            return err
+        }
 
-		if err != nil {
-			_ = st.Errorf(ctx, -1, "Failed to establish connection to store - error: %v", err)
-			return err
-		}
+        // Hookup the namespace prefixing mechanism
+        //
+        store.Client = cli
+        store.UnprefixedKV = cli.KV
+        store.UnprefixedLease = cli.Lease
+        store.UnprefixedWatcher = cli.Watcher
 
-		// Hookup the namespace prefixing mechanism
-		//
-		store.Client = cli
-		store.UnprefixedKV = cli.KV
-		store.UnprefixedLease = cli.Lease
-		store.UnprefixedWatcher = cli.Watcher
+        namespace := cloudChamberNamespace + slash
 
-		namespace := cloudChamberNamespace + slash
+        suffix := store.GetNamespaceSuffix()
 
-		suffix := store.GetNamespaceSuffix()
+        if "" != suffix {
+            namespace += suffix + slash
+        }
 
-		if "" != suffix {
-			namespace += suffix + slash
-		}
+        store.Namespace = namespace
 
-		store.Namespace = namespace
+        cli.KV = ns.NewKV(cli.KV, store.Namespace)
+        cli.Watcher = ns.NewWatcher(cli.Watcher, store.Namespace)
+        cli.Lease = ns.NewLease(cli.Lease, store.Namespace)
 
-		cli.KV = ns.NewKV(cli.KV, store.Namespace)
-		cli.Watcher = ns.NewWatcher(cli.Watcher, store.Namespace)
-		cli.Lease = ns.NewLease(cli.Lease, store.Namespace)
-
-		return nil
-	})
+        return nil
+    })
 }
 
 // Disconnect is a method used to terminate the connection between the store object
@@ -601,114 +600,112 @@ func (store *Store) Connect() error {
 // no further IO should be attempted.
 //
 func (store *Store) Disconnect() {
-	_ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		if nil == store.Client {
-			st.Infof(ctx, -1, "Store is already disconnected. No action taken")
-			return nil
-		}
+    _ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if nil == store.Client {
+            st.Infof(ctx, -1, "Store is already disconnected. No action taken")
+            return nil
+        }
 
-		_ = store.Client.Close()
+        _ = store.Client.Close()
 
-		store.Client = nil
-		store.UnprefixedKV = nil
-		store.UnprefixedLease = nil
-		store.UnprefixedWatcher = nil
+        store.Client = nil
+        store.UnprefixedKV = nil
+        store.UnprefixedLease = nil
+        store.UnprefixedWatcher = nil
 
-		return nil
-	})
+        return nil
+    })
 }
 
 // Cluster is a structure which describes aspects of a cluster and the members of that cluster.
 //
 type Cluster struct {
-	ID      uint64
-	Members []ClusterMember
+    ID      uint64
+    Members []ClusterMember
 }
 
 // ClusterMember is a structure which describes aspects of a single member within a cluster
 //
 type ClusterMember struct {
-	ID         uint64
-	Name       string
-	PeerURLs   []string
-	ClientURLs []string
+    ID         uint64
+    Name       string
+    PeerURLs   []string
+    ClientURLs []string
 }
 
 // GetClusterMembers is a method to fetch a description of the cluster to which the store
 // object is currently connected.
 //
 func (store *Store) GetClusterMembers() (result *Cluster, err error) {
-	err = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		var response *clientv3.MemberListResponse
+    err = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+        // Originally had a new context here - not sure if we can use the supplied
+        // ctx or whether we still need the new one.
+        //
+        opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
+        response, err := store.Client.MemberList(opCtx)
+        cancel()
 
-		// Originally had a new context here - not sure if we can use the supplied
-		// ctx or whether we still need the new one.
-		//
-		opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
-		response, err = store.Client.MemberList(opCtx)
-		cancel()
+        if err != nil {
+            store.logEtcdResponseError(ctx, err)
+        } else {
+            result = &Cluster{
+                ID:      response.Header.GetClusterId(),
+                Members: make([]ClusterMember, len(response.Members))}
 
-		if err != nil {
-			store.logEtcdResponseError(ctx, err)
-		} else {
-			result = &Cluster{
-				ID:      response.Header.GetClusterId(),
-				Members: make([]ClusterMember, len(response.Members))}
+            for i, member := range response.Members {
+                result.Members[i] = ClusterMember{
+                    Name:       member.GetName(),
+                    ID:         member.GetID(),
+                    PeerURLs:   member.GetPeerURLs(),
+                    ClientURLs: member.GetClientURLs()}
+            }
 
-			for i, member := range response.Members {
-				result.Members[i] = ClusterMember{
-					Name:       member.GetName(),
-					ID:         member.GetID(),
-					PeerURLs:   member.GetPeerURLs(),
-					ClientURLs: member.GetClientURLs()}
-			}
+            if store.trace(traceFlagExpandResults) {
+                for i, node := range result.Members {
+                    st.Infof(ctx, -1, "node [%v] Id: %v Name: %v", i, node.ID, node.Name)
 
-			if store.trace(traceFlagExpandResults) {
-				for i, node := range result.Members {
-					st.Infof(ctx, -1, "node [%v] Id: %v Name: %v", i, node.ID, node.Name)
+                    for j, url := range node.ClientURLs {
+                        st.Infof(ctx, -1, "  client [%v] URL: %v", j, url)
+                    }
 
-					for j, url := range node.ClientURLs {
-						st.Infof(ctx, -1, "  client [%v] URL: %v", j, url)
-					}
+                    for k, url := range node.PeerURLs {
+                        st.Infof(ctx, -1, "  peer [%v] URL: %v", k, url)
+                    }
+                }
+            }
 
-					for k, url := range node.PeerURLs {
-						st.Infof(ctx, -1, "  peer [%v] URL: %v", k, url)
-					}
-				}
-			}
+            st.Infof(ctx, -1, "Processed %v items", len(result.Members))
+        }
 
-			st.Infof(ctx, -1, "Processed %v items", len(result.Members))
-		}
+        return err
+    })
 
-		return err
-	})
-
-	return result, err
+    return result, err
 }
 
 // UpdateClusterConnections is a method which updates the current set of connections
 // to the connected underlying store according to the currently available connections
 //
 func (store *Store) UpdateClusterConnections() error {
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+    return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
-		err = store.Client.Sync(opCtx)
-		cancel()
+        opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
+        err = store.Client.Sync(opCtx)
+        cancel()
 
-		if err != nil {
-			store.logEtcdResponseError(ctx, err)
-		}
+        if err != nil {
+            store.logEtcdResponseError(ctx, err)
+        }
 
-		return err
-	})
+        return err
+    })
 }
 
 // Write is a method to write a new value into the store or update an existing
@@ -718,23 +715,23 @@ func (store *Store) UpdateClusterConnections() error {
 // to the backed db server.
 //
 func (store *Store) Write(key string, value string) error {
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+    return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
-		_, err = store.Client.Put(opCtx, key, value)
-		cancel()
+        opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
+        _, err = store.Client.Put(opCtx, key, value)
+        cancel()
 
-		if err != nil {
-			store.logEtcdResponseError(ctx, err)
-		} else {
-			st.Infof(ctx, -1, "wrote/updated key: %v value: %v", key, value)
-		}
+        if err != nil {
+            store.logEtcdResponseError(ctx, err)
+        } else {
+            st.Infof(ctx, -1, "wrote/updated key: %v value: %v", key, value)
+        }
 
-		return err
-	})
+        return err
+    })
 }
 
 // WriteMultiple is a method to write or update a set of values using a supplied
@@ -744,52 +741,52 @@ func (store *Store) Write(key string, value string) error {
 // in a single call rather than repeating individual calls to the Write() method.
 //
 func (store *Store) WriteMultiple(keyValueSet []KeyValueArg) error {
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		var processedCount int
+    return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        var processedCount int
 
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		// The timeout multiplier (5) is arbitrary. May not even be necessary.
-		//
-		opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest*5)
+        // The timeout multiplier (5) is arbitrary. May not even be necessary.
+        //
+        opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest*5)
 
-		for _, vp := range keyValueSet {
-			_, err = store.Client.Put(opCtx, vp.key, vp.value)
-			if err != nil {
-				break
-			}
-			processedCount++
-		}
+        for _, vp := range keyValueSet {
+            _, err = store.Client.Put(opCtx, vp.key, vp.value)
+            if err != nil {
+                break
+            }
+            processedCount++
+        }
 
-		cancel()
+        cancel()
 
-		if err != nil {
-			store.logEtcdResponseError(ctx, err)
-			_ = st.Errorf(
-				ctx, -1,
-				"Unable to write all the key/value pairs - requested: %v achieved: %v",
-				len(keyValueSet), processedCount)
-		}
+        if err != nil {
+            store.logEtcdResponseError(ctx, err)
+            _ = st.Errorf(
+                ctx, -1,
+                "Unable to write all the key/value pairs - requested: %v achieved: %v",
+                len(keyValueSet), processedCount)
+        }
 
-		if store.trace(traceFlagExpandResults) {
-			for i := 0; i < processedCount; i++ {
-				if store.trace(traceFlagTraceKeyAndValue) {
-					st.Infof(
-						ctx, -1,
-						"wrote/updated [%v/%v] key: %v value: %v",
-						i, processedCount, keyValueSet[i].key, keyValueSet[i].value)
-				} else if store.trace(traceFlagTraceKey) {
-					st.Infof(ctx, -1, "wrote/updated [%v/%v] key: %v", i, processedCount, keyValueSet[i].key)
-				}
-			}
-		}
+        if store.trace(traceFlagExpandResults) {
+            for i := 0; i < processedCount; i++ {
+                if store.trace(traceFlagTraceKeyAndValue) {
+                    st.Infof(
+                        ctx, -1,
+                        "wrote/updated [%v/%v] key: %v value: %v",
+                        i, processedCount, keyValueSet[i].key, keyValueSet[i].value)
+                } else if store.trace(traceFlagTraceKey) {
+                    st.Infof(ctx, -1, "wrote/updated [%v/%v] key: %v", i, processedCount, keyValueSet[i].key)
+                }
+            }
+        }
 
-		st.Infof(ctx, -1, "Processed %v items", processedCount)
+        st.Infof(ctx, -1, "Processed %v items", processedCount)
 
-		return err
-	})
+        return err
+    })
 }
 
 // Read is a method to read a single value from the store using the supplied key.
@@ -798,36 +795,36 @@ func (store *Store) WriteMultiple(keyValueSet []KeyValueArg) error {
 // to the backed db server.
 //
 func (store *Store) Read(key string) (result []byte, err error) {
-	err = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+    err = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
-		response, err := store.Client.Get(opCtx, key)
-		cancel()
+        opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
+        response, err := store.Client.Get(opCtx, key)
+        cancel()
 
-		if err != nil {
-			store.logEtcdResponseError(ctx, err)
-		} else if 0 == len(response.Kvs) {
-			err = ErrStoreKeyNotFound(key)
-			_ = st.Errorf(ctx, -1, "unable to read the requested key/value pair - error: %v", err)
-		} else if 1 != len(response.Kvs) {
-			err = ErrStoreBadRecordCount{key, 1, len(response.Kvs)}
-			_ = st.Errorf(ctx, -1, "expected a single result and instead received something else - error: %v", err)
-		} else {
-			result = response.Kvs[0].Value
-			if store.trace(traceFlagTraceKeyAndValue) {
-				st.Infof(ctx, -1, "read key: %v value: %v", key, string(result))
-			} else if store.trace(traceFlagTraceKey) {
-				st.Infof(ctx, -1, "read key: %v", key)
-			}
-		}
+        if err != nil {
+            store.logEtcdResponseError(ctx, err)
+        } else if 0 == len(response.Kvs) {
+            err = ErrStoreKeyNotFound(key)
+            _ = st.Errorf(ctx, -1, "unable to read the requested key/value pair - error: %v", err)
+        } else if 1 != len(response.Kvs) {
+            err = ErrStoreBadRecordCount{key, 1, len(response.Kvs)}
+            _ = st.Errorf(ctx, -1, "expected a single result and instead received something else - error: %v", err)
+        } else {
+            result = response.Kvs[0].Value
+            if store.trace(traceFlagTraceKeyAndValue) {
+                st.Infof(ctx, -1, "read key: %v value: %v", key, string(result))
+            } else if store.trace(traceFlagTraceKey) {
+                st.Infof(ctx, -1, "read key: %v", key)
+            }
+        }
 
-		return err
-	})
+        return err
+    })
 
-	return result, err
+    return result, err
 }
 
 // ReadMultiple is a method to read a set of values from the store using a supplied
@@ -837,64 +834,64 @@ func (store *Store) Read(key string) (result []byte, err error) {
 // in a single call rather than repeating individual calls to the Read() method.
 //
 func (store *Store) ReadMultiple(keySet []string) (results []KeyValueResponse, err error) {
-	err = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		var processedCount int
+    err = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        var processedCount int
 
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		responses := make([]*clientv3.GetResponse, len(keySet))
+        responses := make([]*clientv3.GetResponse, len(keySet))
 
-		// The timeout multiplier (5) is arbitrary. May not even be necessary.
-		//
-		opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest*5)
+        // The timeout multiplier (5) is arbitrary. May not even be necessary.
+        //
+        opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest*5)
 
-		for i, key := range keySet {
-			responses[i], err = store.Client.Get(opCtx, key)
-			if err != nil {
-				break
-			}
-			processedCount++
-		}
+        for i, key := range keySet {
+            responses[i], err = store.Client.Get(opCtx, key)
+            if err != nil {
+                break
+            }
+            processedCount++
+        }
 
-		cancel()
+        cancel()
 
-		if err != nil {
-			store.logEtcdResponseError(ctx, err)
-			_ = st.Errorf(
-				ctx, -1,
-				"Unable to read all the key/value pairs - requested: %v achieved: %v",
-				len(keySet), processedCount)
-		} else {
-			results = make([]KeyValueResponse, processedCount)
+        if err != nil {
+            store.logEtcdResponseError(ctx, err)
+            _ = st.Errorf(
+                ctx, -1,
+                "Unable to read all the key/value pairs - requested: %v achieved: %v",
+                len(keySet), processedCount)
+        } else {
+            results = make([]KeyValueResponse, processedCount)
 
-			for i := 0; i < processedCount; i++ {
-				if 1 != len(responses[i].Kvs) {
-					err = ErrStoreBadRecordCount{string(responses[i].Kvs[0].Key), 1, len(responses[i].Kvs)}
-					_ = st.Errorf(ctx, -1, "number of responses did not match expectations - error: %v", err)
-				} else {
-					results[i].key = string(responses[i].Kvs[0].Key)
-					results[i].value = responses[i].Kvs[0].Value
-				}
-			}
-		}
+            for i := 0; i < processedCount; i++ {
+                if 1 != len(responses[i].Kvs) {
+                    err = ErrStoreBadRecordCount{string(responses[i].Kvs[0].Key), 1, len(responses[i].Kvs)}
+                    _ = st.Errorf(ctx, -1, "number of responses did not match expectations - error: %v", err)
+                } else {
+                    results[i].key = string(responses[i].Kvs[0].Key)
+                    results[i].value = responses[i].Kvs[0].Value
+                }
+            }
+        }
 
-		if store.trace(traceFlagExpandResults) {
-			for i := 0; i < processedCount; i++ {
-				if store.trace(traceFlagTraceKeyAndValue) {
-					st.Infof(ctx, -1, "read [%v/%v] key: %v value: %v", i, processedCount, results[i].key, string(results[i].value))
-				} else if store.trace(traceFlagTraceKey) {
-					st.Infof(ctx, -1, "read [%v/%v] key: %v", i, processedCount, results[i].key)
-				}
-			}
-		}
+        if store.trace(traceFlagExpandResults) {
+            for i := 0; i < processedCount; i++ {
+                if store.trace(traceFlagTraceKeyAndValue) {
+                    st.Infof(ctx, -1, "read [%v/%v] key: %v value: %v", i, processedCount, results[i].key, string(results[i].value))
+                } else if store.trace(traceFlagTraceKey) {
+                    st.Infof(ctx, -1, "read [%v/%v] key: %v", i, processedCount, results[i].key)
+                }
+            }
+        }
 
-		st.Infof(ctx, -1, "Processed %v items", processedCount)
-		return err
-	})
+        st.Infof(ctx, -1, "Processed %v items", processedCount)
+        return err
+    })
 
-	return results, err
+    return results, err
 }
 
 // ReadWithPrefix is a method used to query for a set of zero or more key/value pairs
@@ -908,85 +905,83 @@ func (store *Store) ReadMultiple(keySet []string) (results []KeyValueResponse, e
 // prefix.
 //
 func (store *Store) ReadWithPrefix(ctx context.Context, keyPrefix string) (rs *RecordSet, err error) {
-	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-		var response *clientv3.GetResponse
+    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+        opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
+        response, err := store.Client.Get(
+            opCtx,
+            keyPrefix,
+            clientv3.WithPrefix(),
+            clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
+        cancel()
 
-		opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
-		response, err = store.Client.Get(
-			opCtx,
-			keyPrefix,
-			clientv3.WithPrefix(),
-			clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
-		cancel()
+        if err != nil {
+            store.logEtcdResponseError(ctx, err)
+            return err
+        }
 
-		if err != nil {
-			store.logEtcdResponseError(ctx, err)
-			return err
-		}
+        resultSet := &RecordSet{
+            Revision: 0,
+            Records:  make(map[string]Record, len(response.Kvs)),
+        }
 
-		resultSet := &RecordSet{
-			Revision: 0,
-			Records:  make(map[string]Record, len(response.Kvs)),
-		}
+        for i, kv := range response.Kvs {
+            key := string(kv.Key)
+            val := string(kv.Value)
+            rev := kv.ModRevision
 
-		for i, kv := range response.Kvs {
-			key := string(kv.Key)
-			val := string(kv.Value)
-			rev := kv.ModRevision
+            resultSet.Records[key] = Record{Revision: rev, Value: val}
 
-			resultSet.Records[key] = Record{Revision: rev, Value: val}
+            if store.trace(traceFlagExpandResults) {
+                if store.trace(traceFlagTraceKeyAndValue) {
+                    st.Infof(ctx, -1, "read [%v/%v] key: %v rev: %v value: %q", i, len(response.Kvs), key, rev, val)
+                } else if store.trace(traceFlagTraceKey) {
+                    st.Infof(ctx, -1, "read [%v/%v] key: %v", i, len(response.Kvs), key)
+                }
+            }
+        }
 
-			if store.trace(traceFlagExpandResults) {
-				if store.trace(traceFlagTraceKeyAndValue) {
-					st.Infof(ctx, -1, "read [%v/%v] key: %v rev: %v value: %q", i, len(response.Kvs), key, rev, val)
-				} else if store.trace(traceFlagTraceKey) {
-					st.Infof(ctx, -1, "read [%v/%v] key: %v", i, len(response.Kvs), key)
-				}
-			}
-		}
+        resultSet.Revision = response.Header.Revision
 
-		resultSet.Revision = response.Header.Revision
+        rs = resultSet
 
-		rs = resultSet
+        st.Infof(ctx, -1, "Processed %v items", len(resultSet.Records))
 
-		st.Infof(ctx, -1, "Processed %v items", len(resultSet.Records))
+        return nil
+    })
 
-		return nil
-	})
-
-	return rs, err
+    return rs, err
 }
 
 // Delete is a method used to remove a single key/value pair using the supplied name.
 //
 func (store *Store) Delete(key string) error {
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+    return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
-		response, err := store.Client.Delete(opCtx, key)
-		cancel()
+        opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
+        response, err := store.Client.Delete(opCtx, key)
+        cancel()
 
-		if err != nil {
-			store.logEtcdResponseError(ctx, err)
-		} else if 0 == response.Deleted {
-			err = ErrStoreKeyNotFound(key)
-			_ = st.Errorf(ctx, -1, "failed to delete the requested key/value pair - error: %v", err)
-		} else if 1 != response.Deleted {
-			err = ErrStoreBadRecordCount{key, 1, int(response.Deleted)}
-			_ = st.Errorf(ctx, -1, "expected a single deletion and instead received something else - error: %v", err)
-		} else {
-			st.Infof(ctx, -1, "deleted key: %v", key)
-		}
+        if err != nil {
+            store.logEtcdResponseError(ctx, err)
+        } else if 0 == response.Deleted {
+            err = ErrStoreKeyNotFound(key)
+            _ = st.Errorf(ctx, -1, "failed to delete the requested key/value pair - error: %v", err)
+        } else if 1 != response.Deleted {
+            err = ErrStoreBadRecordCount{key, 1, int(response.Deleted)}
+            _ = st.Errorf(ctx, -1, "expected a single deletion and instead received something else - error: %v", err)
+        } else {
+            st.Infof(ctx, -1, "deleted key: %v", key)
+        }
 
-		return err
-	})
+        return err
+    })
 }
 
 // DeleteMultiple is a method that can be used to remove a set of key/value pairs.
@@ -995,75 +990,73 @@ func (store *Store) Delete(key string) error {
 // in a single call rather than repeating individual calls to the Delete() method.
 //
 func (store *Store) DeleteMultiple(keySet []string) error {
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		var processedCount int
+    return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        var processedCount int
 
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		// The timeout multiplier (5) is arbitrary. May not even be necessary.
-		//
-		opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest*5)
+        // The timeout multiplier (5) is arbitrary. May not even be necessary.
+        //
+        opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest*5)
 
-		for _, key := range keySet {
-			_, err = store.Client.Delete(opCtx, key)
-			if err != nil {
-				break
-			}
-			processedCount++
-		}
+        for _, key := range keySet {
+            _, err = store.Client.Delete(opCtx, key)
+            if err != nil {
+                break
+            }
+            processedCount++
+        }
 
-		cancel()
+        cancel()
 
-		if err != nil {
-			store.logEtcdResponseError(ctx, err)
-			_ = st.Errorf(ctx, -1, "Unable to delete all the keys - requested: %v achieved: %v", len(keySet), processedCount)
-		}
+        if err != nil {
+            store.logEtcdResponseError(ctx, err)
+            _ = st.Errorf(ctx, -1, "Unable to delete all the keys - requested: %v achieved: %v", len(keySet), processedCount)
+        }
 
-		if store.trace(traceFlagExpandResults) {
-			for i := 0; i < processedCount; i++ {
-				st.Infof(ctx, -1, "deleted [%v/%v] key: %v", i, processedCount, keySet[i])
-			}
-		}
+        if store.trace(traceFlagExpandResults) {
+            for i := 0; i < processedCount; i++ {
+                st.Infof(ctx, -1, "deleted [%v/%v] key: %v", i, processedCount, keySet[i])
+            }
+        }
 
-		st.Infof(ctx, -1, "Processed %v items", processedCount)
+        st.Infof(ctx, -1, "Processed %v items", processedCount)
 
-		return err
-	})
+        return err
+    })
 }
 
 // DeleteWithPrefix is a method used to remove an entire sub-tree of key/value
 // pairs which have a common key name prefix.
 //
 func (store *Store) DeleteWithPrefix(keyPrefix string) error {
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		var response *clientv3.DeleteResponse
+    return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+        opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
+        response, err := store.Client.Delete(opCtx, keyPrefix, clientv3.WithPrefix())
+        cancel()
 
-		opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
-		response, err = store.Client.Delete(opCtx, keyPrefix, clientv3.WithPrefix())
-		cancel()
+        if err != nil {
+            store.logEtcdResponseError(ctx, err)
+        } else {
+            st.Infof(ctx, -1, "deleted %v keys under prefix %v", response.Deleted, keyPrefix)
+        }
 
-		if err != nil {
-			store.logEtcdResponseError(ctx, err)
-		} else {
-			st.Infof(ctx, -1, "deleted %v keys under prefix %v", response.Deleted, keyPrefix)
-		}
-
-		return err
-	})
+        return err
+    })
 }
 
 // SetWatch is a method used to establish a watchpoint on a single key/value pari
 //
 func (store *Store) SetWatch(key string) error {
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		return ErrStoreNotImplemented("SetWatch")
-	})
+    return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        return ErrStoreNotImplemented("SetWatch")
+    })
 }
 
 // SetWatchMultiple is a method used to establish a set of watchpoints on a set of
@@ -1073,18 +1066,18 @@ func (store *Store) SetWatch(key string) error {
 // in a single call rather than repeating individual calls to the SetWatch() method.
 //
 func (store *Store) SetWatchMultiple(key []string) error {
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		return ErrStoreNotImplemented("SetWatchMultiple")
-	})
+    return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        return ErrStoreNotImplemented("SetWatchMultiple")
+    })
 }
 
 // SetWatchWithPrefix is a method used to establish a watchpoint on a entire
 // sub-tree of key/value pairs which have a common key name prefix/
 //
 func (store *Store) SetWatchWithPrefix(keyPrefix string) error {
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		return ErrStoreNotImplemented("SetWatchWithPrefix")
-	})
+    return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+        return ErrStoreNotImplemented("SetWatchWithPrefix")
+    })
 }
 
 // RevisionInvalid is returned from certain operations if
@@ -1092,7 +1085,7 @@ func (store *Store) SetWatchWithPrefix(keyPrefix string) error {
 // unconditional write to the store.
 //
 const (
-	RevisionInvalid int64 = 0
+    RevisionInvalid int64 = 0
 )
 
 // Condition is a type used to define the test to be
@@ -1104,46 +1097,46 @@ type Condition string
 // conditional record update.
 //
 const (
-	ConditionCreate                 = Condition("new")
-	ConditionUnconditional          = Condition("*")
-	ConditionRevisionNotEqual       = Condition("!=")
-	ConditionRevisionLess           = Condition("<")
-	ConditionRevisionLessOrEqual    = Condition("<=")
-	ConditionRevisionEqual          = Condition("==")
-	ConditionRevisionEqualOrGreater = Condition(">=")
-	ConditionRevisionGreater        = Condition(">")
+    ConditionCreate                 = Condition("new")
+    ConditionUnconditional          = Condition("*")
+    ConditionRevisionNotEqual       = Condition("!=")
+    ConditionRevisionLess           = Condition("<")
+    ConditionRevisionLessOrEqual    = Condition("<=")
+    ConditionRevisionEqual          = Condition("==")
+    ConditionRevisionEqualOrGreater = Condition(">=")
+    ConditionRevisionGreater        = Condition(">")
 )
 
 // RecordKeySet is a struct defining the set of keys to be read along with an arbitrary
 // label to tag the transaction.
 //
 type RecordKeySet struct {
-	Label string
-	Keys  []string
+    Label string
+    Keys  []string
 }
 
 // Record is a struct defining a single value and the associated revision describing
 // the store revision when the value was last updated.
 //
 type Record struct {
-	Revision int64
-	Value    string
+    Revision int64
+    Value    string
 }
 
 // RecordSet is a struct defining a set of k,v pairs along with the revision of the
 // store at the time the values were retrieved.
 //
 type RecordSet struct {
-	Revision int64
-	Records  map[string]Record
+    Revision int64
+    Records  map[string]Record
 }
 
 // RecordUpdate is a struct defining a single value and it's revision along with
 // a condition based upon that revision which will permit an update to be attempted.
 //
 type RecordUpdate struct {
-	Condition Condition
-	Record    Record
+    Condition Condition
+    Record    Record
 }
 
 // RecordUpdateSet is a struct defining the set of key value pairs to be updated
@@ -1151,192 +1144,192 @@ type RecordUpdate struct {
 // the current revision of the k,v pair
 //
 type RecordUpdateSet struct {
-	Label   string
-	Records map[string]RecordUpdate
+    Label   string
+    Records map[string]RecordUpdate
 }
 
 func generatePrefetchKeys(recordSet *RecordUpdateSet) (*[]string, error) {
-	prefetchKeys := make([]string, 0, len(recordSet.Records))
+    prefetchKeys := make([]string, 0, len(recordSet.Records))
 
-	// Build an array of keys to supply as the arg to prefetch
-	// on the WithPrefetch() option below
-	//
-	for k, ru := range recordSet.Records {
-		switch ru.Condition {
-		case ConditionUnconditional:
-			// No need to prefetch if not comparing anything
-			break
+    // Build an array of keys to supply as the arg to prefetch
+    // on the WithPrefetch() option below
+    //
+    for k, ru := range recordSet.Records {
+        switch ru.Condition {
+        case ConditionUnconditional:
+            // No need to prefetch if not comparing anything
+            break
 
-		case ConditionRevisionNotEqual:
-			fallthrough
+        case ConditionRevisionNotEqual:
+            fallthrough
 
-		case ConditionRevisionLess:
-			fallthrough
+        case ConditionRevisionLess:
+            fallthrough
 
-		case ConditionRevisionLessOrEqual:
-			fallthrough
+        case ConditionRevisionLessOrEqual:
+            fallthrough
 
-		case ConditionRevisionEqual:
-			fallthrough
+        case ConditionRevisionEqual:
+            fallthrough
 
-		case ConditionRevisionEqualOrGreater:
-			fallthrough
+        case ConditionRevisionEqualOrGreater:
+            fallthrough
 
-		case ConditionRevisionGreater:
-			if ru.Record.Revision == RevisionInvalid {
-				return nil, ErrStoreBadArgRevision{k, RevisionInvalid, ru.Record.Revision}
-			}
+        case ConditionRevisionGreater:
+            if ru.Record.Revision == RevisionInvalid {
+                return nil, ErrStoreBadArgRevision{k, RevisionInvalid, ru.Record.Revision}
+            }
 
-			fallthrough
+            fallthrough
 
-		case ConditionCreate:
-			prefetchKeys = append(prefetchKeys, k)
+        case ConditionCreate:
+            prefetchKeys = append(prefetchKeys, k)
 
-		default:
-			return nil, ErrStoreBadArgCondition{k, ru.Condition}
-		}
-	}
+        default:
+            return nil, ErrStoreBadArgCondition{k, ru.Condition}
+        }
+    }
 
-	return &prefetchKeys, nil
+    return &prefetchKeys, nil
 }
 
 func checkConditions(stm concurrency.STM, recordSet *RecordUpdateSet) error {
-	for k, ru := range recordSet.Records {
-		if ru.Condition == ConditionCreate {
-			if stm.Get(k) != "" {
-				return ErrStoreAlreadyExists(k)
-			}
-		} else if ru.Condition != ConditionUnconditional {
-			rev := stm.Rev(k)
+    for k, ru := range recordSet.Records {
+        if ru.Condition == ConditionCreate {
+            if stm.Get(k) != "" {
+                return ErrStoreAlreadyExists(k)
+            }
+        } else if ru.Condition != ConditionUnconditional {
+            rev := stm.Rev(k)
 
-			switch ru.Condition {
-			case ConditionRevisionLess:
-				if rev >= ru.Record.Revision {
-					return ErrStoreConditionFail{k, ru.Record.Revision, ru.Condition, rev}
-				}
+            switch ru.Condition {
+            case ConditionRevisionLess:
+                if rev >= ru.Record.Revision {
+                    return ErrStoreConditionFail{k, ru.Record.Revision, ru.Condition, rev}
+                }
 
-			case ConditionRevisionLessOrEqual:
-				if rev > ru.Record.Revision {
-					return ErrStoreConditionFail{k, ru.Record.Revision, ru.Condition, rev}
-				}
+            case ConditionRevisionLessOrEqual:
+                if rev > ru.Record.Revision {
+                    return ErrStoreConditionFail{k, ru.Record.Revision, ru.Condition, rev}
+                }
 
-			case ConditionRevisionEqual:
-				if rev != ru.Record.Revision {
-					return ErrStoreConditionFail{k, ru.Record.Revision, ru.Condition, rev}
-				}
+            case ConditionRevisionEqual:
+                if rev != ru.Record.Revision {
+                    return ErrStoreConditionFail{k, ru.Record.Revision, ru.Condition, rev}
+                }
 
-			case ConditionRevisionNotEqual:
-				if rev == ru.Record.Revision {
-					return ErrStoreConditionFail{k, ru.Record.Revision, ru.Condition, rev}
-				}
+            case ConditionRevisionNotEqual:
+                if rev == ru.Record.Revision {
+                    return ErrStoreConditionFail{k, ru.Record.Revision, ru.Condition, rev}
+                }
 
-			case ConditionRevisionEqualOrGreater:
-				if rev < ru.Record.Revision {
-					return ErrStoreConditionFail{k, ru.Record.Revision, ru.Condition, rev}
-				}
+            case ConditionRevisionEqualOrGreater:
+                if rev < ru.Record.Revision {
+                    return ErrStoreConditionFail{k, ru.Record.Revision, ru.Condition, rev}
+                }
 
-			case ConditionRevisionGreater:
-				if rev <= ru.Record.Revision {
-					return ErrStoreConditionFail{k, ru.Record.Revision, ru.Condition, rev}
-				}
-			}
-		}
-	}
+            case ConditionRevisionGreater:
+                if rev <= ru.Record.Revision {
+                    return ErrStoreConditionFail{k, ru.Record.Revision, ru.Condition, rev}
+                }
+            }
+        }
+    }
 
-	return nil
+    return nil
 }
 
 func getPrefetchKeys(req *Request) (*[]string, error) {
-	prefetchKeys := make([]string, 0, len(req.Records))
+    prefetchKeys := make([]string, 0, len(req.Records))
 
-	// Build an array of keys to supply as the arg to prefetch
-	// on the WithPrefetch() option below
-	//
-	for k, r := range req.Records {
-		c := req.Conditions[k]
-		switch c {
-		case ConditionUnconditional:
-			// No need to prefetch if not comparing anything
-			break
+    // Build an array of keys to supply as the arg to prefetch
+    // on the WithPrefetch() option below
+    //
+    for k, r := range req.Records {
+        c := req.Conditions[k]
+        switch c {
+        case ConditionUnconditional:
+            // No need to prefetch if not comparing anything
+            break
 
-		case ConditionRevisionNotEqual:
-			fallthrough
+        case ConditionRevisionNotEqual:
+            fallthrough
 
-		case ConditionRevisionLess:
-			fallthrough
+        case ConditionRevisionLess:
+            fallthrough
 
-		case ConditionRevisionLessOrEqual:
-			fallthrough
+        case ConditionRevisionLessOrEqual:
+            fallthrough
 
-		case ConditionRevisionEqual:
-			fallthrough
+        case ConditionRevisionEqual:
+            fallthrough
 
-		case ConditionRevisionEqualOrGreater:
-			fallthrough
+        case ConditionRevisionEqualOrGreater:
+            fallthrough
 
-		case ConditionRevisionGreater:
-			if r.Revision == RevisionInvalid {
-				return nil, ErrStoreBadArgRevision{k, RevisionInvalid, r.Revision}
-			}
+        case ConditionRevisionGreater:
+            if r.Revision == RevisionInvalid {
+                return nil, ErrStoreBadArgRevision{k, RevisionInvalid, r.Revision}
+            }
 
-			fallthrough
+            fallthrough
 
-		case ConditionCreate:
-			prefetchKeys = append(prefetchKeys, k)
+        case ConditionCreate:
+            prefetchKeys = append(prefetchKeys, k)
 
-		default:
-			return nil, ErrStoreBadArgCondition{k, c}
-		}
-	}
+        default:
+            return nil, ErrStoreBadArgCondition{k, c}
+        }
+    }
 
-	return &prefetchKeys, nil
+    return &prefetchKeys, nil
 }
 
 func chkConditions(stm concurrency.STM, req *Request) error {
-	for k, r := range req.Records {
-		c := req.Conditions[k]
-		if c == ConditionCreate {
-			if stm.Get(k) != "" {
-				return ErrStoreAlreadyExists(k)
-			}
-		} else if c != ConditionUnconditional {
-			rev := stm.Rev(k)
+    for k, r := range req.Records {
+        c := req.Conditions[k]
+        if c == ConditionCreate {
+            if stm.Get(k) != "" {
+                return ErrStoreAlreadyExists(k)
+            }
+        } else if c != ConditionUnconditional {
+            rev := stm.Rev(k)
 
-			switch c {
-			case ConditionRevisionLess:
-				if rev >= r.Revision {
-					return ErrStoreConditionFail{k, r.Revision, c, rev}
-				}
+            switch c {
+            case ConditionRevisionLess:
+                if rev >= r.Revision {
+                    return ErrStoreConditionFail{k, r.Revision, c, rev}
+                }
 
-			case ConditionRevisionLessOrEqual:
-				if rev > r.Revision {
-					return ErrStoreConditionFail{k, r.Revision, c, rev}
-				}
+            case ConditionRevisionLessOrEqual:
+                if rev > r.Revision {
+                    return ErrStoreConditionFail{k, r.Revision, c, rev}
+                }
 
-			case ConditionRevisionEqual:
-				if rev != r.Revision {
-					return ErrStoreConditionFail{k, r.Revision, c, rev}
-				}
+            case ConditionRevisionEqual:
+                if rev != r.Revision {
+                    return ErrStoreConditionFail{k, r.Revision, c, rev}
+                }
 
-			case ConditionRevisionNotEqual:
-				if rev == r.Revision {
-					return ErrStoreConditionFail{k, r.Revision, c, rev}
-				}
+            case ConditionRevisionNotEqual:
+                if rev == r.Revision {
+                    return ErrStoreConditionFail{k, r.Revision, c, rev}
+                }
 
-			case ConditionRevisionEqualOrGreater:
-				if rev < r.Revision {
-					return ErrStoreConditionFail{k, r.Revision, c, rev}
-				}
+            case ConditionRevisionEqualOrGreater:
+                if rev < r.Revision {
+                    return ErrStoreConditionFail{k, r.Revision, c, rev}
+                }
 
-			case ConditionRevisionGreater:
-				if rev <= r.Revision {
-					return ErrStoreConditionFail{k, r.Revision, c, rev}
-				}
-			}
-		}
-	}
+            case ConditionRevisionGreater:
+                if rev <= r.Revision {
+                    return ErrStoreConditionFail{k, r.Revision, c, rev}
+                }
+            }
+        }
+    }
 
-	return nil
+    return nil
 }
 
 // ListWithPrefix is a method used to query for a set of zero or more key/value pairs
@@ -1350,249 +1343,241 @@ func chkConditions(stm concurrency.STM, req *Request) error {
 // prefix.
 //
 func (store *Store) ListWithPrefix(ctx context.Context, keyPrefix string) (response *Response, err error) {
-	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-		var getResponse *clientv3.GetResponse
+    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+        opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
+        getResponse, err := store.Client.Get(
+            opCtx,
+            keyPrefix,
+            clientv3.WithPrefix(),
+            clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
+        cancel()
 
-		opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
-		getResponse, err = store.Client.Get(
-			opCtx,
-			keyPrefix,
-			clientv3.WithPrefix(),
-			clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
-		cancel()
+        if err != nil {
+            store.logEtcdResponseError(ctx, err)
+            return err
+        }
 
-		if err != nil {
-			store.logEtcdResponseError(ctx, err)
-			return err
-		}
+        resp := &Response{
+            Revision: RevisionInvalid,
+            Records:  make(map[string]Record, len(getResponse.Kvs)),
+        }
 
-		resp := &Response{
-			Revision: RevisionInvalid,
-			Records:  make(map[string]Record, len(getResponse.Kvs)),
-		}
+        for i, kv := range getResponse.Kvs {
+            key := string(kv.Key)
+            val := string(kv.Value)
+            rev := kv.ModRevision
 
-		for i, kv := range getResponse.Kvs {
-			key := string(kv.Key)
-			val := string(kv.Value)
-			rev := kv.ModRevision
+            resp.Records[key] = Record{Revision: rev, Value: val}
 
-			resp.Records[key] = Record{Revision: rev, Value: val}
+            if store.trace(traceFlagExpandResults) {
+                if store.trace(traceFlagTraceKeyAndValue) {
+                    st.Infof(ctx, -1, "read [%v/%v] key: %v rev: %v value: %q", i, len(getResponse.Kvs), key, rev, val)
+                } else if store.trace(traceFlagTraceKey) {
+                    st.Infof(ctx, -1, "read [%v/%v] key: %v", i, len(getResponse.Kvs), key)
+                }
+            }
+        }
 
-			if store.trace(traceFlagExpandResults) {
-				if store.trace(traceFlagTraceKeyAndValue) {
-					st.Infof(ctx, -1, "read [%v/%v] key: %v rev: %v value: %q", i, len(getResponse.Kvs), key, rev, val)
-				} else if store.trace(traceFlagTraceKey) {
-					st.Infof(ctx, -1, "read [%v/%v] key: %v", i, len(getResponse.Kvs), key)
-				}
-			}
-		}
+        resp.Revision = getResponse.Header.GetRevision()
 
-		resp.Revision = getResponse.Header.GetRevision()
+        response = resp
 
-		response = resp
+        st.Infof(ctx, -1, "Processed %v items", len(resp.Records))
 
-		st.Infof(ctx, -1, "Processed %v items", len(resp.Records))
+        return nil
+    })
 
-		return nil
-	})
-
-	return response, err
+    return response, err
 }
 
 // ReadMultipleTxn is a method to fetch a set of arbitrary keys within a
 // single txn so they form a (self-)consistent set.
 //
 func (store *Store) ReadMultipleTxn(ctx context.Context, keySet RecordKeySet) (*RecordSet, error) {
-	resultSet := RecordSet{
-		Revision: 0,
-		Records:  make(map[string]Record),
-	}
+    resultSet := RecordSet{
+        Revision: 0,
+        Records:  make(map[string]Record),
+    }
 
-	err := st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+    err := st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		actionReadRecords := func(stm concurrency.STM) error {
-			st.Infof(ctx, -1, "Inside action for %q with %v keys", keySet.Label, len(keySet.Keys))
+        actionReadRecords := func(stm concurrency.STM) error {
+            st.Infof(ctx, -1, "Inside action for %q with %v keys", keySet.Label, len(keySet.Keys))
 
-			for _, k := range keySet.Keys {
+            for _, k := range keySet.Keys {
 
-				rev := stm.Rev(k)
+                rev := stm.Rev(k)
 
-				// If the revision is zero, we take that to mean the key
-				// does not actually exist.
-				//
-				// Note that a key might well exist even if the value is
-				// an empty string. At least I believe it can. We choose
-				// to use the revision instead as a more reliable
-				// indicator of existence.
-				//
-				if rev != 0 {
-					resultSet.Records[k] = Record{Revision: rev, Value: stm.Get(k)}
-				}
-			}
+                // If the revision is zero, we take that to mean the key
+                // does not actually exist.
+                //
+                // Note that a key might well exist even if the value is
+                // an empty string. At least I believe it can. We choose
+                // to use the revision instead as a more reliable
+                // indicator of existence.
+                //
+                if rev != 0 {
+                    resultSet.Records[k] = Record{Revision: rev, Value: stm.Get(k)}
+                }
+            }
 
-			return nil
-		}
+            return nil
+        }
 
-		var response *clientv3.TxnResponse
+        response, err := concurrency.NewSTM(
+            store.Client,
+            actionReadRecords,
+            concurrency.WithIsolation(concurrency.ReadCommitted),
+            concurrency.WithPrefetch(keySet.Keys...),
+        )
 
-		response, err = concurrency.NewSTM(
-			store.Client,
-			actionReadRecords,
-			concurrency.WithIsolation(concurrency.ReadCommitted),
-			concurrency.WithPrefetch(keySet.Keys...),
-		)
+        if err != nil {
+            return err
+        }
 
-		if err != nil {
-			return err
-		}
+        if !response.Succeeded {
+            err = ErrStoreKeyReadFailure(keySet.Label)
+            _ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
+            return err
+        }
 
-		if !response.Succeeded {
-			err = ErrStoreKeyReadFailure(keySet.Label)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
-		}
+        // And finally, the revision for the store as a whole.
+        //
+        resultSet.Revision = response.Header.Revision
 
-		// And finally, the revision for the store as a whole.
-		//
-		resultSet.Revision = response.Header.Revision
+        return nil
+    })
 
-		return nil
-	})
+    if err != nil {
+        return nil, err
+    }
 
-	if err != nil {
-		return nil, err
-	}
-
-	return &resultSet, nil
+    return &resultSet, nil
 }
 
 // WriteMultipleTxn is a method to write/update a set of arbitrary keys within a
 // single txn so they form a (self-)consistent set.
 //
 func (store *Store) WriteMultipleTxn(ctx context.Context, recordSet *RecordUpdateSet) (int64, error) {
-	revision := RevisionInvalid
+    revision := RevisionInvalid
 
-	err := st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+    err := st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		var prefetchKeys *[]string
+        var prefetchKeys *[]string
 
-		if prefetchKeys, err = generatePrefetchKeys(recordSet); err != nil {
-			return err
-		}
+        if prefetchKeys, err = generatePrefetchKeys(recordSet); err != nil {
+            return err
+        }
 
-		actionWriteRecords := func(stm concurrency.STM) error {
+        actionWriteRecords := func(stm concurrency.STM) error {
 
-			if err = checkConditions(stm, recordSet); err != nil {
-				return err
-			}
+            if err = checkConditions(stm, recordSet); err != nil {
+                return err
+            }
 
-			// it is only now that we know the conditions have been
-			// met for all the keys that we take the time to process
-			// all the updates.
-			//
-			for k, ru := range recordSet.Records {
-				stm.Put(k, ru.Record.Value)
-			}
+            // it is only now that we know the conditions have been
+            // met for all the keys that we take the time to process
+            // all the updates.
+            //
+            for k, ru := range recordSet.Records {
+                stm.Put(k, ru.Record.Value)
+            }
 
-			return nil
-		}
+            return nil
+        }
 
-		var response *clientv3.TxnResponse
+        response, err := concurrency.NewSTM(
+            store.Client,
+            actionWriteRecords,
+            concurrency.WithIsolation(concurrency.Serializable),
+            concurrency.WithPrefetch(*prefetchKeys...),
+        )
 
-		response, err = concurrency.NewSTM(
-			store.Client,
-			actionWriteRecords,
-			concurrency.WithIsolation(concurrency.Serializable),
-			concurrency.WithPrefetch(*prefetchKeys...),
-		)
+        if err != nil {
+            return err
+        }
 
-		if err != nil {
-			return err
-		}
+        if !response.Succeeded {
+            err = ErrStoreKeyWriteFailure(recordSet.Label)
+            _ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
+            return err
+        }
 
-		if !response.Succeeded {
-			err = ErrStoreKeyWriteFailure(recordSet.Label)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
-		}
+        revision = response.Header.Revision
 
-		revision = response.Header.Revision
+        return nil
+    })
 
-		return nil
-	})
-
-	return revision, err
+    return revision, err
 }
 
 // DeleteMultipleTxn is a method to delete a set of arbitrary keys within a
 // single txn so they form a (self-)consistent operation.
 //
 func (store *Store) DeleteMultipleTxn(ctx context.Context, recordSet *RecordUpdateSet) (int64, error) {
-	revision := RevisionInvalid
+    revision := RevisionInvalid
 
-	err := st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+    err := st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		var prefetchKeys *[]string
+        var prefetchKeys *[]string
 
-		if prefetchKeys, err = generatePrefetchKeys(recordSet); err != nil {
-			return err
-		}
+        if prefetchKeys, err = generatePrefetchKeys(recordSet); err != nil {
+            return err
+        }
 
-		actionDeleteRecords := func(stm concurrency.STM) error {
+        actionDeleteRecords := func(stm concurrency.STM) error {
 
-			if err = checkConditions(stm, recordSet); err != nil {
-				return err
-			}
+            if err = checkConditions(stm, recordSet); err != nil {
+                return err
+            }
 
-			// it is only now that we know the conditions have been
-			// met for all the keys that we take the time to process
-			// all the updates.
-			//
-			for k := range recordSet.Records {
-				stm.Del(k)
-			}
+            // it is only now that we know the conditions have been
+            // met for all the keys that we take the time to process
+            // all the updates.
+            //
+            for k := range recordSet.Records {
+                stm.Del(k)
+            }
 
-			return nil
-		}
+            return nil
+        }
 
-		var response *clientv3.TxnResponse
+        response, err := concurrency.NewSTM(
+            store.Client,
+            actionDeleteRecords,
+            concurrency.WithIsolation(concurrency.Serializable),
+            concurrency.WithPrefetch(*prefetchKeys...),
+        )
 
-		response, err = concurrency.NewSTM(
-			store.Client,
-			actionDeleteRecords,
-			concurrency.WithIsolation(concurrency.Serializable),
-			concurrency.WithPrefetch(*prefetchKeys...),
-		)
+        if err != nil {
+            return err
+        }
 
-		if err != nil {
-			return err
-		}
+        if !response.Succeeded {
+            err = ErrStoreKeyDeleteFailure(recordSet.Label)
+            _ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
+            return err
+        }
 
-		if !response.Succeeded {
-			err = ErrStoreKeyDeleteFailure(recordSet.Label)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
-		}
+        revision = response.Header.Revision
 
-		revision = response.Header.Revision
+        return nil
+    })
 
-		return nil
-	})
-
-	return revision, err
+    return revision, err
 }
 
 //
@@ -1603,213 +1588,209 @@ func (store *Store) DeleteMultipleTxn(ctx context.Context, recordSet *RecordUpda
 // single txn so they form a (self-)consistent set.
 //
 func (store *Store) ReadTxn(ctx context.Context, request *Request) (response *Response, err error) {
-	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		var prefetchKeys *[]string
+        var prefetchKeys *[]string
 
-		if prefetchKeys, err = getPrefetchKeys(request); err != nil {
-			return err
-		}
+        if prefetchKeys, err = getPrefetchKeys(request); err != nil {
+            return err
+        }
 
-		resp := &Response{
-			Revision: RevisionInvalid,
-			Records:  make(map[string]Record, len(request.Records)),
-		}
+        resp := &Response{
+            Revision: RevisionInvalid,
+            Records:  make(map[string]Record, len(request.Records)),
+        }
 
-		txnAction := func(stm concurrency.STM) error {
+        txnAction := func(stm concurrency.STM) error {
 
-			if err = chkConditions(stm, request); err != nil {
-				return err
-			}
+            if err = chkConditions(stm, request); err != nil {
+                return err
+            }
 
-			// It is only now that we know the conditions have been
-			// met for all the keys that we take the time to process
-			// all the updates.
-			//
-			// If the revision is zero, we take that to mean the key
-			// does not actually exist.
-			//
-			// Note that a key might well exist even if the value is
-			// an empty string. At least I believe it can. We choose
-			// to use the revision instead as a more reliable
-			// indicator of existence.
-			//
-			for k := range request.Records {
+            // It is only now that we know the conditions have been
+            // met for all the keys that we take the time to process
+            // all the updates.
+            //
+            // If the revision is zero, we take that to mean the key
+            // does not actually exist.
+            //
+            // Note that a key might well exist even if the value is
+            // an empty string. At least I believe it can. We choose
+            // to use the revision instead as a more reliable
+            // indicator of existence.
+            //
+            for k := range request.Records {
 
-				rev := stm.Rev(k)
+                rev := stm.Rev(k)
 
-				if rev != 0 {
-					resp.Records[k] = Record{Revision: rev, Value: stm.Get(k)}
-				}
-			}
+                if rev != 0 {
+                    resp.Records[k] = Record{Revision: rev, Value: stm.Get(k)}
+                }
+            }
 
-			return nil
-		}
+            return nil
+        }
 
-		txnResponse, err := concurrency.NewSTM(
-			store.Client,
-			txnAction,
-			concurrency.WithIsolation(concurrency.ReadCommitted),
-			concurrency.WithPrefetch(*prefetchKeys...),
-		)
+        txnResponse, err := concurrency.NewSTM(
+            store.Client,
+            txnAction,
+            concurrency.WithIsolation(concurrency.ReadCommitted),
+            concurrency.WithPrefetch(*prefetchKeys...),
+        )
 
-		if err != nil {
-			return err
-		}
+        if err != nil {
+            return err
+        }
 
-		if !txnResponse.Succeeded {
-			err = ErrStoreKeyReadFailure(request.Reason)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
-		}
+        if !txnResponse.Succeeded {
+            err = ErrStoreKeyReadFailure(request.Reason)
+            _ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
+            return err
+        }
 
-		// And finally, the revision for the store as a whole.
-		//
-		resp.Revision = txnResponse.Header.GetRevision()
+        // And finally, the revision for the store as a whole.
+        //
+        resp.Revision = txnResponse.Header.GetRevision()
 
-		response = resp
+        response = resp
 
-		return nil
-	})
+        return nil
+    })
 
-	return response, err
+    return response, err
 }
 
 // WriteTxn is a method to write/update a set of arbitrary keys within a
 // single txn so they form a (self-)consistent set.
 //
 func (store *Store) WriteTxn(ctx context.Context, request *Request) (response *Response, err error) {
-	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		var prefetchKeys *[]string
+        var prefetchKeys *[]string
 
-		if prefetchKeys, err = getPrefetchKeys(request); err != nil {
-			return err
-		}
+        if prefetchKeys, err = getPrefetchKeys(request); err != nil {
+            return err
+        }
 
-		resp := &Response{
-			Revision: RevisionInvalid,
-			Records:  make(map[string]Record),
-		}
+        resp := &Response{
+            Revision: RevisionInvalid,
+            Records:  make(map[string]Record),
+        }
 
-		txnAction := func(stm concurrency.STM) error {
+        txnAction := func(stm concurrency.STM) error {
 
-			if err = chkConditions(stm, request); err != nil {
-				return err
-			}
+            if err = chkConditions(stm, request); err != nil {
+                return err
+            }
 
-			// It is only now that we know the conditions have been
-			// met for all the keys that we take the time to process
-			// all the updates.
-			//
-			for k, r := range request.Records {
-				stm.Put(k, r.Value)
-			}
+            // It is only now that we know the conditions have been
+            // met for all the keys that we take the time to process
+            // all the updates.
+            //
+            for k, r := range request.Records {
+                stm.Put(k, r.Value)
+            }
 
-			return nil
-		}
+            return nil
+        }
 
-		var txnResponse *clientv3.TxnResponse
+        txnResponse, err := concurrency.NewSTM(
+            store.Client,
+            txnAction,
+            concurrency.WithIsolation(concurrency.Serializable),
+            concurrency.WithPrefetch(*prefetchKeys...),
+        )
 
-		txnResponse, err = concurrency.NewSTM(
-			store.Client,
-			txnAction,
-			concurrency.WithIsolation(concurrency.Serializable),
-			concurrency.WithPrefetch(*prefetchKeys...),
-		)
+        if err != nil {
+            return err
+        }
 
-		if err != nil {
-			return err
-		}
+        if !txnResponse.Succeeded {
+            err = ErrStoreKeyWriteFailure(request.Reason)
+            _ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
+            return err
+        }
 
-		if !txnResponse.Succeeded {
-			err = ErrStoreKeyWriteFailure(request.Reason)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
-		}
+        // And finally, the revision for the store as a whole.
+        //
+        resp.Revision = txnResponse.Header.GetRevision()
 
-		// And finally, the revision for the store as a whole.
-		//
-		resp.Revision = txnResponse.Header.GetRevision()
+        response = resp
 
-		response = resp
+        return nil
+    })
 
-		return nil
-	})
-
-	return response, err
+    return response, err
 }
 
 // DeleteTxn is a method to delete a set of arbitrary keys within a
 // single txn so they form a (self-)consistent operation.
 //
 func (store *Store) DeleteTxn(ctx context.Context, request *Request) (response *Response, err error) {
-	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		var prefetchKeys *[]string
+        var prefetchKeys *[]string
 
-		if prefetchKeys, err = getPrefetchKeys(request); err != nil {
-			return err
-		}
+        if prefetchKeys, err = getPrefetchKeys(request); err != nil {
+            return err
+        }
 
-		resp := &Response{
-			Revision: RevisionInvalid,
-			Records:  make(map[string]Record),
-		}
+        resp := &Response{
+            Revision: RevisionInvalid,
+            Records:  make(map[string]Record),
+        }
 
-		txnAction := func(stm concurrency.STM) error {
+        txnAction := func(stm concurrency.STM) error {
 
-			if err = chkConditions(stm, request); err != nil {
-				return err
-			}
+            if err = chkConditions(stm, request); err != nil {
+                return err
+            }
 
-			// it is only now that we know the conditions have been
-			// met for all the keys that we take the time to process
-			// all the updates.
-			//
-			for k := range request.Records {
-				stm.Del(k)
-			}
+            // it is only now that we know the conditions have been
+            // met for all the keys that we take the time to process
+            // all the updates.
+            //
+            for k := range request.Records {
+                stm.Del(k)
+            }
 
-			return nil
-		}
+            return nil
+        }
 
-		var txnResponse *clientv3.TxnResponse
+        txnResponse, err := concurrency.NewSTM(
+            store.Client,
+            txnAction,
+            concurrency.WithIsolation(concurrency.Serializable),
+            concurrency.WithPrefetch(*prefetchKeys...),
+        )
 
-		txnResponse, err = concurrency.NewSTM(
-			store.Client,
-			txnAction,
-			concurrency.WithIsolation(concurrency.Serializable),
-			concurrency.WithPrefetch(*prefetchKeys...),
-		)
+        if err != nil {
+            return err
+        }
 
-		if err != nil {
-			return err
-		}
+        if !txnResponse.Succeeded {
+            err = ErrStoreKeyDeleteFailure(request.Reason)
+            _ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
+            return err
+        }
 
-		if !txnResponse.Succeeded {
-			err = ErrStoreKeyDeleteFailure(request.Reason)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
-		}
+        // And finally, the revision for the store as a whole.
+        //
+        resp.Revision = txnResponse.Header.GetRevision()
 
-		// And finally, the revision for the store as a whole.
-		//
-		resp.Revision = txnResponse.Header.GetRevision()
+        response = resp
 
-		response = resp
+        return nil
+    })
 
-		return nil
-	})
-
-	return response, err
+    return response, err
 }

--- a/internal/clients/store/store.go
+++ b/internal/clients/store/store.go
@@ -14,12 +14,12 @@
 //		ReadWithPrefix()
 //		Delete()
 //		DeleteMultiple()
-//		DeleteWithPrexix()
+//		DeleteWithPrefix()
 //
 // which typically take a string key or set of keys along with a set of string values for the
 // WriteXxx() methods.
 //
-// The ReadXxx() methods areturn an array of KeyValueResponse structs which describe a set
+// The ReadXxx() methods return an array of KeyValueResponse structs which describe a set
 // of zero of more key/value pairs. Note that the keys are returned as string but the values
 // are []byte slices. These can readily be converted to strings as necessary.
 //
@@ -87,7 +87,7 @@ import (
 )
 
 // All CloudChamber key-value pairs are stored under a common namespace root.
-// This is fixed and cannot be changed programatically. However, to help
+// This is fixed and cannot be changed programmatically. However, to help
 // certain situations, such as test, an additional suffix to the namespace
 // can be added, changed, removed etc.
 //
@@ -203,7 +203,7 @@ func (store *Store) connected(ctx context.Context) error {
 
 	if nil != store.Client {
 		err := ErrStoreConnected
-		st.Errorf(ctx, -1, "unable to perform operation - store is connected - error: %v", err)
+		_ = st.Errorf(ctx, -1, "unable to perform operation - store is connected - error: %v", err)
 		return err
 	}
 
@@ -214,7 +214,7 @@ func (store *Store) disconnected(ctx context.Context) error {
 
 	if nil == store.Client {
 		err := ErrStoreNotConnected
-		st.Errorf(ctx, -1, "unable to perform operation - no current connection - error: %v", err)
+		_ = st.Errorf(ctx, -1, "unable to perform operation - no current connection - error: %v", err)
 		return err
 	}
 
@@ -225,9 +225,11 @@ func (store *Store) disconnected(ctx context.Context) error {
 // the back-end db service.
 //
 func Initialize(cfg *config.GlobalConfig) {
+	_ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+		storeRoot.DefaultEndpoints = []string {
+			fmt.Sprintf("%s:%d", cfg.Store.EtcdService.Hostname, cfg.Store.EtcdService.Port),
+		}
 
-	st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		storeRoot.DefaultEndpoints = []string{fmt.Sprintf("%s:%v", cfg.Store.EtcdService.Hostname, cfg.Store.EtcdService.Port)}
 		storeRoot.DefaultTimeoutConnect = time.Duration(cfg.Store.ConnectTimeout) * time.Second
 		storeRoot.DefaultTimeoutRequest = time.Duration(cfg.Store.RequestTimeout) * time.Second
 		storeRoot.DefaultTraceFlags = TraceFlags(cfg.Store.TraceLevel)
@@ -243,7 +245,7 @@ func Initialize(cfg *config.GlobalConfig) {
 			storeRoot.DefaultTraceFlags,
 			storeRoot.DefaultNamespaceSuffix)
 
-		// See if any part of the test namespace requires initialization and optionally cleanining.
+		// See if any part of the test namespace requires initialization and optionally cleaning.
 		//
 		// NOTE: This only affects the test namespace, not the production namespace. Ideally it
 		//       would not be here but the store is used by other services as part of their test
@@ -259,11 +261,10 @@ func Initialize(cfg *config.GlobalConfig) {
 // clean out the store of data left from previous runs and set a test specific namespace for all
 // subsequent store operations.
 //
-// NOTE: It is expected that this is call soon after the store is initiaitlized and before any
+// NOTE: It is expected that this is call soon after the store is initialized and before any
 //       data related operations have taken place.
 //
 func PrepareTestNamespace(ctx context.Context, cfg *config.GlobalConfig) {
-
 	if !cfg.Store.Test.UseTestNamespace {
 		return
 	}
@@ -272,7 +273,8 @@ func PrepareTestNamespace(ctx context.Context, cfg *config.GlobalConfig) {
 	// and to clean the store before the tests are run
 	//
 	if cfg.Store.Test.UseUniqueInstance && cfg.Store.Test.PreCleanStore {
-		log.Fatalf("invalid configuration: : %v", ErrStoreInvalidConfiguration("both UseUniqueInstance and PreCleanStore are enabled"))
+		log.Fatalf("invalid configuration: : %v",
+			ErrStoreInvalidConfiguration("both UseUniqueInstance and PreCleanStore are enabled"))
 	}
 
 	// For test purposes, need to set an alternate namespace rather than
@@ -297,7 +299,7 @@ func PrepareTestNamespace(ctx context.Context, cfg *config.GlobalConfig) {
 		if err := cleanNamespace(testNamespace); err != nil {
 			msg := fmt.Sprintf("failed to pre-clean the store as requested - namespace: %s err: %v", testNamespace, err)
 
-			st.Errorf(ctx, -1, msg)
+			_ = st.Errorf(ctx, -1, msg)
 			log.Fatalf(msg)
 		}
 	}
@@ -306,7 +308,6 @@ func PrepareTestNamespace(ctx context.Context, cfg *config.GlobalConfig) {
 }
 
 func cleanNamespace(testNamespace string) error {
-
 	store := NewStore()
 
 	if store == nil {
@@ -316,9 +317,11 @@ func cleanNamespace(testNamespace string) error {
 	if err := store.SetNamespaceSuffix(""); err != nil {
 		return err
 	}
+
 	if err := store.Connect(); err != nil {
 		return err
 	}
+
 	if err := store.DeleteWithPrefix(testNamespace); err != nil {
 		return err
 	}
@@ -355,8 +358,12 @@ func NewStore() *Store {
 //
 // providing the store has not yet connected to the back-end db service.
 //
-func New(endpoints []string, timeoutConnect time.Duration, timeoutRequest time.Duration, traceFlags TraceFlags, namespace string) *Store {
-
+func New(
+		endpoints []string,
+		timeoutConnect time.Duration,
+		timeoutRequest time.Duration,
+		traceFlags TraceFlags,
+		namespace string) *Store {
 	store := &Store{
 		Endpoints:       endpoints,
 		TimeoutConnect:  timeoutConnect,
@@ -370,19 +377,35 @@ func New(endpoints []string, timeoutConnect time.Duration, timeoutRequest time.D
 
 // Initialize is a method used to initialize a specific instance of a Store struct.
 //
-func (store *Store) Initialize(endpoints []string, timeoutConnect time.Duration, timeoutRequest time.Duration, traceFlags TraceFlags, namespaceSuffix string) error {
-
+func (store *Store) Initialize(
+		endpoints []string,
+		timeoutConnect time.Duration,
+		timeoutRequest time.Duration,
+		traceFlags TraceFlags,
+		namespaceSuffix string) error {
 	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-
-		if err := store.connected(ctx); err != nil {
+		if err = store.connected(ctx); err != nil {
 			return err
 		}
 
-		store.SetAddress(endpoints)
-		store.SetTimeoutConnect(timeoutConnect)
-		store.SetTimeoutRequest(timeoutRequest)
+		if err = store.SetAddress(endpoints); err != nil {
+			return err
+		}
+
+		if err = store.SetTimeoutConnect(timeoutConnect); err != nil {
+			return err
+		}
+
+		if err = store.SetTimeoutRequest(timeoutRequest); err != nil {
+			return err
+		}
+
 		store.SetTraceFlags(traceFlags)
-		store.SetNamespaceSuffix(namespaceSuffix)
+
+		if err = store.SetNamespaceSuffix(namespaceSuffix); err != nil {
+			return err
+		}
+
 
 		store.Client = nil
 		return nil
@@ -393,13 +416,13 @@ func (store *Store) logEtcdResponseError(ctx context.Context, err error) {
 	if store.traceEnabled() {
 		switch err {
 		case context.Canceled:
-			st.Errorf(ctx, -1, "ctx is canceled by another routine: %v", err)
+			_ = st.Errorf(ctx, -1, "ctx is canceled by another routine: %v", err)
 
 		case context.DeadlineExceeded:
-			st.Errorf(ctx, -1, "ctx is attached with a deadline is exceeded: %v", err)
+			_ = st.Errorf(ctx, -1, "ctx is attached with a deadline is exceeded: %v", err)
 
 		case rpctypes.ErrEmptyKey:
-			st.Errorf(ctx, -1, "client-side error: %v", err)
+			_ = st.Errorf(ctx, -1, "client-side error: %v", err)
 
 		default:
 			if ev, ok := status.FromError(err); ok {
@@ -408,10 +431,10 @@ func (store *Store) logEtcdResponseError(ctx context.Context, err error) {
 					// server-side context might have timed-out first (due to clock skew)
 					// while original client-side context is not timed-out yet
 					//
-					st.Errorf(ctx, -1, "server-side deadline is exceeded: %v", code)
+					_ = st.Errorf(ctx, -1, "server-side deadline is exceeded: %v", code)
 				}
 			} else {
-				st.Errorf(ctx, -1, "bad cluster endpoints, which are not etcd servers: %v", err)
+				_ = st.Errorf(ctx, -1, "bad cluster endpoints, which are not etcd servers: %v", err)
 			}
 		}
 	}
@@ -423,8 +446,7 @@ func (store *Store) logEtcdResponseError(ctx context.Context, err error) {
 // store object.
 //
 func (store *Store) SetTraceFlags(traceLevel TraceFlags) {
-
-	st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+	_ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
 		store.TraceFlags = traceLevel
 		st.Infof(ctx, -1, "TraceFlags: %v", store.GetTraceFlags())
 		return nil
@@ -440,9 +462,8 @@ func (store *Store) GetTraceFlags() TraceFlags { return store.TraceFlags }
 //
 // This method can only be used when the store object is not connected.
 //
-func (store *Store) SetAddress(endpoints []string) (err error) {
-
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+func (store *Store) SetAddress(endpoints []string) error {
+	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
 		if err := store.connected(ctx); err != nil {
 			return err
 		}
@@ -464,9 +485,8 @@ func (store *Store) GetAddress() []string { return store.Endpoints }
 //
 // This method can only be used when the store object is not connected.
 //
-func (store *Store) SetTimeoutConnect(timeout time.Duration) (err error) {
-
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+func (store *Store) SetTimeoutConnect(timeout time.Duration) error {
+	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
 		if err := store.connected(ctx); err != nil {
 			return err
 		}
@@ -489,9 +509,8 @@ func (store *Store) GetTimeoutConnect() time.Duration { return store.TimeoutConn
 // The request timeout can be set or updated regardless of the connection state of the
 // store object, although it will only affect IO initiated after the method has returned.
 //
-func (store *Store) SetTimeoutRequest(timeout time.Duration) (err error) {
-
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+func (store *Store) SetTimeoutRequest(timeout time.Duration) error {
+	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
 		store.TimeoutRequest = timeout
 
 		st.Infof(ctx, -1, "TimeoutRequest: %v", store.GetTimeoutRequest())
@@ -511,9 +530,7 @@ func (store *Store) GetTimeoutRequest() time.Duration { return store.TimeoutRequ
 // old temporary test data.
 //
 func (store *Store) SetNamespaceSuffix(suffix string) error {
-
-	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-
+	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
 		if err := store.connected(ctx); err != nil {
 			return err
 		}
@@ -536,20 +553,21 @@ func (store *Store) GetNamespaceSuffix() string { return store.NamespaceSuffix }
 // backend etcd database. A connection is required before any IO to the database can be
 // attempted.
 //
-func (store *Store) Connect() (err error) {
-
+func (store *Store) Connect() error {
 	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		if err := store.connected(ctx); err != nil {
+		var cli *clientv3.Client
+
+		if err = store.connected(ctx); err != nil {
 			return err
 		}
 
-		cli, err := clientv3.New(clientv3.Config{
+		cli, err = clientv3.New(clientv3.Config{
 			Endpoints:   store.GetAddress(),
 			DialTimeout: store.GetTimeoutConnect(),
 		})
 
 		if err != nil {
-			st.Errorf(ctx, -1, "Failed to establish connection to store - error: %v", err)
+			_ = st.Errorf(ctx, -1, "Failed to establish connection to store - error: %v", err)
 			return err
 		}
 
@@ -579,18 +597,17 @@ func (store *Store) Connect() (err error) {
 }
 
 // Disconnect is a method used to terminate the connection between the store object
-// instance and the backed etcd service. Once the connection has been terninated,
+// instance and the backed etcd service. Once the connection has been terminated,
 // no further IO should be attempted.
 //
 func (store *Store) Disconnect() {
-
-	st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+	_ = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
 		if nil == store.Client {
 			st.Infof(ctx, -1, "Store is already disconnected. No action taken")
 			return nil
 		}
 
-		store.Client.Close()
+		_ = store.Client.Close()
 
 		store.Client = nil
 		store.UnprefixedKV = nil
@@ -608,7 +625,7 @@ type Cluster struct {
 	Members []ClusterMember
 }
 
-// ClusterMember is a structure which describes aspecs of a single member within a cluster
+// ClusterMember is a structure which describes aspects of a single member within a cluster
 //
 type ClusterMember struct {
 	ID         uint64
@@ -621,9 +638,10 @@ type ClusterMember struct {
 // object is currently connected.
 //
 func (store *Store) GetClusterMembers() (result *Cluster, err error) {
-
 	err = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		if err := store.disconnected(ctx); err != nil {
+		var response *clientv3.MemberListResponse
+
+		if err = store.disconnected(ctx); err != nil {
 			return err
 		}
 
@@ -631,7 +649,7 @@ func (store *Store) GetClusterMembers() (result *Cluster, err error) {
 		// ctx or whether we still need the new one.
 		//
 		opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
-		response, err := store.Client.MemberList(opCtx)
+		response, err = store.Client.MemberList(opCtx)
 		cancel()
 
 		if err != nil {
@@ -652,11 +670,13 @@ func (store *Store) GetClusterMembers() (result *Cluster, err error) {
 			if store.trace(traceFlagExpandResults) {
 				for i, node := range result.Members {
 					st.Infof(ctx, -1, "node [%v] Id: %v Name: %v", i, node.ID, node.Name)
-					for i, url := range node.ClientURLs {
-						st.Infof(ctx, -1, "  client [%v] URL: %v", i, url)
+
+					for j, url := range node.ClientURLs {
+						st.Infof(ctx, -1, "  client [%v] URL: %v", j, url)
 					}
-					for i, url := range node.PeerURLs {
-						st.Infof(ctx, -1, "  peer [%v] URL: %v", i, url)
+
+					for k, url := range node.PeerURLs {
+						st.Infof(ctx, -1, "  peer [%v] URL: %v", k, url)
 					}
 				}
 			}
@@ -674,7 +694,6 @@ func (store *Store) GetClusterMembers() (result *Cluster, err error) {
 // to the connected underlying store according to the currently available connections
 //
 func (store *Store) UpdateClusterConnections() error {
-
 	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
 		if err = store.disconnected(ctx); err != nil {
 			return err
@@ -699,7 +718,6 @@ func (store *Store) UpdateClusterConnections() error {
 // to the backed db server.
 //
 func (store *Store) Write(key string, value string) error {
-
 	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
 		if err = store.disconnected(ctx); err != nil {
 			return err
@@ -722,11 +740,10 @@ func (store *Store) Write(key string, value string) error {
 // WriteMultiple is a method to write or update a set of values using a supplied
 // set of keys in a pair-wise fashion.
 //
-// This is essentially a convenience method to allow multiuple values to be fetched
+// This is essentially a convenience method to allow multiple values to be fetched
 // in a single call rather than repeating individual calls to the Write() method.
 //
-func (store *Store) WriteMultiple(keyValueSet []KeyValueArg) (err error) {
-
+func (store *Store) WriteMultiple(keyValueSet []KeyValueArg) error {
 	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
 		var processedCount int
 
@@ -750,13 +767,19 @@ func (store *Store) WriteMultiple(keyValueSet []KeyValueArg) (err error) {
 
 		if err != nil {
 			store.logEtcdResponseError(ctx, err)
-			st.Errorf(ctx, -1, "Unable to write all the key/value pairs - requested: %v achieved: %v", len(keyValueSet), processedCount)
+			_ = st.Errorf(
+				ctx, -1,
+				"Unable to write all the key/value pairs - requested: %v achieved: %v",
+				len(keyValueSet), processedCount)
 		}
 
 		if store.trace(traceFlagExpandResults) {
 			for i := 0; i < processedCount; i++ {
 				if store.trace(traceFlagTraceKeyAndValue) {
-					st.Infof(ctx, -1, "wrote/updated [%v/%v] key: %v value: %v", i, processedCount, keyValueSet[i].key, keyValueSet[i].value)
+					st.Infof(
+						ctx, -1,
+						"wrote/updated [%v/%v] key: %v value: %v",
+						i, processedCount, keyValueSet[i].key, keyValueSet[i].value)
 				} else if store.trace(traceFlagTraceKey) {
 					st.Infof(ctx, -1, "wrote/updated [%v/%v] key: %v", i, processedCount, keyValueSet[i].key)
 				}
@@ -775,7 +798,6 @@ func (store *Store) WriteMultiple(keyValueSet []KeyValueArg) (err error) {
 // to the backed db server.
 //
 func (store *Store) Read(key string) (result []byte, err error) {
-
 	err = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
 		if err = store.disconnected(ctx); err != nil {
 			return err
@@ -789,16 +811,16 @@ func (store *Store) Read(key string) (result []byte, err error) {
 			store.logEtcdResponseError(ctx, err)
 		} else if 0 == len(response.Kvs) {
 			err = ErrStoreKeyNotFound(key)
-			st.Errorf(ctx, -1, "unable to read the requested key/value pair - error: %v", err)
+			_ = st.Errorf(ctx, -1, "unable to read the requested key/value pair - error: %v", err)
 		} else if 1 != len(response.Kvs) {
 			err = ErrStoreBadRecordCount{key, 1, len(response.Kvs)}
-			st.Errorf(ctx, -1, "expected a single result and instead received something else - error: %v", err)
+			_ = st.Errorf(ctx, -1, "expected a single result and instead received something else - error: %v", err)
 		} else {
 			result = response.Kvs[0].Value
 			if store.trace(traceFlagTraceKeyAndValue) {
-				st.Infof(ctx, -1, "read key: %v value: %v", string(key), string(result))
+				st.Infof(ctx, -1, "read key: %v value: %v", key, string(result))
 			} else if store.trace(traceFlagTraceKey) {
-				st.Infof(ctx, -1, "read key: %v", string(key))
+				st.Infof(ctx, -1, "read key: %v", key)
 			}
 		}
 
@@ -811,11 +833,10 @@ func (store *Store) Read(key string) (result []byte, err error) {
 // ReadMultiple is a method to read a set of values from the store using a supplied
 // set of keys is a pair-wise fashion.
 //
-// This is essentially a convenience method to allow multiuple values to be fetched
+// This is essentially a convenience method to allow multiple values to be fetched
 // in a single call rather than repeating individual calls to the Read() method.
 //
 func (store *Store) ReadMultiple(keySet []string) (results []KeyValueResponse, err error) {
-
 	err = st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
 		var processedCount int
 
@@ -841,14 +862,17 @@ func (store *Store) ReadMultiple(keySet []string) (results []KeyValueResponse, e
 
 		if err != nil {
 			store.logEtcdResponseError(ctx, err)
-			st.Errorf(ctx, -1, "Unable to read all the key/value pairs - requested: %v achieved: %v", len(keySet), processedCount)
+			_ = st.Errorf(
+				ctx, -1,
+				"Unable to read all the key/value pairs - requested: %v achieved: %v",
+				len(keySet), processedCount)
 		} else {
 			results = make([]KeyValueResponse, processedCount)
 
 			for i := 0; i < processedCount; i++ {
 				if 1 != len(responses[i].Kvs) {
 					err = ErrStoreBadRecordCount{string(responses[i].Kvs[0].Key), 1, len(responses[i].Kvs)}
-					st.Errorf(ctx, -1, "number of responses did not match expectations - error: %v", err)
+					_ = st.Errorf(ctx, -1, "number of responses did not match expectations - error: %v", err)
 				} else {
 					results[i].key = string(responses[i].Kvs[0].Key)
 					results[i].value = responses[i].Kvs[0].Value
@@ -859,9 +883,9 @@ func (store *Store) ReadMultiple(keySet []string) (results []KeyValueResponse, e
 		if store.trace(traceFlagExpandResults) {
 			for i := 0; i < processedCount; i++ {
 				if store.trace(traceFlagTraceKeyAndValue) {
-					st.Infof(ctx, -1, "read [%v/%v] key: %v value: %v", i, processedCount, string(results[i].key), string(results[i].value))
+					st.Infof(ctx, -1, "read [%v/%v] key: %v value: %v", i, processedCount, results[i].key, string(results[i].value))
 				} else if store.trace(traceFlagTraceKey) {
-					st.Infof(ctx, -1, "read [%v/%v] key: %v", i, processedCount, string(results[i].key))
+					st.Infof(ctx, -1, "read [%v/%v] key: %v", i, processedCount, results[i].key)
 				}
 			}
 		}
@@ -878,21 +902,25 @@ func (store *Store) ReadMultiple(keySet []string) (results []KeyValueResponse, e
 // care should be taken with key naming to avoid attempting to fetch a large number
 // of key/value pairs.
 //
-// It is not an error to attmept to retrieve an empty set. For example, when querying
+// It is not an error to attempt to retrieve an empty set. For example, when querying
 // for the presence of a set of values, this method can be used which would successfully
 // return an empty set of key/value pairs if there are no matches for the supplied key
 // prefix.
 //
 func (store *Store) ReadWithPrefix(ctx context.Context, keyPrefix string) (rs *RecordSet, err error) {
-
 	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+		var response *clientv3.GetResponse
 
 		if err = store.disconnected(ctx); err != nil {
 			return err
 		}
 
 		opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
-		response, err := store.Client.Get(opCtx, keyPrefix, clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
+		response, err = store.Client.Get(
+			opCtx,
+			keyPrefix,
+			clientv3.WithPrefix(),
+			clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
 		cancel()
 
 		if err != nil {
@@ -900,7 +928,10 @@ func (store *Store) ReadWithPrefix(ctx context.Context, keyPrefix string) (rs *R
 			return err
 		}
 
-		resultSet := &RecordSet{Revision: 0, Records: make(map[string]Record, len(response.Kvs))}
+		resultSet := &RecordSet{
+			Revision: 0,
+			Records:  make(map[string]Record, len(response.Kvs)),
+		}
 
 		for i, kv := range response.Kvs {
 			key := string(kv.Key)
@@ -932,8 +963,7 @@ func (store *Store) ReadWithPrefix(ctx context.Context, keyPrefix string) (rs *R
 
 // Delete is a method used to remove a single key/value pair using the supplied name.
 //
-func (store *Store) Delete(key string) (err error) {
-
+func (store *Store) Delete(key string) error {
 	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
 		if err = store.disconnected(ctx); err != nil {
 			return err
@@ -947,10 +977,10 @@ func (store *Store) Delete(key string) (err error) {
 			store.logEtcdResponseError(ctx, err)
 		} else if 0 == response.Deleted {
 			err = ErrStoreKeyNotFound(key)
-			st.Errorf(ctx, -1, "failed to delete the requested key/value pair - error: %v", err)
+			_ = st.Errorf(ctx, -1, "failed to delete the requested key/value pair - error: %v", err)
 		} else if 1 != response.Deleted {
 			err = ErrStoreBadRecordCount{key, 1, int(response.Deleted)}
-			st.Errorf(ctx, -1, "expected a single deletion and instead received something else - error: %v", err)
+			_ = st.Errorf(ctx, -1, "expected a single deletion and instead received something else - error: %v", err)
 		} else {
 			st.Infof(ctx, -1, "deleted key: %v", key)
 		}
@@ -961,11 +991,10 @@ func (store *Store) Delete(key string) (err error) {
 
 // DeleteMultiple is a method that can be used to remove a set of key/value pairs.
 //
-// This is essentially a convenience method to allow multiuple values to be removed
+// This is essentially a convenience method to allow multiple values to be removed
 // in a single call rather than repeating individual calls to the Delete() method.
 //
-func (store *Store) DeleteMultiple(keySet []string) (err error) {
-
+func (store *Store) DeleteMultiple(keySet []string) error {
 	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
 		var processedCount int
 
@@ -989,7 +1018,7 @@ func (store *Store) DeleteMultiple(keySet []string) (err error) {
 
 		if err != nil {
 			store.logEtcdResponseError(ctx, err)
-			st.Errorf(ctx, -1, "Unable to delete all the keys - requested: %v achieved: %v", len(keySet), processedCount)
+			_ = st.Errorf(ctx, -1, "Unable to delete all the keys - requested: %v achieved: %v", len(keySet), processedCount)
 		}
 
 		if store.trace(traceFlagExpandResults) {
@@ -1007,15 +1036,16 @@ func (store *Store) DeleteMultiple(keySet []string) (err error) {
 // DeleteWithPrefix is a method used to remove an entire sub-tree of key/value
 // pairs which have a common key name prefix.
 //
-func (store *Store) DeleteWithPrefix(keyPrefix string) (err error) {
-
+func (store *Store) DeleteWithPrefix(keyPrefix string) error {
 	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
+		var response *clientv3.DeleteResponse
+
 		if err = store.disconnected(ctx); err != nil {
 			return err
 		}
 
 		opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
-		response, err := store.Client.Delete(opCtx, keyPrefix, clientv3.WithPrefix())
+		response, err = store.Client.Delete(opCtx, keyPrefix, clientv3.WithPrefix())
 		cancel()
 
 		if err != nil {
@@ -1039,7 +1069,7 @@ func (store *Store) SetWatch(key string) error {
 // SetWatchMultiple is a method used to establish a set of watchpoints on a set of
 // key/value pairs.
 //
-// This is essentially a convenience method to allow multiuple values to be fetched
+// This is essentially a convenience method to allow multiple values to be fetched
 // in a single call rather than repeating individual calls to the SetWatch() method.
 //
 func (store *Store) SetWatchMultiple(key []string) error {
@@ -1049,7 +1079,7 @@ func (store *Store) SetWatchMultiple(key []string) error {
 }
 
 // SetWatchWithPrefix is a method used to establish a watchpoint on a entire
-// sub-tree of key/value pairs whic have a common key name prefix/
+// sub-tree of key/value pairs which have a common key name prefix/
 //
 func (store *Store) SetWatchWithPrefix(keyPrefix string) error {
 	return st.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
@@ -1126,7 +1156,6 @@ type RecordUpdateSet struct {
 }
 
 func generatePrefetchKeys(recordSet *RecordUpdateSet) (*[]string, error) {
-
 	prefetchKeys := make([]string, 0, len(recordSet.Records))
 
 	// Build an array of keys to supply as the arg to prefetch
@@ -1164,7 +1193,7 @@ func generatePrefetchKeys(recordSet *RecordUpdateSet) (*[]string, error) {
 			prefetchKeys = append(prefetchKeys, k)
 
 		default:
-			return nil, ErrStoreBadArgCondition{k, Condition(ru.Condition)}
+			return nil, ErrStoreBadArgCondition{k, ru.Condition}
 		}
 	}
 
@@ -1172,7 +1201,6 @@ func generatePrefetchKeys(recordSet *RecordUpdateSet) (*[]string, error) {
 }
 
 func checkConditions(stm concurrency.STM, recordSet *RecordUpdateSet) error {
-
 	for k, ru := range recordSet.Records {
 		if ru.Condition == ConditionCreate {
 			if stm.Get(k) != "" {
@@ -1219,7 +1247,6 @@ func checkConditions(stm concurrency.STM, recordSet *RecordUpdateSet) error {
 }
 
 func getPrefetchKeys(req *Request) (*[]string, error) {
-
 	prefetchKeys := make([]string, 0, len(req.Records))
 
 	// Build an array of keys to supply as the arg to prefetch
@@ -1258,7 +1285,7 @@ func getPrefetchKeys(req *Request) (*[]string, error) {
 			prefetchKeys = append(prefetchKeys, k)
 
 		default:
-			return nil, ErrStoreBadArgCondition{k, Condition(c)}
+			return nil, ErrStoreBadArgCondition{k, c}
 		}
 	}
 
@@ -1266,7 +1293,6 @@ func getPrefetchKeys(req *Request) (*[]string, error) {
 }
 
 func chkConditions(stm concurrency.STM, req *Request) error {
-
 	for k, r := range req.Records {
 		c := req.Conditions[k]
 		if c == ConditionCreate {
@@ -1318,21 +1344,25 @@ func chkConditions(stm concurrency.STM, req *Request) error {
 // care should be taken with key naming to avoid attempting to fetch a large number
 // of key/value pairs.
 //
-// It is not an error to attmept to retrieve an empty set. For example, when querying
+// It is not an error to attempt to retrieve an empty set. For example, when querying
 // for the presence of a set of values, this method can be used which would successfully
 // return an empty set of key/value pairs if there are no matches for the supplied key
 // prefix.
 //
 func (store *Store) ListWithPrefix(ctx context.Context, keyPrefix string) (response *Response, err error) {
-
 	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+		var getResponse *clientv3.GetResponse
 
 		if err = store.disconnected(ctx); err != nil {
 			return err
 		}
 
 		opCtx, cancel := context.WithTimeout(context.Background(), store.TimeoutRequest)
-		getResponse, err := store.Client.Get(opCtx, keyPrefix, clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
+		getResponse, err = store.Client.Get(
+			opCtx,
+			keyPrefix,
+			clientv3.WithPrefix(),
+			clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
 		cancel()
 
 		if err != nil {
@@ -1340,7 +1370,10 @@ func (store *Store) ListWithPrefix(ctx context.Context, keyPrefix string) (respo
 			return err
 		}
 
-		resp := &Response{Revision: RevisionInvalid, Records: make(map[string]Record, len(getResponse.Kvs))}
+		resp := &Response{
+			Revision: RevisionInvalid,
+			Records:  make(map[string]Record, len(getResponse.Kvs)),
+		}
 
 		for i, kv := range getResponse.Kvs {
 			key := string(kv.Key)
@@ -1374,12 +1407,13 @@ func (store *Store) ListWithPrefix(ctx context.Context, keyPrefix string) (respo
 // single txn so they form a (self-)consistent set.
 //
 func (store *Store) ReadMultipleTxn(ctx context.Context, keySet RecordKeySet) (*RecordSet, error) {
-
-	resultSet := RecordSet{Revision: 0, Records: make(map[string]Record)}
+	resultSet := RecordSet{
+		Revision: 0,
+		Records:  make(map[string]Record),
+	}
 
 	err := st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-
-		if err := store.disconnected(ctx); err != nil {
+		if err = store.disconnected(ctx); err != nil {
 			return err
 		}
 
@@ -1406,7 +1440,9 @@ func (store *Store) ReadMultipleTxn(ctx context.Context, keySet RecordKeySet) (*
 			return nil
 		}
 
-		response, err := concurrency.NewSTM(
+		var response *clientv3.TxnResponse
+
+		response, err = concurrency.NewSTM(
 			store.Client,
 			actionReadRecords,
 			concurrency.WithIsolation(concurrency.ReadCommitted),
@@ -1419,7 +1455,7 @@ func (store *Store) ReadMultipleTxn(ctx context.Context, keySet RecordKeySet) (*
 
 		if !response.Succeeded {
 			err = ErrStoreKeyReadFailure(keySet.Label)
-			st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
+			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
 			return err
 		}
 
@@ -1441,12 +1477,10 @@ func (store *Store) ReadMultipleTxn(ctx context.Context, keySet RecordKeySet) (*
 // single txn so they form a (self-)consistent set.
 //
 func (store *Store) WriteMultipleTxn(ctx context.Context, recordSet *RecordUpdateSet) (int64, error) {
-
 	revision := RevisionInvalid
 
 	err := st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-
-		if err := store.disconnected(ctx); err != nil {
+		if err = store.disconnected(ctx); err != nil {
 			return err
 		}
 
@@ -1467,13 +1501,15 @@ func (store *Store) WriteMultipleTxn(ctx context.Context, recordSet *RecordUpdat
 			// all the updates.
 			//
 			for k, ru := range recordSet.Records {
-				stm.Put(k, string(ru.Record.Value))
+				stm.Put(k, ru.Record.Value)
 			}
 
 			return nil
 		}
 
-		response, err := concurrency.NewSTM(
+		var response *clientv3.TxnResponse
+
+		response, err = concurrency.NewSTM(
 			store.Client,
 			actionWriteRecords,
 			concurrency.WithIsolation(concurrency.Serializable),
@@ -1485,8 +1521,8 @@ func (store *Store) WriteMultipleTxn(ctx context.Context, recordSet *RecordUpdat
 		}
 
 		if !response.Succeeded {
-			err := ErrStoreKeyWriteFailure(recordSet.Label)
-			st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
+			err = ErrStoreKeyWriteFailure(recordSet.Label)
+			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
 			return err
 		}
 
@@ -1502,12 +1538,10 @@ func (store *Store) WriteMultipleTxn(ctx context.Context, recordSet *RecordUpdat
 // single txn so they form a (self-)consistent operation.
 //
 func (store *Store) DeleteMultipleTxn(ctx context.Context, recordSet *RecordUpdateSet) (int64, error) {
-
 	revision := RevisionInvalid
 
 	err := st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-
-		if err := store.disconnected(ctx); err != nil {
+		if err = store.disconnected(ctx); err != nil {
 			return err
 		}
 
@@ -1534,7 +1568,9 @@ func (store *Store) DeleteMultipleTxn(ctx context.Context, recordSet *RecordUpda
 			return nil
 		}
 
-		response, err := concurrency.NewSTM(
+		var response *clientv3.TxnResponse
+
+		response, err = concurrency.NewSTM(
 			store.Client,
 			actionDeleteRecords,
 			concurrency.WithIsolation(concurrency.Serializable),
@@ -1546,8 +1582,8 @@ func (store *Store) DeleteMultipleTxn(ctx context.Context, recordSet *RecordUpda
 		}
 
 		if !response.Succeeded {
-			err := ErrStoreKeyDeleteFailure(recordSet.Label)
-			st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
+			err = ErrStoreKeyDeleteFailure(recordSet.Label)
+			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
 			return err
 		}
 
@@ -1567,10 +1603,8 @@ func (store *Store) DeleteMultipleTxn(ctx context.Context, recordSet *RecordUpda
 // single txn so they form a (self-)consistent set.
 //
 func (store *Store) ReadTxn(ctx context.Context, request *Request) (response *Response, err error) {
-
 	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-
-		if err := store.disconnected(ctx); err != nil {
+		if err = store.disconnected(ctx); err != nil {
 			return err
 		}
 
@@ -1580,7 +1614,10 @@ func (store *Store) ReadTxn(ctx context.Context, request *Request) (response *Re
 			return err
 		}
 
-		resp := &Response{Revision: RevisionInvalid, Records: make(map[string]Record, len(request.Records))}
+		resp := &Response{
+			Revision: RevisionInvalid,
+			Records:  make(map[string]Record, len(request.Records)),
+		}
 
 		txnAction := func(stm concurrency.STM) error {
 
@@ -1625,7 +1662,7 @@ func (store *Store) ReadTxn(ctx context.Context, request *Request) (response *Re
 
 		if !txnResponse.Succeeded {
 			err = ErrStoreKeyReadFailure(request.Reason)
-			st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
+			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
 			return err
 		}
 
@@ -1638,17 +1675,15 @@ func (store *Store) ReadTxn(ctx context.Context, request *Request) (response *Re
 		return nil
 	})
 
-	return response, nil
+	return response, err
 }
 
 // WriteTxn is a method to write/update a set of arbitrary keys within a
 // single txn so they form a (self-)consistent set.
 //
 func (store *Store) WriteTxn(ctx context.Context, request *Request) (response *Response, err error) {
-
 	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-
-		if err := store.disconnected(ctx); err != nil {
+		if err = store.disconnected(ctx); err != nil {
 			return err
 		}
 
@@ -1658,7 +1693,10 @@ func (store *Store) WriteTxn(ctx context.Context, request *Request) (response *R
 			return err
 		}
 
-		resp := &Response{Revision: RevisionInvalid, Records: make(map[string]Record, 0)}
+		resp := &Response{
+			Revision: RevisionInvalid,
+			Records:  make(map[string]Record),
+		}
 
 		txnAction := func(stm concurrency.STM) error {
 
@@ -1671,13 +1709,15 @@ func (store *Store) WriteTxn(ctx context.Context, request *Request) (response *R
 			// all the updates.
 			//
 			for k, r := range request.Records {
-				stm.Put(k, string(r.Value))
+				stm.Put(k, r.Value)
 			}
 
 			return nil
 		}
 
-		txnResponse, err := concurrency.NewSTM(
+		var txnResponse *clientv3.TxnResponse
+
+		txnResponse, err = concurrency.NewSTM(
 			store.Client,
 			txnAction,
 			concurrency.WithIsolation(concurrency.Serializable),
@@ -1689,8 +1729,8 @@ func (store *Store) WriteTxn(ctx context.Context, request *Request) (response *R
 		}
 
 		if !txnResponse.Succeeded {
-			err := ErrStoreKeyWriteFailure(request.Reason)
-			st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
+			err = ErrStoreKeyWriteFailure(request.Reason)
+			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
 			return err
 		}
 
@@ -1710,10 +1750,8 @@ func (store *Store) WriteTxn(ctx context.Context, request *Request) (response *R
 // single txn so they form a (self-)consistent operation.
 //
 func (store *Store) DeleteTxn(ctx context.Context, request *Request) (response *Response, err error) {
-
 	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-
-		if err := store.disconnected(ctx); err != nil {
+		if err = store.disconnected(ctx); err != nil {
 			return err
 		}
 
@@ -1723,7 +1761,10 @@ func (store *Store) DeleteTxn(ctx context.Context, request *Request) (response *
 			return err
 		}
 
-		resp := &Response{Revision: RevisionInvalid, Records: make(map[string]Record, 0)}
+		resp := &Response{
+			Revision: RevisionInvalid,
+			Records:  make(map[string]Record),
+		}
 
 		txnAction := func(stm concurrency.STM) error {
 
@@ -1742,7 +1783,9 @@ func (store *Store) DeleteTxn(ctx context.Context, request *Request) (response *
 			return nil
 		}
 
-		txnResponse, err := concurrency.NewSTM(
+		var txnResponse *clientv3.TxnResponse
+
+		txnResponse, err = concurrency.NewSTM(
 			store.Client,
 			txnAction,
 			concurrency.WithIsolation(concurrency.Serializable),
@@ -1754,8 +1797,8 @@ func (store *Store) DeleteTxn(ctx context.Context, request *Request) (response *
 		}
 
 		if !txnResponse.Succeeded {
-			err := ErrStoreKeyDeleteFailure(request.Reason)
-			st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
+			err = ErrStoreKeyDeleteFailure(request.Reason)
+			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
 			return err
 		}
 

--- a/internal/clients/store/storeapi.go
+++ b/internal/clients/store/storeapi.go
@@ -1,16 +1,16 @@
 package store
 
 import (
-	"context"
-	"strings"
+    "context"
+    "strings"
 
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
+    "github.com/golang/protobuf/jsonpb"
+    "github.com/golang/protobuf/proto"
 
-	"github.com/Jim3Things/CloudChamber/internal/tracing"
-	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+    "github.com/Jim3Things/CloudChamber/internal/tracing"
+    st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 
-	"google.golang.org/protobuf/runtime/protoiface"
+    "google.golang.org/protobuf/runtime/protoiface"
 )
 
 // KeyRoot is used to describe which part of the store namespace
@@ -21,52 +21,52 @@ type KeyRoot int
 // The set of available namespace roots used by various record types
 //
 const (
-	KeyRootUsers KeyRoot = iota
-	KeyRootBlades
-	KeyRootRacks
-	KeyRootWorkloads
-	KeyRootStoreTest
+    KeyRootUsers KeyRoot = iota
+    KeyRootBlades
+    KeyRootRacks
+    KeyRootWorkloads
+    KeyRootStoreTest
 )
 const (
-	namespaceRootUsers     = "users"
-	namespaceRootRacks     = "racks"
-	namespaceRootBlades    = "blades"
-	namespaceRootWorkloads = "workloads"
-	namespaceRootStoreTest = "storetest"
+    namespaceRootUsers     = "users"
+    namespaceRootRacks     = "racks"
+    namespaceRootBlades    = "blades"
+    namespaceRootWorkloads = "workloads"
+    namespaceRootStoreTest = "storetest"
 )
 
 var namespaceRoots = map[KeyRoot]string{
-	KeyRootUsers:     namespaceRootUsers,
-	KeyRootRacks:     namespaceRootBlades,
-	KeyRootBlades:    namespaceRootBlades,
-	KeyRootWorkloads: namespaceRootWorkloads,
-	KeyRootStoreTest: namespaceRootStoreTest,
+    KeyRootUsers:     namespaceRootUsers,
+    KeyRootRacks:     namespaceRootBlades,
+    KeyRootBlades:    namespaceRootBlades,
+    KeyRootWorkloads: namespaceRootWorkloads,
+    KeyRootStoreTest: namespaceRootStoreTest,
 }
 
 func getNamespaceRootFromKeyRoot(r KeyRoot) string {
-	return namespaceRoots[r]
+    return namespaceRoots[r]
 }
 
 func getNamespacePrefixFromKeyRoot(r KeyRoot) string {
-	return namespaceRoots[r] + "/"
+    return namespaceRoots[r] + "/"
 }
 
 func getKeyFromKeyRootAndName(r KeyRoot, n string) string {
-	return namespaceRoots[r] + "/" + GetNormalizedName(n)
+    return namespaceRoots[r] + "/" + GetNormalizedName(n)
 }
 
 // GetKeyFromUsername1 is a utility function to convert a supplied username to
 // a store usable key for use when operating with user records.
 //
 func GetKeyFromUsername1(name string) string {
-	return getKeyFromKeyRootAndName(KeyRootUsers, name)
+    return getKeyFromKeyRootAndName(KeyRootUsers, name)
 }
 
 // GetNormalizedName is a utility function to prepare a name for use when
 // building a key suitable for operating with records in the store
 //
 func GetNormalizedName(name string) string {
-	return strings.ToLower(name)
+    return strings.ToLower(name)
 }
 
 // Request is a struct defining the collection of values needed to make a request
@@ -74,143 +74,136 @@ func GetNormalizedName(name string) string {
 // For example, setting any "value" for a read request is ignored.
 //
 type Request struct {
-	Reason     string
-	Records    map[string]Record
-	Conditions map[string]Condition
+    Reason     string
+    Records    map[string]Record
+    Conditions map[string]Condition
 }
 
 // Response is a struct defining the set of values returned from a request.
 //
 type Response struct {
-	Revision int64
-	Records  map[string]Record
+    Revision int64
+    Records  map[string]Record
 }
 
 // Encode is a default protobuf defined message to JSON encoded string encoder
 //
 func Encode(m proto.Message) (s string, err error) {
-	p := jsonpb.Marshaler{}
+    p := jsonpb.Marshaler{}
 
-	if s, err = p.MarshalToString(m); err != nil {
-		return "", err
-	}
+    if s, err = p.MarshalToString(m); err != nil {
+        return "", err
+    }
 
-	return s, nil
+    return s, nil
 }
 
 // Decode is a default JSON encoded string to protobuf defined message decoder
 //
 func Decode(s string, m protoiface.MessageV1) error {
-	if err := jsonpb.Unmarshal(strings.NewReader(s), m); err != nil {
-		return err
-	}
+    if err := jsonpb.Unmarshal(strings.NewReader(s), m); err != nil {
+        return err
+    }
 
-	return nil
+    return nil
 }
 
 // CreateNew is a function to create a single key, value record pair
 //
 func (store *Store) CreateNew(
-		ctx context.Context,
-		r KeyRoot,
-		n string,
-		m protoiface.MessageV1) (revision int64, err error) {
-	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-		var (
-			v string
-			resp *Response
-		)
+        ctx context.Context,
+        r KeyRoot,
+        n string,
+        m protoiface.MessageV1) (revision int64, err error) {
+    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+        prefix := getNamespacePrefixFromKeyRoot(r)
 
-		prefix := getNamespacePrefixFromKeyRoot(r)
+        st.Infof(ctx, -1, "Request to create new %q under prefix %q", n, prefix)
 
-		st.Infof(ctx, -1, "Request to create new %q under prefix %q", n, prefix)
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+        v, err := Encode(m)
 
-		v, err = Encode(m)
+        if err != nil {
+            return err
+        }
 
-		if err != nil {
-			return err
-		}
+        request := &Request{
+            Records:    make(map[string]Record),
+            Conditions: make(map[string]Condition),
+        }
 
-		request := &Request{
-			Records:    make(map[string]Record),
-			Conditions: make(map[string]Condition),
-		}
+        k := getKeyFromKeyRootAndName(r, n)
+        request.Records[k] = Record{Revision: RevisionInvalid, Value: v}
+        request.Conditions[k] = ConditionCreate
 
-		k := getKeyFromKeyRootAndName(r, n)
-		request.Records[k] = Record{Revision: RevisionInvalid, Value: v}
-		request.Conditions[k] = ConditionCreate
+        resp, err := store.WriteTxn(ctx, request)
 
-		resp, err = store.WriteTxn(ctx, request)
+        // Need to strip the namespace prefix and return something described
+        // in terms the caller should recognize
+        //
+        if err == ErrStoreAlreadyExists(k) {
+            return ErrStoreAlreadyExists(n)
+        }
 
-		// Need to strip the namespace prefix and return something described
-		// in terms the caller should recognize
-		//
-		if err == ErrStoreAlreadyExists(k) {
-			return ErrStoreAlreadyExists(n)
-		}
+        if err != nil {
+            return err
+        }
 
-		if err != nil {
-			return err
-		}
+        st.Infof(ctx, -1, "Created record for %q under prefix %q with revision %v", n, prefix, resp.Revision)
 
-		st.Infof(ctx, -1, "Created record for %q under prefix %q with revision %v", n, prefix, resp.Revision)
+        revision = resp.Revision
 
-		revision = resp.Revision
+        return nil
+    })
 
-		return nil
-	})
-
-	return revision, err
+    return revision, err
 }
 
 // CreateNewValue is a function to create a single key, value record pair
 //
 func (store *Store) CreateNewValue(ctx context.Context, r KeyRoot, n string, v string) (revision int64, err error) {
-	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-		var resp *Response
+    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+        prefix := getNamespacePrefixFromKeyRoot(r)
 
-		prefix := getNamespacePrefixFromKeyRoot(r)
+        st.Infof(ctx, -1, "Request to create new %q under prefix %q", n, prefix)
 
-		st.Infof(ctx, -1, "Request to create new %q under prefix %q", n, prefix)
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+        request := &Request{
+            Records:    make(map[string]Record),
+            Conditions: make(map[string]Condition),
+        }
 
-		request := &Request{
-			Records:    make(map[string]Record),
-			Conditions: make(map[string]Condition),
-		}
+        k := getKeyFromKeyRootAndName(r, n)
+        request.Records[k] = Record{Revision: RevisionInvalid, Value: v}
+        request.Conditions[k] = ConditionCreate
 
-		k := getKeyFromKeyRootAndName(r, n)
-		request.Records[k] = Record{Revision: RevisionInvalid, Value: v}
-		request.Conditions[k] = ConditionCreate
+        resp, err := store.WriteTxn(ctx, request)
 
-		resp, err = store.WriteTxn(ctx, request)
+        // Need to strip the namespace prefix and return something described
+        // in terms the caller should recognize
+        //
+        if err == ErrStoreAlreadyExists(k) {
+            return ErrStoreAlreadyExists(n)
+        }
 
-		// Need to strip the namespace prefix and return something described
-		// in terms the caller should recognize
-		//
-		if err == ErrStoreAlreadyExists(k) {
-			return ErrStoreAlreadyExists(n)
-		}
+        if err != nil {
+            return err
+        }
 
-		if err != nil {
-			return err
-		}
+        st.Infof(ctx, -1, "Created record for %q under prefix %q with revision %v", n, prefix, resp.Revision)
 
-		st.Infof(ctx, -1, "Created record for %q under prefix %q with revision %v", n, prefix, resp.Revision)
+        revision = resp.Revision
 
-		revision = resp.Revision
+        return nil
+    })
 
-		return nil
-	})
-
-	return revision, err
+    return revision, err
 }
 
 // ReadNew is a method to retrieve the user record associated with the
@@ -224,71 +217,71 @@ func (store *Store) CreateNewValue(ctx context.Context, r KeyRoot, n string, v s
 //       about the encode/decode formats or indeed the target record itself.
 //
 func (store *Store) ReadNew(
-		ctx context.Context,
-		r KeyRoot,
-		n string,
-		m protoiface.MessageV1) (revision int64, err error) {
-	revision = RevisionInvalid
+        ctx context.Context,
+        r KeyRoot,
+        n string,
+        m protoiface.MessageV1) (revision int64, err error) {
+    revision = RevisionInvalid
 
-	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-		prefix := getNamespacePrefixFromKeyRoot(r)
+    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+        prefix := getNamespacePrefixFromKeyRoot(r)
 
-		st.Infof(ctx, -1, "Request to read and decode %q under prefix %q", n, prefix)
+        st.Infof(ctx, -1, "Request to read and decode %q under prefix %q", n, prefix)
 
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		var (
-			rev      int64
-			val      string
-			response *Response
-		)
+        var (
+            rev      int64
+            val      string
+            response *Response
+        )
 
-		// If we need to do the read to get the revision, we will need an array of the keys
-		//
-		request := &Request{
-			Records:    make(map[string]Record),
-			Conditions: make(map[string]Condition),
-		}
+        // If we need to do the read to get the revision, we will need an array of the keys
+        //
+        request := &Request{
+            Records:    make(map[string]Record),
+            Conditions: make(map[string]Condition),
+        }
 
-		k := getKeyFromKeyRootAndName(r, n)
-		request.Records[k] = Record{Revision: RevisionInvalid}
-		request.Conditions[k] = ConditionUnconditional
+        k := getKeyFromKeyRootAndName(r, n)
+        request.Records[k] = Record{Revision: RevisionInvalid}
+        request.Conditions[k] = ConditionUnconditional
 
-		if response, err = store.ReadTxn(ctx, request); err != nil {
-			return err
-		}
+        if response, err = store.ReadTxn(ctx, request); err != nil {
+            return err
+        }
 
-		recordCount := len(response.Records)
+        recordCount := len(response.Records)
 
-		switch recordCount {
-		default:
-			return ErrStoreBadRecordCount{n, 1, recordCount}
+        switch recordCount {
+        default:
+            return ErrStoreBadRecordCount{n, 1, recordCount}
 
-		case 0:
-			return ErrStoreKeyNotFound(n)
+        case 0:
+            return ErrStoreKeyNotFound(n)
 
-		case 1:
-			rev = response.Records[k].Revision
-			val = response.Records[k].Value
+        case 1:
+            rev = response.Records[k].Revision
+            val = response.Records[k].Value
 
-			if err = Decode(val, m); err != nil {
-				return err
-			}
+            if err = Decode(val, m); err != nil {
+                return err
+            }
 
-			st.Infof(
-				ctx, -1,
-				"found and decoded record for %q under prefix %q with revision %v and value %q",
-				n, prefix, rev, val)
+            st.Infof(
+                ctx, -1,
+                "found and decoded record for %q under prefix %q with revision %v and value %q",
+                n, prefix, rev, val)
 
-			revision = rev
+            revision = rev
 
-			return nil
-		}
-	})
+            return nil
+        }
+    })
 
-	return revision, err
+    return revision, err
 }
 
 // ReadNewValue is a method to retrieve the user record associated with the
@@ -302,181 +295,177 @@ func (store *Store) ReadNew(
 //       about the encode/decode formats or indeed the target record itself.
 //
 func (store *Store) ReadNewValue(ctx context.Context, r KeyRoot, n string) (value *string, revision int64, err error) {
-	revision = RevisionInvalid
+    revision = RevisionInvalid
 
-	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-		prefix := getNamespacePrefixFromKeyRoot(r)
+    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+        prefix := getNamespacePrefixFromKeyRoot(r)
 
-		st.Infof(ctx, -1, "Request to read value of %q under prefix %q", n, prefix)
+        st.Infof(ctx, -1, "Request to read value of %q under prefix %q", n, prefix)
 
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		var (
-			rev      int64
-			val      string
-			response *Response
-		)
+        var (
+            rev      int64
+            val      string
+            response *Response
+        )
 
-		// If we need to do the read to get the revision, we will need an array of the keys
-		//
-		request := &Request{
-			Records:    make(map[string]Record),
-			Conditions: make(map[string]Condition),
-		}
+        // If we need to do the read to get the revision, we will need an array of the keys
+        //
+        request := &Request{
+            Records:    make(map[string]Record),
+            Conditions: make(map[string]Condition),
+        }
 
-		k := getKeyFromKeyRootAndName(r, n)
-		request.Records[k] = Record{Revision: RevisionInvalid}
-		request.Conditions[k] = ConditionUnconditional
+        k := getKeyFromKeyRootAndName(r, n)
+        request.Records[k] = Record{Revision: RevisionInvalid}
+        request.Conditions[k] = ConditionUnconditional
 
-		if response, err = store.ReadTxn(ctx, request); err != nil {
-			return err
-		}
+        if response, err = store.ReadTxn(ctx, request); err != nil {
+            return err
+        }
 
-		recordCount := len(response.Records)
+        recordCount := len(response.Records)
 
-		switch recordCount {
-		default:
-			return ErrStoreBadRecordCount{n, 1, recordCount}
+        switch recordCount {
+        default:
+            return ErrStoreBadRecordCount{n, 1, recordCount}
 
-		case 0:
-			return ErrStoreKeyNotFound(n)
+        case 0:
+            return ErrStoreKeyNotFound(n)
 
-		case 1:
-			rev = response.Records[k].Revision
-			val = response.Records[k].Value
-			st.Infof(ctx, -1, "found record for %q under prefix %q, with revision %v and value %q", n, prefix, rev, val)
+        case 1:
+            rev = response.Records[k].Revision
+            val = response.Records[k].Value
+            st.Infof(ctx, -1, "found record for %q under prefix %q, with revision %v and value %q", n, prefix, rev, val)
 
-			revision = rev
-			value = &val
+            revision = rev
+            value = &val
 
-			return nil
-		}
-	})
+            return nil
+        }
+    })
 
-	return value, revision, err
+    return value, revision, err
 }
 
 // UpdateNew is a function to conditionally update a value for a single key
 //
 func (store *Store) UpdateNew(
-		ctx context.Context,
-		r KeyRoot,
-		n string,
-		rev int64,
-		m protoiface.MessageV1) (revision int64, err error) {
-	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-		var (
-			v string
-			resp *Response
-		)
+        ctx context.Context,
+        r KeyRoot,
+        n string,
+        rev int64,
+        m protoiface.MessageV1) (revision int64, err error) {
+    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+        prefix := getNamespacePrefixFromKeyRoot(r)
 
-		prefix := getNamespacePrefixFromKeyRoot(r)
+        st.Infof(ctx, -1, "Request to update %q under prefix %q", n, prefix)
 
-		st.Infof(ctx, -1, "Request to update %q under prefix %q", n, prefix)
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+        v, err := Encode(m)
 
-		v, err = Encode(m)
+        if err != nil {
+            return err
+        }
 
-		if err != nil {
-			return err
-		}
+        var condition Condition
 
-		var condition Condition
+        switch {
+        case rev == RevisionInvalid:
+            condition = ConditionUnconditional
 
-		switch {
-		case rev == RevisionInvalid:
-			condition = ConditionUnconditional
+        default:
+            condition = ConditionRevisionEqual
+        }
 
-		default:
-			condition = ConditionRevisionEqual
-		}
+        request := &Request{
+            Records:    make(map[string]Record),
+            Conditions: make(map[string]Condition)}
 
-		request := &Request{
-			Records:    make(map[string]Record),
-			Conditions: make(map[string]Condition)}
+        k := getKeyFromKeyRootAndName(r, n)
+        request.Records[k] = Record{Revision: rev, Value: v}
+        request.Conditions[k] = condition
 
-		k := getKeyFromKeyRootAndName(r, n)
-		request.Records[k] = Record{Revision: rev, Value: v}
-		request.Conditions[k] = condition
+        resp, err := store.WriteTxn(ctx, request)
 
-		resp, err = store.WriteTxn(ctx, request)
+        if err != nil {
+            return err
+        }
 
-		if err != nil {
-			return err
-		}
+        st.Infof(
+            ctx, -1,
+            "Updated record %q under prefix %q from revision %v to revision %v",
+            n, prefix, rev, resp.Revision)
 
-		st.Infof(ctx, -1, "Updated record %q under prefix %q from revision %v to revision %v", n, prefix, rev, resp.Revision)
+        revision = resp.Revision
 
-		revision = resp.Revision
+        return nil
+    })
 
-		return nil
-	})
-
-	return revision, err
+    return revision, err
 }
 
 // DeleteNew is a function to delete a single key, value record pair
 //
 func (store *Store) DeleteNew(ctx context.Context, r KeyRoot, n string, rev int64) (revision int64, err error) {
-	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-		var resp *Response
+    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+        prefix := getNamespacePrefixFromKeyRoot(r)
 
-		prefix := getNamespacePrefixFromKeyRoot(r)
+        st.Infof(ctx, -1, "Request to delete %q under prefix %q", n, prefix)
 
-		st.Infof(ctx, -1, "Request to delete %q under prefix %q", n, prefix)
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+        var condition Condition
 
-		var condition Condition
+        switch {
+        case rev == RevisionInvalid:
+            condition = ConditionUnconditional
 
-		switch {
-		case rev == RevisionInvalid:
-			condition = ConditionUnconditional
+        default:
+            condition = ConditionRevisionEqual
+        }
 
-		default:
-			condition = ConditionRevisionEqual
-		}
+        request := &Request{
+            Records:    make(map[string]Record),
+            Conditions: make(map[string]Condition),
+        }
 
-		request := &Request{
-			Records:    make(map[string]Record),
-			Conditions: make(map[string]Condition),
-		}
+        k := getKeyFromKeyRootAndName(r, n)
+        request.Records[k] = Record{Revision: rev}
+        request.Conditions[k] = condition
 
-		k := getKeyFromKeyRootAndName(r, n)
-		request.Records[k] = Record{Revision: rev}
-		request.Conditions[k] = condition
+        resp, err := store.DeleteTxn(ctx, request)
 
-		resp, err = store.DeleteTxn(ctx, request)
+        // Need to strip the namespace prefix and return something described
+        // in terms the caller should recognize
+        //
+        if err == ErrStoreKeyNotFound(k) {
+            return ErrStoreKeyNotFound(n)
+        }
 
-		// Need to strip the namespace prefix and return something described
-		// in terms the caller should recognize
-		//
-		if err == ErrStoreKeyNotFound(k) {
-			return ErrStoreKeyNotFound(n)
-		}
+        if err != nil {
+            return err
+        }
 
-		if err != nil {
-			return err
-		}
+        st.Infof(
+            ctx, -1,
+            "Deleted record for %q under prefix %q with revision %v resulting in store revision %v",
+            n, prefix, rev, resp.Revision)
 
-		st.Infof(
-			ctx, -1,
-			"Deleted record for %q under prefix %q with revision %v resulting in store revision %v",
-			n, prefix, rev, resp.Revision)
+        revision = resp.Revision
 
-		revision = resp.Revision
+        return nil
+    })
 
-		return nil
-	})
-
-	return revision, err
+    return revision, err
 }
 
 // ListNew is a method to return all the user records using a single call.
@@ -486,49 +475,47 @@ func (store *Store) DeleteNew(ctx context.Context, r KeyRoot, n string, rev int6
 // NOTE: This should only be used at present if the number of user records
 //       is limited as there is a limit to the number of records that can
 //       be fetched from the store in a single shot. Eventually this will
-//       be updated to user an "interrupted" enum style call to allow for
+//       be updated to use an "interrupted" enum style call to allow for
 //		 an essentially infinite number of records.
 //
 func (store *Store) ListNew(ctx context.Context, r KeyRoot) (records *map[string]Record, revision int64, err error) {
-	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-		var response *Response
+    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+        prefix := getNamespacePrefixFromKeyRoot(r)
 
-		prefix := getNamespacePrefixFromKeyRoot(r)
+        st.Infof(ctx, -1, "Request to list keys under prefix %q", prefix)
 
-		st.Infof(ctx, -1, "Request to list keys under prefix %q", prefix)
+        if err = store.disconnected(ctx); err != nil {
+            return err
+        }
 
-		if err = store.disconnected(ctx); err != nil {
-			return err
-		}
+        response, err := store.ListWithPrefix(ctx, prefix)
 
-		response, err = store.ListWithPrefix(ctx, prefix)
+        if err != nil {
+            return err
+        }
 
-		if err != nil {
-			return err
-		}
+        recs := make(map[string]Record, len(response.Records))
 
-		recs := make(map[string]Record, len(response.Records))
+        for k, record := range response.Records {
 
-		for k, record := range response.Records {
+            if !strings.HasPrefix(k, prefix) {
+                return ErrStoreBadRecordKey(k)
+            }
 
-			if !strings.HasPrefix(k, prefix) {
-				return ErrStoreBadRecordKey(k)
-			}
+            name := strings.TrimPrefix(k, prefix)
 
-			name := strings.TrimPrefix(k, prefix)
+            recs[name] = Record{Revision: record.Revision, Value: record.Value}
 
-			recs[name] = Record{Revision: record.Revision, Value: record.Value}
+            st.Infof(ctx, -1, "found record with key %q for name %q with revision %v", k, name, record.Revision)
+        }
 
-			st.Infof(ctx, -1, "found record with key %q for name %q with revision %v", k, name, record.Revision)
-		}
+        st.Infof(ctx, -1, "returned %v records at store revision %v", len(response.Records), response.Revision)
 
-		st.Infof(ctx, -1, "returned %v records at store revision %v", len(response.Records), response.Revision)
+        records = &recs
+        revision = response.Revision
 
-		records = &recs
-		revision = response.Revision
+        return nil
+    })
 
-		return nil
-	})
-
-	return records, revision, err
+    return records, revision, err
 }

--- a/internal/clients/store/storeapi.go
+++ b/internal/clients/store/storeapi.go
@@ -1,16 +1,16 @@
 package store
 
 import (
-    "context"
-    "strings"
+	"context"
+	"strings"
 
-    "github.com/golang/protobuf/jsonpb"
-    "github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
 
-    "github.com/Jim3Things/CloudChamber/internal/tracing"
-    st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+	"github.com/Jim3Things/CloudChamber/internal/tracing"
+	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 
-    "google.golang.org/protobuf/runtime/protoiface"
+	"google.golang.org/protobuf/runtime/protoiface"
 )
 
 // KeyRoot is used to describe which part of the store namespace
@@ -21,52 +21,52 @@ type KeyRoot int
 // The set of available namespace roots used by various record types
 //
 const (
-    KeyRootUsers KeyRoot = iota
-    KeyRootBlades
-    KeyRootRacks
-    KeyRootWorkloads
-    KeyRootStoreTest
+	KeyRootUsers KeyRoot = iota
+	KeyRootBlades
+	KeyRootRacks
+	KeyRootWorkloads
+	KeyRootStoreTest
 )
 const (
-    namespaceRootUsers     = "users"
-    namespaceRootRacks     = "racks"
-    namespaceRootBlades    = "blades"
-    namespaceRootWorkloads = "workloads"
-    namespaceRootStoreTest = "storetest"
+	namespaceRootUsers     = "users"
+	namespaceRootRacks     = "racks"
+	namespaceRootBlades    = "blades"
+	namespaceRootWorkloads = "workloads"
+	namespaceRootStoreTest = "storetest"
 )
 
 var namespaceRoots = map[KeyRoot]string{
-    KeyRootUsers:     namespaceRootUsers,
-    KeyRootRacks:     namespaceRootBlades,
-    KeyRootBlades:    namespaceRootBlades,
-    KeyRootWorkloads: namespaceRootWorkloads,
-    KeyRootStoreTest: namespaceRootStoreTest,
+	KeyRootUsers:     namespaceRootUsers,
+	KeyRootRacks:     namespaceRootBlades,
+	KeyRootBlades:    namespaceRootBlades,
+	KeyRootWorkloads: namespaceRootWorkloads,
+	KeyRootStoreTest: namespaceRootStoreTest,
 }
 
 func getNamespaceRootFromKeyRoot(r KeyRoot) string {
-    return namespaceRoots[r]
+	return namespaceRoots[r]
 }
 
 func getNamespacePrefixFromKeyRoot(r KeyRoot) string {
-    return namespaceRoots[r] + "/"
+	return namespaceRoots[r] + "/"
 }
 
 func getKeyFromKeyRootAndName(r KeyRoot, n string) string {
-    return namespaceRoots[r] + "/" + GetNormalizedName(n)
+	return namespaceRoots[r] + "/" + GetNormalizedName(n)
 }
 
 // GetKeyFromUsername1 is a utility function to convert a supplied username to
 // a store usable key for use when operating with user records.
 //
 func GetKeyFromUsername1(name string) string {
-    return getKeyFromKeyRootAndName(KeyRootUsers, name)
+	return getKeyFromKeyRootAndName(KeyRootUsers, name)
 }
 
 // GetNormalizedName is a utility function to prepare a name for use when
 // building a key suitable for operating with records in the store
 //
 func GetNormalizedName(name string) string {
-    return strings.ToLower(name)
+	return strings.ToLower(name)
 }
 
 // Request is a struct defining the collection of values needed to make a request
@@ -74,136 +74,136 @@ func GetNormalizedName(name string) string {
 // For example, setting any "value" for a read request is ignored.
 //
 type Request struct {
-    Reason     string
-    Records    map[string]Record
-    Conditions map[string]Condition
+	Reason     string
+	Records    map[string]Record
+	Conditions map[string]Condition
 }
 
 // Response is a struct defining the set of values returned from a request.
 //
 type Response struct {
-    Revision int64
-    Records  map[string]Record
+	Revision int64
+	Records  map[string]Record
 }
 
 // Encode is a default protobuf defined message to JSON encoded string encoder
 //
 func Encode(m proto.Message) (s string, err error) {
-    p := jsonpb.Marshaler{}
+	p := jsonpb.Marshaler{}
 
-    if s, err = p.MarshalToString(m); err != nil {
-        return "", err
-    }
+	if s, err = p.MarshalToString(m); err != nil {
+		return "", err
+	}
 
-    return s, nil
+	return s, nil
 }
 
 // Decode is a default JSON encoded string to protobuf defined message decoder
 //
 func Decode(s string, m protoiface.MessageV1) error {
-    if err := jsonpb.Unmarshal(strings.NewReader(s), m); err != nil {
-        return err
-    }
+	if err := jsonpb.Unmarshal(strings.NewReader(s), m); err != nil {
+		return err
+	}
 
-    return nil
+	return nil
 }
 
 // CreateNew is a function to create a single key, value record pair
 //
 func (store *Store) CreateNew(
-        ctx context.Context,
-        r KeyRoot,
-        n string,
-        m protoiface.MessageV1) (revision int64, err error) {
-    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-        prefix := getNamespacePrefixFromKeyRoot(r)
+	ctx context.Context,
+	r KeyRoot,
+	n string,
+	m protoiface.MessageV1) (revision int64, err error) {
+	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+		prefix := getNamespacePrefixFromKeyRoot(r)
 
-        st.Infof(ctx, -1, "Request to create new %q under prefix %q", n, prefix)
+		st.Infof(ctx, -1, "Request to create new %q under prefix %q", n, prefix)
 
-        if err = store.disconnected(ctx); err != nil {
-            return err
-        }
+		if err = store.disconnected(ctx); err != nil {
+			return err
+		}
 
-        v, err := Encode(m)
+		v, err := Encode(m)
 
-        if err != nil {
-            return err
-        }
+		if err != nil {
+			return err
+		}
 
-        request := &Request{
-            Records:    make(map[string]Record),
-            Conditions: make(map[string]Condition),
-        }
+		request := &Request{
+			Records:    make(map[string]Record),
+			Conditions: make(map[string]Condition),
+		}
 
-        k := getKeyFromKeyRootAndName(r, n)
-        request.Records[k] = Record{Revision: RevisionInvalid, Value: v}
-        request.Conditions[k] = ConditionCreate
+		k := getKeyFromKeyRootAndName(r, n)
+		request.Records[k] = Record{Revision: RevisionInvalid, Value: v}
+		request.Conditions[k] = ConditionCreate
 
-        resp, err := store.WriteTxn(ctx, request)
+		resp, err := store.WriteTxn(ctx, request)
 
-        // Need to strip the namespace prefix and return something described
-        // in terms the caller should recognize
-        //
-        if err == ErrStoreAlreadyExists(k) {
-            return ErrStoreAlreadyExists(n)
-        }
+		// Need to strip the namespace prefix and return something described
+		// in terms the caller should recognize
+		//
+		if err == ErrStoreAlreadyExists(k) {
+			return ErrStoreAlreadyExists(n)
+		}
 
-        if err != nil {
-            return err
-        }
+		if err != nil {
+			return err
+		}
 
-        st.Infof(ctx, -1, "Created record for %q under prefix %q with revision %v", n, prefix, resp.Revision)
+		st.Infof(ctx, -1, "Created record for %q under prefix %q with revision %v", n, prefix, resp.Revision)
 
-        revision = resp.Revision
+		revision = resp.Revision
 
-        return nil
-    })
+		return nil
+	})
 
-    return revision, err
+	return revision, err
 }
 
 // CreateNewValue is a function to create a single key, value record pair
 //
 func (store *Store) CreateNewValue(ctx context.Context, r KeyRoot, n string, v string) (revision int64, err error) {
-    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-        prefix := getNamespacePrefixFromKeyRoot(r)
+	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+		prefix := getNamespacePrefixFromKeyRoot(r)
 
-        st.Infof(ctx, -1, "Request to create new %q under prefix %q", n, prefix)
+		st.Infof(ctx, -1, "Request to create new %q under prefix %q", n, prefix)
 
-        if err = store.disconnected(ctx); err != nil {
-            return err
-        }
+		if err = store.disconnected(ctx); err != nil {
+			return err
+		}
 
-        request := &Request{
-            Records:    make(map[string]Record),
-            Conditions: make(map[string]Condition),
-        }
+		request := &Request{
+			Records:    make(map[string]Record),
+			Conditions: make(map[string]Condition),
+		}
 
-        k := getKeyFromKeyRootAndName(r, n)
-        request.Records[k] = Record{Revision: RevisionInvalid, Value: v}
-        request.Conditions[k] = ConditionCreate
+		k := getKeyFromKeyRootAndName(r, n)
+		request.Records[k] = Record{Revision: RevisionInvalid, Value: v}
+		request.Conditions[k] = ConditionCreate
 
-        resp, err := store.WriteTxn(ctx, request)
+		resp, err := store.WriteTxn(ctx, request)
 
-        // Need to strip the namespace prefix and return something described
-        // in terms the caller should recognize
-        //
-        if err == ErrStoreAlreadyExists(k) {
-            return ErrStoreAlreadyExists(n)
-        }
+		// Need to strip the namespace prefix and return something described
+		// in terms the caller should recognize
+		//
+		if err == ErrStoreAlreadyExists(k) {
+			return ErrStoreAlreadyExists(n)
+		}
 
-        if err != nil {
-            return err
-        }
+		if err != nil {
+			return err
+		}
 
-        st.Infof(ctx, -1, "Created record for %q under prefix %q with revision %v", n, prefix, resp.Revision)
+		st.Infof(ctx, -1, "Created record for %q under prefix %q with revision %v", n, prefix, resp.Revision)
 
-        revision = resp.Revision
+		revision = resp.Revision
 
-        return nil
-    })
+		return nil
+	})
 
-    return revision, err
+	return revision, err
 }
 
 // ReadNew is a method to retrieve the user record associated with the
@@ -217,71 +217,71 @@ func (store *Store) CreateNewValue(ctx context.Context, r KeyRoot, n string, v s
 //       about the encode/decode formats or indeed the target record itself.
 //
 func (store *Store) ReadNew(
-        ctx context.Context,
-        r KeyRoot,
-        n string,
-        m protoiface.MessageV1) (revision int64, err error) {
-    revision = RevisionInvalid
+	ctx context.Context,
+	r KeyRoot,
+	n string,
+	m protoiface.MessageV1) (revision int64, err error) {
+	revision = RevisionInvalid
 
-    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-        prefix := getNamespacePrefixFromKeyRoot(r)
+	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+		prefix := getNamespacePrefixFromKeyRoot(r)
 
-        st.Infof(ctx, -1, "Request to read and decode %q under prefix %q", n, prefix)
+		st.Infof(ctx, -1, "Request to read and decode %q under prefix %q", n, prefix)
 
-        if err = store.disconnected(ctx); err != nil {
-            return err
-        }
+		if err = store.disconnected(ctx); err != nil {
+			return err
+		}
 
-        var (
-            rev      int64
-            val      string
-            response *Response
-        )
+		var (
+			rev      int64
+			val      string
+			response *Response
+		)
 
-        // If we need to do the read to get the revision, we will need an array of the keys
-        //
-        request := &Request{
-            Records:    make(map[string]Record),
-            Conditions: make(map[string]Condition),
-        }
+		// If we need to do the read to get the revision, we will need an array of the keys
+		//
+		request := &Request{
+			Records:    make(map[string]Record),
+			Conditions: make(map[string]Condition),
+		}
 
-        k := getKeyFromKeyRootAndName(r, n)
-        request.Records[k] = Record{Revision: RevisionInvalid}
-        request.Conditions[k] = ConditionUnconditional
+		k := getKeyFromKeyRootAndName(r, n)
+		request.Records[k] = Record{Revision: RevisionInvalid}
+		request.Conditions[k] = ConditionUnconditional
 
-        if response, err = store.ReadTxn(ctx, request); err != nil {
-            return err
-        }
+		if response, err = store.ReadTxn(ctx, request); err != nil {
+			return err
+		}
 
-        recordCount := len(response.Records)
+		recordCount := len(response.Records)
 
-        switch recordCount {
-        default:
-            return ErrStoreBadRecordCount{n, 1, recordCount}
+		switch recordCount {
+		default:
+			return ErrStoreBadRecordCount{n, 1, recordCount}
 
-        case 0:
-            return ErrStoreKeyNotFound(n)
+		case 0:
+			return ErrStoreKeyNotFound(n)
 
-        case 1:
-            rev = response.Records[k].Revision
-            val = response.Records[k].Value
+		case 1:
+			rev = response.Records[k].Revision
+			val = response.Records[k].Value
 
-            if err = Decode(val, m); err != nil {
-                return err
-            }
+			if err = Decode(val, m); err != nil {
+				return err
+			}
 
-            st.Infof(
-                ctx, -1,
-                "found and decoded record for %q under prefix %q with revision %v and value %q",
-                n, prefix, rev, val)
+			st.Infof(
+				ctx, -1,
+				"found and decoded record for %q under prefix %q with revision %v and value %q",
+				n, prefix, rev, val)
 
-            revision = rev
+			revision = rev
 
-            return nil
-        }
-    })
+			return nil
+		}
+	})
 
-    return revision, err
+	return revision, err
 }
 
 // ReadNewValue is a method to retrieve the user record associated with the
@@ -295,177 +295,176 @@ func (store *Store) ReadNew(
 //       about the encode/decode formats or indeed the target record itself.
 //
 func (store *Store) ReadNewValue(ctx context.Context, r KeyRoot, n string) (value *string, revision int64, err error) {
-    revision = RevisionInvalid
+	revision = RevisionInvalid
 
-    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-        prefix := getNamespacePrefixFromKeyRoot(r)
+	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+		prefix := getNamespacePrefixFromKeyRoot(r)
 
-        st.Infof(ctx, -1, "Request to read value of %q under prefix %q", n, prefix)
+		st.Infof(ctx, -1, "Request to read value of %q under prefix %q", n, prefix)
 
-        if err = store.disconnected(ctx); err != nil {
-            return err
-        }
+		if err = store.disconnected(ctx); err != nil {
+			return err
+		}
 
-        var (
-            rev      int64
-            val      string
-            response *Response
-        )
+		var (
+			rev      int64
+			val      string
+			response *Response
+		)
 
-        // If we need to do the read to get the revision, we will need an array of the keys
-        //
-        request := &Request{
-            Records:    make(map[string]Record),
-            Conditions: make(map[string]Condition),
-        }
+		// If we need to do the read to get the revision, we will need an array of the keys
+		//
+		request := &Request{
+			Records:    make(map[string]Record),
+			Conditions: make(map[string]Condition),
+		}
 
-        k := getKeyFromKeyRootAndName(r, n)
-        request.Records[k] = Record{Revision: RevisionInvalid}
-        request.Conditions[k] = ConditionUnconditional
+		k := getKeyFromKeyRootAndName(r, n)
+		request.Records[k] = Record{Revision: RevisionInvalid}
+		request.Conditions[k] = ConditionUnconditional
 
-        if response, err = store.ReadTxn(ctx, request); err != nil {
-            return err
-        }
+		if response, err = store.ReadTxn(ctx, request); err != nil {
+			return err
+		}
 
-        recordCount := len(response.Records)
+		recordCount := len(response.Records)
 
-        switch recordCount {
-        default:
-            return ErrStoreBadRecordCount{n, 1, recordCount}
+		switch recordCount {
+		default:
+			return ErrStoreBadRecordCount{n, 1, recordCount}
 
-        case 0:
-            return ErrStoreKeyNotFound(n)
+		case 0:
+			return ErrStoreKeyNotFound(n)
 
-        case 1:
-            rev = response.Records[k].Revision
-            val = response.Records[k].Value
-            st.Infof(ctx, -1, "found record for %q under prefix %q, with revision %v and value %q", n, prefix, rev, val)
+		case 1:
+			rev = response.Records[k].Revision
+			val = response.Records[k].Value
+			st.Infof(ctx, -1, "found record for %q under prefix %q, with revision %v and value %q", n, prefix, rev, val)
 
-            revision = rev
-            value = &val
+			revision = rev
+			value = &val
 
-            return nil
-        }
-    })
+			return nil
+		}
+	})
 
-    return value, revision, err
+	return value, revision, err
 }
 
 // UpdateNew is a function to conditionally update a value for a single key
 //
 func (store *Store) UpdateNew(
-        ctx context.Context,
-        r KeyRoot,
-        n string,
-        rev int64,
-        m protoiface.MessageV1) (revision int64, err error) {
-    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-        prefix := getNamespacePrefixFromKeyRoot(r)
+	ctx context.Context,
+	r KeyRoot,
+	n string,
+	rev int64,
+	m protoiface.MessageV1) (revision int64, err error) {
+	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+		prefix := getNamespacePrefixFromKeyRoot(r)
 
-        st.Infof(ctx, -1, "Request to update %q under prefix %q", n, prefix)
+		st.Infof(ctx, -1, "Request to update %q under prefix %q", n, prefix)
 
-        if err = store.disconnected(ctx); err != nil {
-            return err
-        }
+		if err = store.disconnected(ctx); err != nil {
+			return err
+		}
 
-        v, err := Encode(m)
+		v, err := Encode(m)
+		if err != nil {
+			return err
+		}
 
-        if err != nil {
-            return err
-        }
+		var condition Condition
 
-        var condition Condition
+		switch {
+		case rev == RevisionInvalid:
+			condition = ConditionUnconditional
 
-        switch {
-        case rev == RevisionInvalid:
-            condition = ConditionUnconditional
+		default:
+			condition = ConditionRevisionEqual
+		}
 
-        default:
-            condition = ConditionRevisionEqual
-        }
+		request := &Request{
+			Records:    make(map[string]Record),
+			Conditions: make(map[string]Condition)}
 
-        request := &Request{
-            Records:    make(map[string]Record),
-            Conditions: make(map[string]Condition)}
+		k := getKeyFromKeyRootAndName(r, n)
+		request.Records[k] = Record{Revision: rev, Value: v}
+		request.Conditions[k] = condition
 
-        k := getKeyFromKeyRootAndName(r, n)
-        request.Records[k] = Record{Revision: rev, Value: v}
-        request.Conditions[k] = condition
+		resp, err := store.WriteTxn(ctx, request)
 
-        resp, err := store.WriteTxn(ctx, request)
+		if err != nil {
+			return err
+		}
 
-        if err != nil {
-            return err
-        }
+		st.Infof(
+			ctx, -1,
+			"Updated record %q under prefix %q from revision %v to revision %v",
+			n, prefix, rev, resp.Revision)
 
-        st.Infof(
-            ctx, -1,
-            "Updated record %q under prefix %q from revision %v to revision %v",
-            n, prefix, rev, resp.Revision)
+		revision = resp.Revision
 
-        revision = resp.Revision
+		return nil
+	})
 
-        return nil
-    })
-
-    return revision, err
+	return revision, err
 }
 
 // DeleteNew is a function to delete a single key, value record pair
 //
 func (store *Store) DeleteNew(ctx context.Context, r KeyRoot, n string, rev int64) (revision int64, err error) {
-    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-        prefix := getNamespacePrefixFromKeyRoot(r)
+	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+		prefix := getNamespacePrefixFromKeyRoot(r)
 
-        st.Infof(ctx, -1, "Request to delete %q under prefix %q", n, prefix)
+		st.Infof(ctx, -1, "Request to delete %q under prefix %q", n, prefix)
 
-        if err = store.disconnected(ctx); err != nil {
-            return err
-        }
+		if err = store.disconnected(ctx); err != nil {
+			return err
+		}
 
-        var condition Condition
+		var condition Condition
 
-        switch {
-        case rev == RevisionInvalid:
-            condition = ConditionUnconditional
+		switch {
+		case rev == RevisionInvalid:
+			condition = ConditionUnconditional
 
-        default:
-            condition = ConditionRevisionEqual
-        }
+		default:
+			condition = ConditionRevisionEqual
+		}
 
-        request := &Request{
-            Records:    make(map[string]Record),
-            Conditions: make(map[string]Condition),
-        }
+		request := &Request{
+			Records:    make(map[string]Record),
+			Conditions: make(map[string]Condition),
+		}
 
-        k := getKeyFromKeyRootAndName(r, n)
-        request.Records[k] = Record{Revision: rev}
-        request.Conditions[k] = condition
+		k := getKeyFromKeyRootAndName(r, n)
+		request.Records[k] = Record{Revision: rev}
+		request.Conditions[k] = condition
 
-        resp, err := store.DeleteTxn(ctx, request)
+		resp, err := store.DeleteTxn(ctx, request)
 
-        // Need to strip the namespace prefix and return something described
-        // in terms the caller should recognize
-        //
-        if err == ErrStoreKeyNotFound(k) {
-            return ErrStoreKeyNotFound(n)
-        }
+		// Need to strip the namespace prefix and return something described
+		// in terms the caller should recognize
+		//
+		if err == ErrStoreKeyNotFound(k) {
+			return ErrStoreKeyNotFound(n)
+		}
 
-        if err != nil {
-            return err
-        }
+		if err != nil {
+			return err
+		}
 
-        st.Infof(
-            ctx, -1,
-            "Deleted record for %q under prefix %q with revision %v resulting in store revision %v",
-            n, prefix, rev, resp.Revision)
+		st.Infof(
+			ctx, -1,
+			"Deleted record for %q under prefix %q with revision %v resulting in store revision %v",
+			n, prefix, rev, resp.Revision)
 
-        revision = resp.Revision
+		revision = resp.Revision
 
-        return nil
-    })
+		return nil
+	})
 
-    return revision, err
+	return revision, err
 }
 
 // ListNew is a method to return all the user records using a single call.
@@ -479,43 +478,43 @@ func (store *Store) DeleteNew(ctx context.Context, r KeyRoot, n string, rev int6
 //		 an essentially infinite number of records.
 //
 func (store *Store) ListNew(ctx context.Context, r KeyRoot) (records *map[string]Record, revision int64, err error) {
-    err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
-        prefix := getNamespacePrefixFromKeyRoot(r)
+	err = st.WithSpan(ctx, tracing.MethodName(1), func(ctx context.Context) (err error) {
+		prefix := getNamespacePrefixFromKeyRoot(r)
 
-        st.Infof(ctx, -1, "Request to list keys under prefix %q", prefix)
+		st.Infof(ctx, -1, "Request to list keys under prefix %q", prefix)
 
-        if err = store.disconnected(ctx); err != nil {
-            return err
-        }
+		if err = store.disconnected(ctx); err != nil {
+			return err
+		}
 
-        response, err := store.ListWithPrefix(ctx, prefix)
+		response, err := store.ListWithPrefix(ctx, prefix)
 
-        if err != nil {
-            return err
-        }
+		if err != nil {
+			return err
+		}
 
-        recs := make(map[string]Record, len(response.Records))
+		recs := make(map[string]Record, len(response.Records))
 
-        for k, record := range response.Records {
+		for k, record := range response.Records {
 
-            if !strings.HasPrefix(k, prefix) {
-                return ErrStoreBadRecordKey(k)
-            }
+			if !strings.HasPrefix(k, prefix) {
+				return ErrStoreBadRecordKey(k)
+			}
 
-            name := strings.TrimPrefix(k, prefix)
+			name := strings.TrimPrefix(k, prefix)
 
-            recs[name] = Record{Revision: record.Revision, Value: record.Value}
+			recs[name] = Record{Revision: record.Revision, Value: record.Value}
 
-            st.Infof(ctx, -1, "found record with key %q for name %q with revision %v", k, name, record.Revision)
-        }
+			st.Infof(ctx, -1, "found record with key %q for name %q with revision %v", k, name, record.Revision)
+		}
 
-        st.Infof(ctx, -1, "returned %v records at store revision %v", len(response.Records), response.Revision)
+		st.Infof(ctx, -1, "returned %v records at store revision %v", len(response.Records), response.Revision)
 
-        records = &recs
-        revision = response.Revision
+		records = &recs
+		revision = response.Revision
 
-        return nil
-    })
+		return nil
+	})
 
-    return records, revision, err
+	return records, revision, err
 }

--- a/internal/tracing/server/tracing.go
+++ b/internal/tracing/server/tracing.go
@@ -1,47 +1,48 @@
 package server
 
 import (
-	"context"
-	"errors"
-	"fmt"
+    "context"
+    "errors"
+    "fmt"
+    stdLog "log"
 
-	"go.opentelemetry.io/otel/api/correlation"
-	"go.opentelemetry.io/otel/api/global"
-	"go.opentelemetry.io/otel/api/kv"
-	"go.opentelemetry.io/otel/api/trace"
-	"go.opentelemetry.io/otel/instrumentation/grpctrace"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
+    "go.opentelemetry.io/otel/api/correlation"
+    "go.opentelemetry.io/otel/api/global"
+    "go.opentelemetry.io/otel/api/kv"
+    "go.opentelemetry.io/otel/api/trace"
+    "go.opentelemetry.io/otel/instrumentation/grpctrace"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/metadata"
 
-	"github.com/Jim3Things/CloudChamber/internal/tracing"
-	"github.com/Jim3Things/CloudChamber/pkg/protos/log"
+    "github.com/Jim3Things/CloudChamber/internal/tracing"
+    "github.com/Jim3Things/CloudChamber/pkg/protos/log"
 )
 
 // Interceptor intercepts and extracts incoming trace data
 func Interceptor(
-		ctx context.Context,
-		req interface{},
-		info *grpc.UnaryServerInfo,
-		handler grpc.UnaryHandler) (resp interface{}, err error) {
-	requestMetadata, _ := metadata.FromIncomingContext(ctx)
-	metadataCopy := requestMetadata.Copy()
+        ctx context.Context,
+        req interface{},
+        info *grpc.UnaryServerInfo,
+        handler grpc.UnaryHandler) (resp interface{}, err error) {
+    requestMetadata, _ := metadata.FromIncomingContext(ctx)
+    metadataCopy := requestMetadata.Copy()
 
-	entries, spanCtx := grpctrace.Extract(ctx, &metadataCopy)
-	ctx = correlation.ContextWithMap(ctx, correlation.NewMap(correlation.MapUpdate{
-		MultiKV: entries,
-	}))
+    entries, spanCtx := grpctrace.Extract(ctx, &metadataCopy)
+    ctx = correlation.ContextWithMap(ctx, correlation.NewMap(correlation.MapUpdate{
+        MultiKV: entries,
+    }))
 
-	tr := global.TraceProvider().Tracer("server")
+    tr := global.TraceProvider().Tracer("server")
 
-	ctx, span := tr.Start(
-		trace.ContextWithRemoteSpanContext(ctx, spanCtx),
-		info.FullMethod,
-		trace.WithSpanKind(trace.SpanKindServer),
-		trace.WithAttributes(kv.String(tracing.StackTraceKey, tracing.StackTrace())),
-	)
-	defer span.End()
+    ctx, span := tr.Start(
+        trace.ContextWithRemoteSpanContext(ctx, spanCtx),
+        info.FullMethod,
+        trace.WithSpanKind(trace.SpanKindServer),
+        trace.WithAttributes(kv.String(tracing.StackTraceKey, tracing.StackTrace())),
+    )
+    defer span.End()
 
-	return handler(ctx, req)
+    return handler(ctx, req)
 }
 
 // +++ Exported trace invocation methods
@@ -49,11 +50,11 @@ func Interceptor(
 // Execute the supplied function within a span that conforms to the expected
 // tracing pattern
 func WithSpan(ctx context.Context, spanName string, fn func(ctx context.Context) error) error {
-	tr := global.TraceProvider().Tracer("server")
+    tr := global.TraceProvider().Tracer("server")
 
-	return tr.WithSpan(ctx, spanName, fn,
-		trace.WithSpanKind(trace.SpanKindServer),
-		trace.WithAttributes(kv.String(tracing.StackTraceKey, tracing.StackTrace())))
+    return tr.WithSpan(ctx, spanName, fn,
+        trace.WithSpanKind(trace.SpanKindServer),
+        trace.WithAttributes(kv.String(tracing.StackTraceKey, tracing.StackTrace())))
 }
 
 // There should be an Xxx and Xxxf method for every severity level, plus some
@@ -65,53 +66,58 @@ func WithSpan(ctx context.Context, spanName string, fn func(ctx context.Context)
 
 // Post a simple informational trace entry
 func Info(ctx context.Context, tick int64, msg string) {
-	trace.SpanFromContext(ctx).AddEvent(
-		ctx,
-		tracing.MethodName(2),
-		kv.Int64(tracing.StepperTicksKey, tick),
-		kv.Int64(tracing.SeverityKey, int64(log.Severity_Info)),
-		kv.String(tracing.StackTraceKey, tracing.StackTrace()),
-		kv.String(tracing.MessageTextKey, msg))
+    trace.SpanFromContext(ctx).AddEvent(
+        ctx,
+        tracing.MethodName(2),
+        kv.Int64(tracing.StepperTicksKey, tick),
+        kv.Int64(tracing.SeverityKey, int64(log.Severity_Info)),
+        kv.String(tracing.StackTraceKey, tracing.StackTrace()),
+        kv.String(tracing.MessageTextKey, msg))
 }
 
 // Post an informational trace entry with complex formatting
 func Infof(ctx context.Context, tick int64, f string, a ...interface{}) {
-	trace.SpanFromContext(ctx).AddEvent(
-		ctx,
-		tracing.MethodName(2),
-		kv.Int64(tracing.StepperTicksKey, tick),
-		kv.Int64(tracing.SeverityKey, int64(log.Severity_Info)),
-		kv.String(tracing.StackTraceKey, tracing.StackTrace()),
-		kv.String(tracing.MessageTextKey, fmt.Sprintf(f, a...)))
+    trace.SpanFromContext(ctx).AddEvent(
+        ctx,
+        tracing.MethodName(2),
+        kv.Int64(tracing.StepperTicksKey, tick),
+        kv.Int64(tracing.SeverityKey, int64(log.Severity_Info)),
+        kv.String(tracing.StackTraceKey, tracing.StackTrace()),
+        kv.String(tracing.MessageTextKey, fmt.Sprintf(f, a...)))
 }
 
 // Post a method arrival informational trace entry
 func OnEnter(ctx context.Context, tick int64, msg string) {
-	trace.SpanFromContext(ctx).AddEvent(
-		ctx,
-		fmt.Sprintf("On %q entry", tracing.MethodName(2)),
-		kv.Int64(tracing.StepperTicksKey, tick),
-		kv.Int64(tracing.SeverityKey, int64(log.Severity_Info)),
-		kv.String(tracing.StackTraceKey, tracing.StackTrace()),
-		kv.String(tracing.MessageTextKey, msg))
+    trace.SpanFromContext(ctx).AddEvent(
+        ctx,
+        fmt.Sprintf("On %q entry", tracing.MethodName(2)),
+        kv.Int64(tracing.StepperTicksKey, tick),
+        kv.Int64(tracing.SeverityKey, int64(log.Severity_Info)),
+        kv.String(tracing.StackTraceKey, tracing.StackTrace()),
+        kv.String(tracing.MessageTextKey, msg))
 }
 
 // Post a simple error trace
 func Error(ctx context.Context, tick int64, a interface{}) error {
-	if msg, ok := a.(string); ok {
-		return logError(ctx, tick, errors.New(msg))
-	}
+    if msg, ok := a.(string); ok {
+        return logError(ctx, tick, errors.New(msg))
+    }
 
-	if err, ok := a.(error); ok {
-		return logError(ctx, tick, err)
-	}
+    if err, ok := a.(error); ok {
+        return logError(ctx, tick, err)
+    }
 
-	panic("Invalid Error call - no valid arguments found")
+    panic("Invalid Error call - no valid arguments found")
 }
 
 // Post an error trace with a complex string formatting
 func Errorf(ctx context.Context, tick int64, f string, a ...interface{}) error {
-	return logError(ctx, tick, fmt.Errorf(f, a...))
+    return logError(ctx, tick, fmt.Errorf(f, a...))
+}
+
+// Fatalf traces the error, and then terminates the process.
+func Fatalf(ctx context.Context, tick int64, f string, a ...interface{}) {
+    stdLog.Fatal(Errorf(ctx, tick, f, a...))
 }
 
 // --- Exported trace invocation methods
@@ -120,15 +126,15 @@ func Errorf(ctx context.Context, tick int64, f string, a ...interface{}) error {
 
 // Write a specific error entry
 func logError(ctx context.Context, tick int64, err error) error {
-	trace.SpanFromContext(ctx).AddEvent(
-		ctx,
-		fmt.Sprintf("Error from %q", tracing.MethodName(3)),
-		kv.Int64(tracing.StepperTicksKey, tick),
-		kv.Int64(tracing.SeverityKey, int64(log.Severity_Error)),
-		kv.String(tracing.StackTraceKey, tracing.StackTrace()),
-		kv.String(tracing.MessageTextKey, err.Error()))
+    trace.SpanFromContext(ctx).AddEvent(
+        ctx,
+        fmt.Sprintf("Error from %q", tracing.MethodName(3)),
+        kv.Int64(tracing.StepperTicksKey, tick),
+        kv.Int64(tracing.SeverityKey, int64(log.Severity_Error)),
+        kv.String(tracing.StackTraceKey, tracing.StackTrace()),
+        kv.String(tracing.MessageTextKey, err.Error()))
 
-	return err
+    return err
 }
 
 // --- Helper functions


### PR DESCRIPTION
Limited to store.go/storeapi.go

Did not address unused functions/symbols, as some functions still to be written.
Did not address exported symbols that are not used outside of store itself.  That needs further review.