### PR TITLE
Add params to local errors to reduce need for Errorf() invocations

### DIFF
--- a/internal/clients/store/errors.go
+++ b/internal/clients/store/errors.go
@@ -13,17 +13,37 @@ var (
 	// to create a client.
 	//
 	ErrStoreUnableToCreateClient = errors.New("CloudChamber: unable to create a new client")
-
-	// ErrStoreNotConnected indicates the store instance does not have a
-	// currently active client. The Connect() method can be used to establist a client.
-	//
-	ErrStoreNotConnected = errors.New("CloudChamber: client not currently connected")
-
-	// ErrStoreConnected indicates the request failed as the store is currently
-	// connected and the request is not possible in that condition.
-	//
-	ErrStoreConnected = errors.New("CloudChamber: client currently connected")
 )
+
+// ErrStoreNotConnected indicates the store instance does not have a
+// currently active client. The Connect() method can be used to establist a client.
+//
+type ErrStoreNotConnected string
+
+func (esnc ErrStoreNotConnected) Error() string {
+	return fmt.Sprintf("CloudChamber: client not currently connected - %s", string(esnc))
+}
+
+// ErrStoreConnected indicates the request failed as the store is currently
+// connected and the request is not possible in that condition.
+//
+type ErrStoreConnected string
+
+func (esc ErrStoreConnected) Error() string {
+	return fmt.Sprintf("CloudChamber: client currently connected - %s", string(esc))
+}
+
+// ErrStoreConnectionFailed indicates that the attempt to extablish a connection
+// from this client to the store failed
+//
+type ErrStoreConnectionFailed struct {
+	endpoints []string
+	reason    error
+}
+
+func (escf ErrStoreConnectionFailed) Error() string {
+	return fmt.Sprintf("CloudChamber: failed to establish connection to store - endpoints: %q reason: %q", escf.endpoints, escf.reason)
+}
 
 // ErrStoreKeyNotFound indicates the request key was not found when the store
 // lookup/fetch was attempted.

