### PR TITLE
Propagate contexts from http handlers through users layer

### DIFF
--- a/internal/services/frontend/DBUsers.go
+++ b/internal/services/frontend/DBUsers.go
@@ -50,15 +50,12 @@ func InitDBUsers(ctx context.Context, cfg *config.GlobalConfig) (err error) {
 			return err
 		}
 
-		_, err = dbUsers.Create(
-			ctx,
-			&pb.User{
-				Name:              cfg.WebServer.SystemAccount,
-				PasswordHash:      passwordHash,
-				Enabled:           true,
-				CanManageAccounts: true,
-				NeverDelete:       true,
-			})
+		_, err = dbUsers.Create(ctx, &pb.User{
+			Name:              cfg.WebServer.SystemAccount,
+			PasswordHash:      passwordHash,
+			Enabled:           true,
+			CanManageAccounts: true,
+			NeverDelete:       true})
 
 		// If the SystemAccount already exists we need to do a couple of things.
 		//

--- a/internal/services/frontend/DBUsers.go
+++ b/internal/services/frontend/DBUsers.go
@@ -50,7 +50,8 @@ func InitDBUsers(ctx context.Context, cfg *config.GlobalConfig) (err error) {
 			return err
 		}
 
-		_, err = dbUsers.Create(ctx,
+		_, err = dbUsers.Create(
+			ctx,
 			&pb.User{
 				Name:              cfg.WebServer.SystemAccount,
 				PasswordHash:      passwordHash,

--- a/internal/services/frontend/frontend.go
+++ b/internal/services/frontend/frontend.go
@@ -186,7 +186,7 @@ func initService(cfg *config.GlobalConfig) error {
 	store.Initialize(cfg)
 
 	// Finally, initialize the user store
-	return InitDBUsers(cfg)
+	return InitDBUsers(context.Background(), cfg)
 }
 
 // StartService is the primary entry point to start the front-end web service.

--- a/internal/services/frontend/session_manager.go
+++ b/internal/services/frontend/session_manager.go
@@ -168,7 +168,7 @@ func dumpSessionState(session *sessions.Session) string {
 
 // getLoggedInUser returns the user definition for the current session,
 // or an error, if no user can be found.
-func getLoggedInUser(session *sessions.Session) (*pb.User, error) {
+func getLoggedInUser(ctx context.Context, session *sessions.Session) (*pb.User, error) {
 	entry, ok := getSession(session)
 	if !ok {
 		return nil, &HTTPError{
@@ -177,7 +177,7 @@ func getLoggedInUser(session *sessions.Session) (*pb.User, error) {
 		}
 	}
 
-	user, _, err := dbUsers.Read(context.Background(), entry.name)
+	user, _, err := dbUsers.Read(ctx, entry.name)
 	return user, err
 }
 

--- a/internal/services/frontend/session_manager.go
+++ b/internal/services/frontend/session_manager.go
@@ -177,7 +177,7 @@ func getLoggedInUser(session *sessions.Session) (*pb.User, error) {
 		}
 	}
 
-	user, _, err := dbUsers.Read(entry.name)
+	user, _, err := dbUsers.Read(context.Background(), entry.name)
 	return user, err
 }
 

--- a/internal/services/frontend/users.go
+++ b/internal/services/frontend/users.go
@@ -78,7 +78,7 @@ func handlerUsersList(w http.ResponseWriter, r *http.Request) {
 		err = doSessionHeader(
 			ctx, w, r,
 			func(ctx context.Context, session *sessions.Session) error {
-				return canManageAccounts(session, "")
+				return canManageAccounts(ctx, session, "")
 			})
 
 		if err != nil {
@@ -129,7 +129,7 @@ func handlerUserCreate(w http.ResponseWriter, r *http.Request) {
 		err = doSessionHeader(
 			ctx, w, r,
 			func(ctx context.Context, session *sessions.Session) error {
-				return canManageAccounts(session, "")
+				return canManageAccounts(ctx, session, "")
 			})
 
 		if err != nil {
@@ -165,7 +165,7 @@ func handlerUserRead(w http.ResponseWriter, r *http.Request) {
 		err = doSessionHeader(
 			ctx, w, r,
 			func(ctx context.Context, session *sessions.Session) error {
-				return canManageAccounts(session, username)
+				return canManageAccounts(ctx, session, username)
 			})
 
 		if err != nil {
@@ -207,12 +207,12 @@ func handlerUserUpdate(w http.ResponseWriter, r *http.Request) {
 		err = doSessionHeader(
 			ctx, w, r,
 			func(ctx context.Context, session *sessions.Session) (err error) {
-				caller, err = getLoggedInUser(session)
+				caller, err = getLoggedInUser(ctx, session)
 				if err != nil {
 					return err
 				}
 
-				return canManageAccounts(session, username)
+				return canManageAccounts(ctx, session, username)
 			})
 
 		if err != nil {
@@ -279,7 +279,7 @@ func handlerUserDelete(w http.ResponseWriter, r *http.Request) {
 		err = doSessionHeader(
 			ctx, w, r,
 			func(ctx context.Context, session *sessions.Session) error {
-				return canManageAccounts(session, username)
+				return canManageAccounts(ctx, session, username)
 			})
 
 		if err != nil {
@@ -343,7 +343,7 @@ func handlerUserSetPassword(w http.ResponseWriter, r *http.Request) {
 		err = doSessionHeader(
 			ctx, w, r,
 			func(ctx context.Context, session *sessions.Session) (err error) {
-				return canManageAccounts(session, username)
+				return canManageAccounts(ctx, session, username)
 			})
 
 		if err != nil {
@@ -607,8 +607,8 @@ func userSetPassword(ctx context.Context, name string, changes *pb.UserPassword,
 
 // Determine if this session's active login has permission to change or
 // manage the targeted account.  Note that any account may manage itself.
-func canManageAccounts(session *sessions.Session, username string) error {
-	user, err := getLoggedInUser(session)
+func canManageAccounts(ctx context.Context, session *sessions.Session, username string) error {
+	user, err := getLoggedInUser(ctx, session)
 	if err != nil {
 		return NewErrUserPermissionDenied()
 	}

--- a/internal/services/frontend/users.go
+++ b/internal/services/frontend/users.go
@@ -94,7 +94,7 @@ func handlerUsersList(w http.ResponseWriter, r *http.Request) {
 
 		users := &pb.UserList{}
 
-		err = dbUsers.Scan(func(entry *pb.User) (err error) {
+		err = dbUsers.Scan(ctx, func(entry *pb.User) (err error) {
 			target := fmt.Sprintf("%s%s", b, entry.Name)
 			protected := ""
 			if entry.NeverDelete {
@@ -145,7 +145,7 @@ func handlerUserCreate(w http.ResponseWriter, r *http.Request) {
 
 		var rev int64
 
-		if rev, err = userAdd(username, u.Password, u.CanManageAccounts, u.Enabled, false); err != nil {
+		if rev, err = userAdd(ctx, username, u.Password, u.CanManageAccounts, u.Enabled, false); err != nil {
 			return httpError(ctx, w, err)
 		}
 
@@ -172,7 +172,7 @@ func handlerUserRead(w http.ResponseWriter, r *http.Request) {
 			return httpError(ctx, w, err)
 		}
 
-		u, rev, err := userRead(username)
+		u, rev, err := userRead(ctx, username)
 
 		if err != nil {
 			return httpError(ctx, w, err)
@@ -250,7 +250,7 @@ func handlerUserUpdate(w http.ResponseWriter, r *http.Request) {
 		var rev int64
 		var newVer *pb.User
 
-		if newVer, rev, err = userUpdate(username, upd, match); err != nil {
+		if newVer, rev, err = userUpdate(ctx, username, upd, match); err != nil {
 			return httpError(ctx, w, err)
 		}
 
@@ -286,7 +286,7 @@ func handlerUserDelete(w http.ResponseWriter, r *http.Request) {
 			return httpError(ctx, w, err)
 		}
 
-		if err = userRemove(username); err != nil {
+		if err = userRemove(ctx, username); err != nil {
 			return httpError(ctx, w, err)
 		}
 
@@ -309,10 +309,10 @@ func handlerUserOperation(w http.ResponseWriter, r *http.Request) {
 
 			switch op {
 			case Login:
-				s, err = login(session, r)
+				s, err = login(ctx, session, r)
 
 			case Logout:
-				s, err = logout(session, r)
+				s, err = logout(ctx, session, r)
 
 			default:
 				err = NewErrUserInvalidOperation(op)
@@ -373,7 +373,7 @@ func handlerUserSetPassword(w http.ResponseWriter, r *http.Request) {
 		// match.
 		var rev int64
 
-		if rev, err = userSetPassword(username, upd, match); err != nil {
+		if rev, err = userSetPassword(ctx, username, upd, match); err != nil {
 			return httpError(ctx, w, err)
 		}
 
@@ -395,7 +395,7 @@ func handlerUserSetPassword(w http.ResponseWriter, r *http.Request) {
 // applied to the response body.
 
 // Process a login request (?op=login)
-func login(session *sessions.Session, r *http.Request) (_ string, err error) {
+func login(ctx context.Context, session *sessions.Session, r *http.Request) (_ string, err error) {
 	var pwd []byte
 
 	vars := mux.Vars(r)
@@ -414,7 +414,7 @@ func login(session *sessions.Session, r *http.Request) (_ string, err error) {
 
 	// First, verify that this is an actual user account, and that account is
 	// enabled for login operations.
-	if u, _, err := userRead(username); err != nil || !u.Enabled {
+	if u, _, err := userRead(ctx, username); err != nil || !u.Enabled {
 		return "", &HTTPError{
 			SC:   http.StatusNotFound,
 			Base: ErrUserAuthFailed,
@@ -431,7 +431,7 @@ func login(session *sessions.Session, r *http.Request) (_ string, err error) {
 
 	// .. finally, let's confirm that this password matches the one for the
 	// designated user account.
-	if userVerifyPassword(username, pwd) != nil {
+	if userVerifyPassword(ctx, username, pwd) != nil {
 		return "", &HTTPError{
 			SC:   http.StatusForbidden,
 			Base: ErrUserAuthFailed,
@@ -451,7 +451,7 @@ func login(session *sessions.Session, r *http.Request) (_ string, err error) {
 }
 
 // Process a logout request (?op=logout)
-func logout(session *sessions.Session, r *http.Request) (_ string, err error) {
+func logout(ctx context.Context, session *sessions.Session, r *http.Request) (_ string, err error) {
 	vars := mux.Vars(r)
 	username := vars["username"]
 
@@ -475,19 +475,22 @@ func logout(session *sessions.Session, r *http.Request) (_ string, err error) {
 // attributes that are understood by the route handlers to the internal user
 // attributes understood by the storage system.
 
-func userAdd(name string, password string, accountManager bool, enabled bool, neverDelete bool) (int64, error) {
+func userAdd(ctx context.Context, name string, password string, accountManager bool, enabled bool, neverDelete bool) (int64, error) {
 	passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 
 	if err != nil {
 		return InvalidRev, err
 	}
 
-	revision, err := dbUsers.Create(&pb.User{
-		Name:              name,
-		PasswordHash:      passwordHash,
-		Enabled:           enabled,
-		CanManageAccounts: accountManager,
-		NeverDelete:       neverDelete})
+	revision, err := dbUsers.Create(
+		ctx,
+		&pb.User{
+			Name:              name,
+			PasswordHash:      passwordHash,
+			Enabled:           enabled,
+			CanManageAccounts: accountManager,
+			NeverDelete:       neverDelete,
+		})
 
 	if err == ErrUserAlreadyExists(name) {
 		return InvalidRev, NewErrUserAlreadyExists(name)
@@ -500,8 +503,8 @@ func userAdd(name string, password string, accountManager bool, enabled bool, ne
 	return revision, nil
 }
 
-func userUpdate(name string, u *pb.UserUpdate, rev int64) (*pb.User, int64, error) {
-	upd, revision, err := dbUsers.Update(name, u, rev)
+func userUpdate(ctx context.Context, name string, u *pb.UserUpdate, rev int64) (*pb.User, int64, error) {
+	upd, revision, err := dbUsers.Update(ctx, name, u, rev)
 
 	if err == ErrUserNotFound(name) {
 		return nil, InvalidRev, NewErrUserNotFound(name)
@@ -518,9 +521,9 @@ func userUpdate(name string, u *pb.UserUpdate, rev int64) (*pb.User, int64, erro
 	return upd, revision, nil
 }
 
-func userRead(name string) (*pb.User, int64, error) {
+func userRead(ctx context.Context, name string) (*pb.User, int64, error) {
 
-	u, rev, err := dbUsers.Read(name)
+	u, rev, err := dbUsers.Read(ctx, name)
 
 	if err == ErrUserNotFound(name) {
 		return nil, InvalidRev, NewErrUserNotFound(name)
@@ -533,8 +536,8 @@ func userRead(name string) (*pb.User, int64, error) {
 	return u, rev, nil
 }
 
-func userRemove(name string) error {
-	err := dbUsers.Delete(name, InvalidRev)
+func userRemove(ctx context.Context, name string) error {
+	err := dbUsers.Delete(ctx, name, InvalidRev)
 
 	if err == ErrUserProtected(name) {
 		return NewErrUserProtected(name)
@@ -554,9 +557,9 @@ func userRemove(name string) error {
 // TODO: Figure out how to better protect leakage of the password in memory.
 
 // Verify that the password matches the user's current hashed password
-func userVerifyPassword(name string, password []byte) error {
+func userVerifyPassword(ctx context.Context, name string, password []byte) error {
 
-	entry, _, err := userRead(name)
+	entry, _, err := userRead(ctx, name)
 
 	if err != nil {
 		return err
@@ -567,9 +570,9 @@ func userVerifyPassword(name string, password []byte) error {
 
 // Set the password for a given user account, after first verifying that
 // the current password was correctly provided (or an override was in place)
-func userSetPassword(name string, changes *pb.UserPassword, rev int64) (int64, error) {
+func userSetPassword(ctx context.Context, name string, changes *pb.UserPassword, rev int64) (int64, error) {
 	if !changes.Force {
-		if err := userVerifyPassword(name, []byte(changes.OldPassword)); err != nil {
+		if err := userVerifyPassword(ctx, name, []byte(changes.OldPassword)); err != nil {
 			return InvalidRev, NewErrUserPermissionDenied()
 		}
 	}
@@ -580,7 +583,7 @@ func userSetPassword(name string, changes *pb.UserPassword, rev int64) (int64, e
 		return InvalidRev, err
 	}
 
-	_, revision, err := dbUsers.UpdatePassword(name, passwordHash, rev)
+	_, revision, err := dbUsers.UpdatePassword(ctx, name, passwordHash, rev)
 
 	if err == ErrUserNotFound(name) {
 		return InvalidRev, NewErrUserNotFound(name)

--- a/internal/services/frontend/users.go
+++ b/internal/services/frontend/users.go
@@ -482,15 +482,12 @@ func userAdd(ctx context.Context, name string, password string, accountManager b
 		return InvalidRev, err
 	}
 
-	revision, err := dbUsers.Create(
-		ctx,
-		&pb.User{
-			Name:              name,
-			PasswordHash:      passwordHash,
-			Enabled:           enabled,
-			CanManageAccounts: accountManager,
-			NeverDelete:       neverDelete,
-		})
+	revision, err := dbUsers.Create(ctx, &pb.User{
+		Name:              name,
+		PasswordHash:      passwordHash,
+		Enabled:           enabled,
+		CanManageAccounts: accountManager,
+		NeverDelete:       neverDelete})
 
 	if err == ErrUserAlreadyExists(name) {
 		return InvalidRev, NewErrUserAlreadyExists(name)


### PR DESCRIPTION
This change connects up the contexts established in the http handler callbacks through the users layer and down to the store so allowing the association of store trace entries to originating request.

Verified by checking that the parentId field in the trace have non-zero entries for all but the handler calls and that the id's chain back from the store call, through the user layer and up to the originating handler.
