### PR TITLE
Ensure etcd scripts use correct location for script-location based binaries

### DIFF
--- a/scripts/MonitorEtcd.cmd
+++ b/scripts/MonitorEtcd.cmd
@@ -9,6 +9,12 @@
 
 SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
 
+set SCRIPTDIR=%~dp0
+set CLOUDCHAMBERDIR=%SCRIPTDIR:~0,-7%
+set CLOUDCHAMBERFILE=%CLOUDCHAMBERDIR%\Files
+set CLOUDCHAMBERDATA=%CLOUDCHAMBERDIR%\Data
+
+
 set LOCALHOST=127.0.0.1
 
 set BINARY=etcdctl.exe
@@ -37,28 +43,28 @@ if /i "%1" == "--help" (goto :ScriptHelp)
 
 rem Find a binary to use
 rem
-if exist %~dp0%BINARY% (
+if exist %CLOUDCHAMBERFILE%\etcdctl.exe (
 
-  set TARGETBIN=%~dp0%BINARY%
+  set TARGETBIN=%CLOUDCHAMBERFILE%\etcdctl.exe
 
-) else if exist %TARGETBINPATH%\%BINARY% (
+) else if exist %TARGETBINPATH%\etcdctl.exe (
 
-  set TARGETBIN=%TARGETBINPATH%\%BINARY%
+  set TARGETBIN=%TARGETBINPATH%\etcdctl.exe
 
-) else if exist %GOPATH%\bin\%BINARY% (
+) else if exist %GOPATH%\bin\etcdctl.exe (
 
-  set TARGETBIN=%GOPATH%\bin\%BINARY%
+  set TARGETBIN=%GOPATH%\bin\etcdctl.exe
 
 ) else (
 
-   for %%I in (%BINARY%) do set TARGETBIN=%%~$PATH:I
+   for %%I in (etcdctl.exe) do set TARGETBIN=%%~$PATH:I
 
 )
 
 
 if not exist "%TARGETBIN%" (
   echo.
-  echo Unable to find a copy of %BINARY%
+  echo Unable to find a copy of etcdctl.exe
   echo.
   goto :ScriptExit
 )

--- a/scripts/StartEtcd.cmd
+++ b/scripts/StartEtcd.cmd
@@ -9,6 +9,12 @@
 
 SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
 
+set SCRIPTDIR=%~dp0
+set CLOUDCHAMBERDIR=%SCRIPTDIR:~0,-7%
+set CLOUDCHAMBERFILE=%CLOUDCHAMBERDIR%\Files
+set CLOUDCHAMBERDATA=%CLOUDCHAMBERDIR%\Data
+
+
 set LOCALHOST=127.0.0.1
 
 
@@ -44,22 +50,22 @@ if /i "%1" NEQ "" (
 
   set ETCDDIR=%1
 
-) else if "%ETCDDATA%" == "" (
+) else if "%ETCDDATA%" NEQ "" (
 
-  set ETCDDIR=%DEFAULT_ETCDDATA%\%ETCDINSTANCE%.etcd
+  set ETCDDIR=%ETCDDATA%\%ETCDINSTANCE%.etcd
 
 ) else (
 
-  set ETCDDIR=%ETCDDATA%\%ETCDINSTANCE%.etcd
+  set ETCDDIR=%CLOUDCHAMBERDATA%
 
 )
 
 
 rem Find a etcd.exe to use
 rem
-if exist %~dp0etcd.exe (
+if exist %CLOUDCHAMBERFILE%\etcd.exe (
 
-  set TARGETBIN=%~dp0etcd.exe
+  set TARGETBIN=%CLOUDCHAMBERFILE%\etcd.exe
 
 ) else if exist %ETCDBINPATH%\etcd.exe (
 


### PR DESCRIPTION
Currently, the StartEtcd.cmd and MonitorEtcd.cmd do not correctly parse the path to the script file being executed, which results in an improper path selection for the binary, and in the case of StartEtcd.cmd also uses a default etcd data location rather than one from the CloudChamber deployment.

This change fixes the parsing issue which results in the correct paths being built and used.