### PR TITLE
Add source file dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,128 @@ PROTO_GEN_FILES = \
     pkg/protos/trace_sink/trace_sink.pb.go
 
 
+SRC_CONFIG = \
+	internal/config/settings.go
+
+SRC_FRONTEND = \
+	$(SRC_CONFIG) \
+	$(SRC_STORE) \
+	$(SRC_TIMESTAMP) \
+	$(SRC_TRACING) \
+	$(SRC_TRACING_CLIENT) \
+	$(SRC_TRACING_SERVER) \
+	internal/services/frontend/DBInventory.go \
+	internal/services/frontend/DBUsers.go \
+	internal/services/frontend/errors.go \
+	internal/services/frontend/frontend.go \
+	internal/services/frontend/inventory.go \
+	internal/services/frontend/ping.go \
+	internal/services/frontend/session_manager.go \
+	internal/services/frontend/stepper.go \
+	internal/services/frontend/users.go \
+	internal/services/frontend/workloads.go
+
+SRC_MONITOR = \
+	internal/services/monitor/monitor.go
+
+SRC_SM = \
+	$(SRC_TRACING_SERVER) \
+	internal/sm/sm.go
+
+SRC_STEPPER_ACTOR = \
+    $(SRC_SM) \
+	$(SRC_TRACING) \
+	$(SRC_TRACING_SERVER) \
+	internal/services/stepper_actor/actor.go \
+	internal/services/stepper_actor/adapter.go \
+	internal/services/stepper_actor/sm.go
+
+SRC_STORE = \
+	$(SRC_TRACING) \
+	$(SRC_TRACING_SERVER) \
+	internal/clients/store/store.go \
+	internal/clients/store/storeapi.go \
+	internal/clients/store/errors.go
+
+SRC_TIMESTAMP = \
+	internal/clients/timestamp/timestamp.go
+
+SRC_TRACINGSINK = \
+	internal/services/tracing_sink/sink.go
+
+SRC_TRACING = \
+	internal/tracing/constants.go \
+	internal/tracing/StackData.go
+
+SRC_TRACING_EXPORTERS_COMMON = \
+	$(SRC_TRACING) \
+	internal/tracing/exporters/common/common.go \
+	internal/tracing/exporters/common/deferrable.go
+
+SRC_TRACING_EXPORTERS_IO_WRITER = \
+	$(SRC_TRACING_EXPORTERS_COMMON) \
+	internal/tracing/exporters/io_writer/exporter.go
+
+SRC_TRACING_EXPORTERS_PRODUCTION = \
+	$(SRC_TRACING_EXPORTERS_COMMON) \
+	internal/tracing/exporters/production/exporter.go
+
+SRC_TRACING_EXPORTERS = \
+	$(SRC_TRACING_EXPORTERS_IO_WRITER) \
+	$(SRC_TRACING_EXPORTERS_PRODUCTION) \
+	internal/tracing/exporters/exporters.go \
+	internal/tracing/exporters/init.go 
+
+SRC_TRACING_SETUP = \
+	$(SRC_TRACING_EXPORTERS) \
+	$(SRC_TRACING_EXPORTERS_IO_WRITER) \
+	$(SRC_TRACING_EXPORTERS_PRODUCTION) \
+	internal/tracing/setup/config.go \
+
+SRC_TRACING_SERVER = \
+	$(SRC_TRACING) \
+	internal/tracing/server/actor_interceptor.go \
+	internal/tracing/server/span_map.go \
+	internal/tracing/server/tracing.go
+
+SRC_TRACING_CLIENT = \
+	internal/tracing/client/tracing.go \
+
+SRC_VERSION = \
+	pkg/version/version.go
+
+
+SRC_CONTROLLER = \
+	cmd/controllerd/main.go \
+	$(SRC_CONFIG) \
+	$(SRC_MONITOR) \
+	$(SRC_TRACING_EXPORTERS) \
+	$(SRC_TRACING_SERVER) \
+	$(SRC_TRACING_SETUP)
+
+SRC_INVENTORY = \
+	cmd/inventoryd/main.go \
+	$(SRC_CONFIG) \
+	$(SRC_TRACING_EXPORTERS) \
+	$(SRC_TRACING_SETUP)
+
+SRC_SIMSUPPORT = \
+	cmd/sim_supportd/main.go \
+	$(SRC_CONFIG) \
+	$(SRC_STEPPER_ACTOR) \
+	$(SRC_TRACINGSINK) \
+	$(SRC_TRACING_EXPORTERS) \
+	$(SRC_TRACING_SERVER) \
+	$(SRC_TRACING_SETUP)
+
+SRC_WEBSERVER = \
+	cmd/web_server/main.go \
+	$(SRC_CONFIG) \
+	$(SRC_FRONTEND) \
+	$(SRC_TRACING_EXPORTERS) \
+	$(SRC_TRACING_SETUP)
+
+
 SERVICES = \
     deployments/controllerd.exe \
     deployments/inventoryd.exe \