--- a/internal/clients/store/store.go
+++ b/internal/clients/store/store.go
@@ -202,9 +202,7 @@ func setDefaultNamespaceSuffix(suffix string) {
 func (store *Store) connected(ctx context.Context) error {
 
 	if nil != store.Client {
-		err := ErrStoreConnected
-		_ = st.Errorf(ctx, -1, "unable to perform operation - store is connected - error: %v", err)
-		return err
+		return ErrStoreConnected("already connected")
 	}
 
 	return nil
@@ -213,9 +211,7 @@ func (store *Store) connected(ctx context.Context) error {
 func (store *Store) disconnected(ctx context.Context) error {
 
 	if nil == store.Client {
-		err := ErrStoreNotConnected
-		_ = st.Errorf(ctx, -1, "unable to perform operation - no current connection - error: %v", err)
-		return err
+		return ErrStoreNotConnected("already disconnected")
 	}
 
 	return nil
@@ -565,8 +561,7 @@ func (store *Store) Connect() error {
 		})
 
 		if err != nil {
-			_ = st.Errorf(ctx, -1, "Failed to establish connection to store - error: %v", err)
-			return err
+			return ErrStoreConnectionFailed{store.GetAddress(), err}
 		}
 
 		// Hookup the namespace prefixing mechanism
@@ -1442,9 +1437,7 @@ func (store *Store) ReadMultipleTxn(ctx context.Context, keySet RecordKeySet) (*
 		}
 
 		if !response.Succeeded {
-			err = ErrStoreKeyReadFailure(keySet.Label)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
+			return ErrStoreKeyReadFailure(keySet.Label)
 		}
 
 		// And finally, the revision for the store as a whole.
@@ -1507,9 +1500,7 @@ func (store *Store) WriteMultipleTxn(ctx context.Context, recordSet *RecordUpdat
 		}
 
 		if !response.Succeeded {
-			err = ErrStoreKeyWriteFailure(recordSet.Label)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
+			return ErrStoreKeyWriteFailure(recordSet.Label)
 		}
 
 		revision = response.Header.Revision
@@ -1566,9 +1557,7 @@ func (store *Store) DeleteMultipleTxn(ctx context.Context, recordSet *RecordUpda
 		}
 
 		if !response.Succeeded {
-			err = ErrStoreKeyDeleteFailure(recordSet.Label)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
+			return ErrStoreKeyDeleteFailure(recordSet.Label)
 		}
 
 		revision = response.Header.Revision
@@ -1645,9 +1634,7 @@ func (store *Store) ReadTxn(ctx context.Context, request *Request) (response *Re
 		}
 
 		if !txnResponse.Succeeded {
-			err = ErrStoreKeyReadFailure(request.Reason)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
+			return ErrStoreKeyReadFailure(request.Reason)
 		}
 
 		// And finally, the revision for the store as a whole.
@@ -1711,9 +1698,7 @@ func (store *Store) WriteTxn(ctx context.Context, request *Request) (response *R
 		}
 
 		if !txnResponse.Succeeded {
-			err = ErrStoreKeyWriteFailure(request.Reason)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
+			return ErrStoreKeyWriteFailure(request.Reason)
 		}
 
 		// And finally, the revision for the store as a whole.
@@ -1777,9 +1762,7 @@ func (store *Store) DeleteTxn(ctx context.Context, request *Request) (response *
 		}
 
 		if !txnResponse.Succeeded {
-			err = ErrStoreKeyDeleteFailure(request.Reason)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
+			return ErrStoreKeyDeleteFailure(request.Reason)
 		}
 
 		// And finally, the revision for the store as a whole.

--- a/internal/clients/store/store_test.go
+++ b/internal/clients/store/store_test.go
@@ -138,7 +138,7 @@ func TestStoreConnectDisconnect(t *testing.T) {
 
 	err = store.Connect()
 	assert.NotNilf(t, err, "Unexpectedly connected to store again - error: %v", err)
-	assert.Equal(t, ErrStoreConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected, err)
+	assert.Equal(t, ErrStoreConnected("already connected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected("already connected"), err)
 
 	store.Disconnect()
 
@@ -177,7 +177,7 @@ func TestStoreConnectDisconnectWithInitialize(t *testing.T) {
 		getDefaultTraceFlags(),
 		getDefaultNamespaceSuffix())
 	assert.NotNilf(t, err, "Unexpectedly re-initialized store after connect - error: %v", err)
-	assert.Equal(t, ErrStoreConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected, err)
+	assert.Equal(t, ErrStoreConnected("already connected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected("already connected"), err)
 
 	store.Disconnect()
 
@@ -226,22 +226,22 @@ func TestStoreConnectDisconnectWithSet(t *testing.T) {
 
 	err = store.SetAddress(endpoints)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to update the address - error: %v", err)
-	assert.Equal(t, ErrStoreConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected, err)
+	assert.Equal(t, ErrStoreConnected("already connected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected("already connected"), err)
 
 	err = store.SetTimeoutConnect(timeoutConnect)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to update the connect timeout - error: %v", err)
-	assert.Equal(t, ErrStoreConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected, err)
+	assert.Equal(t, ErrStoreConnected("already connected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected("already connected"), err)
 
 	err = store.SetTimeoutRequest(timeoutRequest)
 	assert.Nilf(t, err, "Failed to update the request timeout - error: %v", err)
 
 	err = store.SetNamespaceSuffix(namespaceSuffix)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to update the namespace suffix - error: %v", err)
-	assert.Equal(t, ErrStoreConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected, err)
+	assert.Equal(t, ErrStoreConnected("already connected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected("already connected"), err)
 
 	err = store.Connect()
 	assert.NotNilf(t, err, "Unexpectedly connected to store again - error: %v", err)
-	assert.Equal(t, ErrStoreConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected, err)
+	assert.Equal(t, ErrStoreConnected("already connected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected("already connected"), err)
 
 	store.Disconnect()
 
@@ -534,35 +534,35 @@ func TestStoreWriteReadDeleteWithoutConnect(t *testing.T) {
 
 	err := store.Write(key, value)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to write to store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	err = store.WriteMultiple(keyValueSet)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to write to store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	_, err = store.Read(key)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to read from store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	_, err = store.ReadMultiple(keySet)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to read from store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	_, err = store.ReadWithPrefix(context.Background(), key)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to read from store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	err = store.Delete(key)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to delete from store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	err = store.DeleteMultiple(keySet)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to delete from store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	err = store.DeleteWithPrefix(key)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to delete from store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	store = nil
 


### PR DESCRIPTION
Just a little error text and handling cleanup.