@@ -163,19 +285,19 @@ pkg/protos/trace_sink/trace_sink.pb.go: pkg/protos/trace_sink/trace_sink.proto
 
 
 
-$(VERSION_MARKER) &: pkg/version/version.go
+$(VERSION_MARKER) &: $(SRC_VERSION)
 	go generate $(PROJECT)/$<
 
-deployments/controllerd.exe: cmd/controllerd/main.go   $(PROTO_GEN_FILES) $(VERSION_MARKER)
+deployments/controllerd.exe:  $(SRC_CONTROLLER) $(PROTO_GEN_FILES) $(VERSION_MARKER)
 	go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
-deployments/inventoryd.exe: cmd/inventoryd/main.go     $(PROTO_GEN_FILES) $(VERSION_MARKER)
+deployments/inventoryd.exe:   $(SRC_INVENTORY)  $(PROTO_GEN_FILES) $(VERSION_MARKER)
 	go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
-deployments/sim_supportd.exe: cmd/sim_supportd/main.go $(PROTO_GEN_FILES) $(VERSION_MARKER)
+deployments/sim_supportd.exe: $(SRC_SIMSUPPORT) $(PROTO_GEN_FILES) $(VERSION_MARKER)
 	go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
-deployments/web_server.exe: cmd/web_server/main.go     $(PROTO_GEN_FILES) $(VERSION_MARKER)
+deployments/web_server.exe:   $(SRC_WEBSERVER)  $(PROTO_GEN_FILES) $(VERSION_MARKER)
 	go build -o $(PROJECT)/$@ $(PROJECT)/$<
 
 deployments/readme.md: pkg/version/version_stamp.md

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ PROTO_GEN_FILES = \
 ProdFiles = $(filter-out %_test.go, $(wildcard $(1)/*.go))
 
 SRC_CONFIG = \
-	$(filter-out %_test.go, $(wildcard internal/config/*.go))
+	$(call ProdFiles, internal/config)
 
 SRC_FRONTEND = \
 	$(SRC_CONFIG) \

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ SRC_SM = \
 	internal/sm/sm.go
 
 SRC_STEPPER_ACTOR = \
-    $(SRC_SM) \
+	$(SRC_SM) \
 	$(SRC_TRACING) \
 	$(SRC_TRACING_SERVER) \
 	internal/services/stepper_actor/actor.go \

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ PROTO_GEN_FILES = \
     pkg/protos/trace_sink/trace_sink.pb.go
 
 
+ProdFiles = $(filter-out %_test.go, $(wildcard $(1)/*.go))
+
 SRC_CONFIG = \
 	$(filter-out %_test.go, $(wildcard internal/config/*.go))
 
@@ -50,71 +52,71 @@ SRC_FRONTEND = \
 	$(SRC_TRACING) \
 	$(SRC_TRACING_CLIENT) \
 	$(SRC_TRACING_SERVER) \
-	$(filter-out %_test.go, $(wildcard internal/services/frontend/*.go))
+	$(call ProdFiles, internal/services/frontend)
 
 SRC_MONITOR = \
-	$(filter-out %_test.go, $(wildcard internal/services/monitor/*.go))
+	$(call ProdFiles, internal/services/monitor)
 
 SRC_SM = \
 	$(SRC_TRACING_SERVER) \
-	$(filter-out %_test.go, $(wildcard internal/sm/*.go))
+	$(call ProdFiles, internal/sm)
 
 SRC_STEPPER_ACTOR = \
 	$(SRC_SM) \
 	$(SRC_TRACING) \
 	$(SRC_TRACING_SERVER) \
-	$(filter-out %_test.go, $(wildcard internal/services/stepper_actor/*.go))
+	$(call ProdFiles, internal/services/stepper_actor)
 
 SRC_STORE = \
 	$(SRC_TRACING) \
 	$(SRC_TRACING_SERVER) \
-	$(filter-out %_test.go, $(wildcard internal/clients/store/*.go))
+	$(call ProdFiles, internal/clients/store)
 
 SRC_TIMESTAMP = \
-	$(filter-out %_test.go, $(wildcard internal/clients/timestamp/*.go))
+	$(call ProdFiles, internal/clients/timestamp)
 
 SRC_TRACINGSINK = \
-	$(filter-out %_test.go, $(wildcard internal/services/tracing_sink/*.go))
+	$(call ProdFiles, internal/services/tracing_sink)
 
 SRC_TRACING = \
-	$(filter-out %_test.go, $(wildcard internal/tracing/*.go))
+	$(call ProdFiles, internal/tracing)
 
 SRC_TRACING_EXPORTERS_COMMON = \
 	$(SRC_TRACING) \
-	$(filter-out %_test.go, $(wildcard internal/tracing/exporters/common/*.go))
+	$(call ProdFiles, internal/tracing/exporters/common)
 
 SRC_TRACING_EXPORTERS_IO_WRITER = \
 	$(SRC_TRACING_EXPORTERS_COMMON) \
-	$(filter-out %_test.go, $(wildcard internal/tracing/exporters/io_writer/*.go))
+	$(call ProdFiles, internal/tracing/exporters/io_writer)
 
 SRC_TRACING_EXPORTERS_PRODUCTION = \
 	$(SRC_TRACING_EXPORTERS_COMMON) \
-	$(filter-out %_test.go, $(wildcard internal/tracing/exporters/production/*.go))
+	$(call ProdFiles, internal/tracing/exporters/production)
 
 SRC_TRACING_EXPORTERS = \
 	$(SRC_TRACING_EXPORTERS_IO_WRITER) \
 	$(SRC_TRACING_EXPORTERS_PRODUCTION) \
-	$(filter-out %_test.go, $(wildcard internal/tracing/exporters/*.go))
+	$(call ProdFiles, internal/tracing/exporters)
 
 SRC_TRACING_SETUP = \
 	$(SRC_TRACING_EXPORTERS) \
 	$(SRC_TRACING_EXPORTERS_IO_WRITER) \
 	$(SRC_TRACING_EXPORTERS_PRODUCTION) \
-	$(filter-out %_test.go, $(wildcard internal/tracing/setup/*.go))
+	$(call ProdFiles, internal/tracing/setup)
 
 SRC_TRACING_SERVER = \
 	$(SRC_TRACING) \
-	$(filter-out %_test.go, $(wildcard internal/tracing/server/*.go))
+	$(call ProdFiles, internal/tracing/server)
 
 SRC_TRACING_CLIENT = \
-	$(filter-out %_test.go, $(wildcard internal/tracing/client/*.go))
+	$(call ProdFiles, internal/tracing/client)
 
 SRC_VERSION = \
 	pkg/version/version.go
 
 
 SRC_CONTROLLER = \
-	cmd/controllerd/main.go \
+	$(call ProdFiles, cmd/controllerd) \
 	$(SRC_CONFIG) \
 	$(SRC_MONITOR) \
 	$(SRC_TRACING_EXPORTERS) \
@@ -122,13 +124,13 @@ SRC_CONTROLLER = \
 	$(SRC_TRACING_SETUP)
 
 SRC_INVENTORY = \
-	cmd/inventoryd/main.go \
+	$(call ProdFiles, cmd/inventoryd) \
 	$(SRC_CONFIG) \
 	$(SRC_TRACING_EXPORTERS) \
 	$(SRC_TRACING_SETUP)
 
 SRC_SIMSUPPORT = \
-	cmd/sim_supportd/main.go \
+	$(call ProdFiles, cmd/sim_supportd) \
 	$(SRC_CONFIG) \
 	$(SRC_STEPPER_ACTOR) \
 	$(SRC_TRACINGSINK) \
@@ -137,7 +139,7 @@ SRC_SIMSUPPORT = \
 	$(SRC_TRACING_SETUP)
 
 SRC_WEBSERVER = \
-	cmd/web_server/main.go \
+	$(call ProdFiles, cmd/web_server) \
 	$(SRC_CONFIG) \
 	$(SRC_FRONTEND) \
 	$(SRC_TRACING_EXPORTERS) \

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ PROTO_GEN_FILES = \
 
 
 SRC_CONFIG = \
-	internal/config/settings.go
+	$(filter-out %_test.go, $(wildcard internal/config/*.go))
 
 SRC_FRONTEND = \
 	$(SRC_CONFIG) \
@@ -50,82 +50,64 @@ SRC_FRONTEND = \
 	$(SRC_TRACING) \
 	$(SRC_TRACING_CLIENT) \
 	$(SRC_TRACING_SERVER) \
-	internal/services/frontend/DBInventory.go \
-	internal/services/frontend/DBUsers.go \
-	internal/services/frontend/errors.go \
-	internal/services/frontend/frontend.go \
-	internal/services/frontend/inventory.go \
-	internal/services/frontend/ping.go \
-	internal/services/frontend/session_manager.go \
-	internal/services/frontend/stepper.go \
-	internal/services/frontend/users.go \
-	internal/services/frontend/workloads.go
+	$(filter-out %_test.go, $(wildcard internal/services/frontend/*.go))
 
 SRC_MONITOR = \
-	internal/services/monitor/monitor.go
+	$(filter-out %_test.go, $(wildcard internal/services/monitor/*.go))
 
 SRC_SM = \
 	$(SRC_TRACING_SERVER) \
-	internal/sm/sm.go
+	$(filter-out %_test.go, $(wildcard internal/sm/*.go))
 
 SRC_STEPPER_ACTOR = \
 	$(SRC_SM) \
 	$(SRC_TRACING) \
 	$(SRC_TRACING_SERVER) \
-	internal/services/stepper_actor/actor.go \
-	internal/services/stepper_actor/adapter.go \
-	internal/services/stepper_actor/sm.go
+	$(filter-out %_test.go, $(wildcard internal/services/stepper_actor/*.go))
 
 SRC_STORE = \
 	$(SRC_TRACING) \
 	$(SRC_TRACING_SERVER) \
-	internal/clients/store/store.go \
-	internal/clients/store/storeapi.go \
-	internal/clients/store/errors.go
+	$(filter-out %_test.go, $(wildcard internal/clients/store/*.go))
 
 SRC_TIMESTAMP = \
-	internal/clients/timestamp/timestamp.go
+	$(filter-out %_test.go, $(wildcard internal/clients/timestamp/*.go))
 
 SRC_TRACINGSINK = \
-	internal/services/tracing_sink/sink.go
+	$(filter-out %_test.go, $(wildcard internal/services/tracing_sink/*.go))
 
 SRC_TRACING = \
-	internal/tracing/constants.go \
-	internal/tracing/StackData.go
+	$(filter-out %_test.go, $(wildcard internal/tracing/*.go))
 
 SRC_TRACING_EXPORTERS_COMMON = \
 	$(SRC_TRACING) \
-	internal/tracing/exporters/common/common.go \
-	internal/tracing/exporters/common/deferrable.go
+	$(filter-out %_test.go, $(wildcard internal/tracing/exporters/common/*.go))
 
 SRC_TRACING_EXPORTERS_IO_WRITER = \
 	$(SRC_TRACING_EXPORTERS_COMMON) \
-	internal/tracing/exporters/io_writer/exporter.go
+	$(filter-out %_test.go, $(wildcard internal/tracing/exporters/io_writer/*.go))
 
 SRC_TRACING_EXPORTERS_PRODUCTION = \
 	$(SRC_TRACING_EXPORTERS_COMMON) \
-	internal/tracing/exporters/production/exporter.go
+	$(filter-out %_test.go, $(wildcard internal/tracing/exporters/production/*.go))
 
 SRC_TRACING_EXPORTERS = \
 	$(SRC_TRACING_EXPORTERS_IO_WRITER) \
 	$(SRC_TRACING_EXPORTERS_PRODUCTION) \
-	internal/tracing/exporters/exporters.go \
-	internal/tracing/exporters/init.go 
+	$(filter-out %_test.go, $(wildcard internal/tracing/exporters/*.go))
 
 SRC_TRACING_SETUP = \
 	$(SRC_TRACING_EXPORTERS) \
 	$(SRC_TRACING_EXPORTERS_IO_WRITER) \
 	$(SRC_TRACING_EXPORTERS_PRODUCTION) \
-	internal/tracing/setup/config.go \
+	$(filter-out %_test.go, $(wildcard internal/tracing/setup/*.go))
 
 SRC_TRACING_SERVER = \
 	$(SRC_TRACING) \
-	internal/tracing/server/actor_interceptor.go \
-	internal/tracing/server/span_map.go \
-	internal/tracing/server/tracing.go
+	$(filter-out %_test.go, $(wildcard internal/tracing/server/*.go))
 
 SRC_TRACING_CLIENT = \
-	internal/tracing/client/tracing.go \
+	$(filter-out %_test.go, $(wildcard internal/tracing/client/*.go))
 
 SRC_VERSION = \
 	pkg/version/version.go

--- a/internal/clients/store/errors.go
+++ b/internal/clients/store/errors.go
@@ -13,17 +13,37 @@ var (
 	// to create a client.
 	//
 	ErrStoreUnableToCreateClient = errors.New("CloudChamber: unable to create a new client")
-
-	// ErrStoreNotConnected indicates the store instance does not have a
-	// currently active client. The Connect() method can be used to establist a client.
-	//
-	ErrStoreNotConnected = errors.New("CloudChamber: client not currently connected")
-
-	// ErrStoreConnected indicates the request failed as the store is currently
-	// connected and the request is not possible in that condition.
-	//
-	ErrStoreConnected = errors.New("CloudChamber: client currently connected")
 )
+
+// ErrStoreNotConnected indicates the store instance does not have a
+// currently active client. The Connect() method can be used to establist a client.
+//
+type ErrStoreNotConnected string
+
+func (esnc ErrStoreNotConnected) Error() string {
+	return fmt.Sprintf("CloudChamber: client not currently connected - %s", string(esnc))
+}
+
+// ErrStoreConnected indicates the request failed as the store is currently
+// connected and the request is not possible in that condition.
+//
+type ErrStoreConnected string
+
+func (esc ErrStoreConnected) Error() string {
+	return fmt.Sprintf("CloudChamber: client currently connected - %s", string(esc))
+}
+
+// ErrStoreConnectionFailed indicates that the attempt to extablish a connection
+// from this client to the store failed
+//
+type ErrStoreConnectionFailed struct {
+	endpoints []string
+	reason    error
+}
+
+func (escf ErrStoreConnectionFailed) Error() string {
+	return fmt.Sprintf("CloudChamber: failed to establish connection to store - endpoints: %q reason: %q", escf.endpoints, escf.reason)
+}
 
 // ErrStoreKeyNotFound indicates the request key was not found when the store
 // lookup/fetch was attempted.

--- a/internal/clients/store/store.go
+++ b/internal/clients/store/store.go
@@ -202,9 +202,7 @@ func setDefaultNamespaceSuffix(suffix string) {
 func (store *Store) connected(ctx context.Context) error {
 
 	if nil != store.Client {
-		err := ErrStoreConnected
-		_ = st.Errorf(ctx, -1, "unable to perform operation - store is connected - error: %v", err)
-		return err
+		return ErrStoreConnected("already connected")
 	}
 
 	return nil
@@ -213,9 +211,7 @@ func (store *Store) connected(ctx context.Context) error {
 func (store *Store) disconnected(ctx context.Context) error {
 
 	if nil == store.Client {
-		err := ErrStoreNotConnected
-		_ = st.Errorf(ctx, -1, "unable to perform operation - no current connection - error: %v", err)
-		return err
+		return ErrStoreNotConnected("already disconnected")
 	}
 
 	return nil
@@ -565,8 +561,7 @@ func (store *Store) Connect() error {
 		})
 
 		if err != nil {
-			_ = st.Errorf(ctx, -1, "Failed to establish connection to store - error: %v", err)
-			return err
+			return ErrStoreConnectionFailed{store.GetAddress(), err}
 		}
 
 		// Hookup the namespace prefixing mechanism
@@ -1442,9 +1437,7 @@ func (store *Store) ReadMultipleTxn(ctx context.Context, keySet RecordKeySet) (*
 		}
 
 		if !response.Succeeded {
-			err = ErrStoreKeyReadFailure(keySet.Label)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
+			return ErrStoreKeyReadFailure(keySet.Label)
 		}
 
 		// And finally, the revision for the store as a whole.
@@ -1507,9 +1500,7 @@ func (store *Store) WriteMultipleTxn(ctx context.Context, recordSet *RecordUpdat
 		}
 
 		if !response.Succeeded {
-			err = ErrStoreKeyWriteFailure(recordSet.Label)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
+			return ErrStoreKeyWriteFailure(recordSet.Label)
 		}
 
 		revision = response.Header.Revision
@@ -1566,9 +1557,7 @@ func (store *Store) DeleteMultipleTxn(ctx context.Context, recordSet *RecordUpda
 		}
 
 		if !response.Succeeded {
-			err = ErrStoreKeyDeleteFailure(recordSet.Label)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
+			return ErrStoreKeyDeleteFailure(recordSet.Label)
 		}
 
 		revision = response.Header.Revision
@@ -1645,9 +1634,7 @@ func (store *Store) ReadTxn(ctx context.Context, request *Request) (response *Re
 		}
 
 		if !txnResponse.Succeeded {
-			err = ErrStoreKeyReadFailure(request.Reason)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
+			return ErrStoreKeyReadFailure(request.Reason)
 		}
 
 		// And finally, the revision for the store as a whole.
@@ -1711,9 +1698,7 @@ func (store *Store) WriteTxn(ctx context.Context, request *Request) (response *R
 		}
 
 		if !txnResponse.Succeeded {
-			err = ErrStoreKeyWriteFailure(request.Reason)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
+			return ErrStoreKeyWriteFailure(request.Reason)
 		}
 
 		// And finally, the revision for the store as a whole.
@@ -1777,9 +1762,7 @@ func (store *Store) DeleteTxn(ctx context.Context, request *Request) (response *
 		}
 
 		if !txnResponse.Succeeded {
-			err = ErrStoreKeyDeleteFailure(request.Reason)
-			_ = st.Errorf(ctx, -1, "Unexpected failure of txn - error: %v", err)
-			return err
+			return ErrStoreKeyDeleteFailure(request.Reason)
 		}
 
 		// And finally, the revision for the store as a whole.

--- a/internal/clients/store/store_test.go
+++ b/internal/clients/store/store_test.go
@@ -138,7 +138,7 @@ func TestStoreConnectDisconnect(t *testing.T) {
 
 	err = store.Connect()
 	assert.NotNilf(t, err, "Unexpectedly connected to store again - error: %v", err)
-	assert.Equal(t, ErrStoreConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected, err)
+	assert.Equal(t, ErrStoreConnected("already connected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected("already connected"), err)
 
 	store.Disconnect()
 
@@ -177,7 +177,7 @@ func TestStoreConnectDisconnectWithInitialize(t *testing.T) {
 		getDefaultTraceFlags(),
 		getDefaultNamespaceSuffix())
 	assert.NotNilf(t, err, "Unexpectedly re-initialized store after connect - error: %v", err)
-	assert.Equal(t, ErrStoreConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected, err)
+	assert.Equal(t, ErrStoreConnected("already connected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected("already connected"), err)
 
 	store.Disconnect()
 
@@ -226,22 +226,22 @@ func TestStoreConnectDisconnectWithSet(t *testing.T) {
 
 	err = store.SetAddress(endpoints)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to update the address - error: %v", err)
-	assert.Equal(t, ErrStoreConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected, err)
+	assert.Equal(t, ErrStoreConnected("already connected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected("already connected"), err)
 
 	err = store.SetTimeoutConnect(timeoutConnect)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to update the connect timeout - error: %v", err)
-	assert.Equal(t, ErrStoreConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected, err)
+	assert.Equal(t, ErrStoreConnected("already connected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected("already connected"), err)
 
 	err = store.SetTimeoutRequest(timeoutRequest)
 	assert.Nilf(t, err, "Failed to update the request timeout - error: %v", err)
 
 	err = store.SetNamespaceSuffix(namespaceSuffix)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to update the namespace suffix - error: %v", err)
-	assert.Equal(t, ErrStoreConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected, err)
+	assert.Equal(t, ErrStoreConnected("already connected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected("already connected"), err)
 
 	err = store.Connect()
 	assert.NotNilf(t, err, "Unexpectedly connected to store again - error: %v", err)
-	assert.Equal(t, ErrStoreConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected, err)
+	assert.Equal(t, ErrStoreConnected("already connected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreConnected("already connected"), err)
 
 	store.Disconnect()
 
@@ -534,35 +534,35 @@ func TestStoreWriteReadDeleteWithoutConnect(t *testing.T) {
 
 	err := store.Write(key, value)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to write to store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	err = store.WriteMultiple(keyValueSet)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to write to store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	_, err = store.Read(key)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to read from store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	_, err = store.ReadMultiple(keySet)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to read from store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	_, err = store.ReadWithPrefix(context.Background(), key)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to read from store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	err = store.Delete(key)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to delete from store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	err = store.DeleteMultiple(keySet)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to delete from store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	err = store.DeleteWithPrefix(key)
 	assert.NotNilf(t, err, "Unexpectedly succeeded to delete from store - error: %v", err)
-	assert.Equal(t, ErrStoreNotConnected, err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected, err)
+	assert.Equal(t, ErrStoreNotConnected("already disconnected"), err, "Unexpected error response - expected: %v got: %v", ErrStoreNotConnected("already disconnected"), err)
 
 	store = nil
 


### PR DESCRIPTION
Fixes issue where a change to a single source file is insufficient for make to detect a rebuild is required.

Adds dependency chains based on major components and/or directories, so now a change to a single individual source file will be detected whenever a relevant make target is invoked.

We may choose to break this up or re-organize later on as this does look a little pedantic but at least it should work and be safe.

I'd welcome opinions on the matter.


ps. This is the second in the chain of PR's I mentioned in mail. There is no actual dependency on the Errorf() edits in any way.
