### PR TITLE
Add REST service for trace_sink

### DIFF
--- a/cmd/controllerd/main.go
+++ b/cmd/controllerd/main.go
@@ -40,7 +40,7 @@ func main() {
 		log.Fatalf("failed to set up the trace logger, err=%v", err)
 	}
 
-	if err = setup.SetEndpoint(cfg.SimSupport.EP.Hostname, cfg.SimSupport.EP.Port); err != nil {
+	if err = setup.SetEndpoint(cfg.SimSupport.EP.String()); err != nil {
 		log.Fatalf("failed to set the trace sink endpoint, err=%v", err)
 	}
 

--- a/cmd/inventoryd/main.go
+++ b/cmd/inventoryd/main.go
@@ -36,7 +36,7 @@ func main() {
 		log.Fatalf("failed to set up the trace logger, err=%v", err)
 	}
 
-	if err = setup.SetEndpoint(cfg.SimSupport.EP.Hostname, cfg.SimSupport.EP.Port); err != nil {
+	if err = setup.SetEndpoint(cfg.SimSupport.EP.String()); err != nil {
 		log.Fatalf("failed to set the trace sink endpoint, err=%v", err)
 	}
 

--- a/cmd/sim_supportd/main.go
+++ b/cmd/sim_supportd/main.go
@@ -55,7 +55,7 @@ func main() {
 	// This will fail initially, as the grpc listener is not active yet.  But
 	// a failure to connect is a planned condition and normal reconnection
 	// handling will get this channel set up.
-	if err = setup.SetEndpoint(cfg.SimSupport.EP.Hostname, cfg.SimSupport.EP.Port); err != nil {
+	if err = setup.SetEndpoint(cfg.SimSupport.EP.String()); err != nil {
 		log.Fatalf("failed to set the trace sink endpoint, err=%v", err)
 	}
 

--- a/cmd/web_server/main.go
+++ b/cmd/web_server/main.go
@@ -37,7 +37,7 @@ func main() {
 		log.Fatalf("failed to set up the trace logger, err=%v", err)
 	}
 
-	if err = setup.SetEndpoint(cfg.SimSupport.EP.Hostname, cfg.SimSupport.EP.Port); err != nil {
+	if err = setup.SetEndpoint(cfg.SimSupport.EP.String()); err != nil {
 		log.Fatalf("failed to set the trace sink endpoint, err=%v", err)
 	}
 

--- a/internal/clients/trace_sink/trace_sink.go
+++ b/internal/clients/trace_sink/trace_sink.go
@@ -1,0 +1,131 @@
+package clients
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/Jim3Things/CloudChamber/pkg/protos/log"
+	pb "github.com/Jim3Things/CloudChamber/pkg/protos/trace_sink"
+)
+
+var (
+	dialName string
+	dialOpts []grpc.DialOption
+)
+
+// TraceData contains the 'GetAfter' response, or an error.
+type TraceData struct {
+	Traces *pb.GetAfterResponse
+	Err error
+}
+
+// InitSinkClient stores the information needed to be able to connect to the Stepper service.
+func InitSinkClient(name string, opts ...grpc.DialOption) {
+	dialName = name
+
+	dialOpts = append(dialOpts, opts...)
+}
+
+// Reset forcibly resets the trace sink to its initial state.  This is intended
+// to support unit tests
+func Reset() error {
+	ctx, conn, err := connect()
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	client := pb.NewTraceSinkClient(conn)
+
+	_, err = client.Reset(ctx, &pb.ResetRequest{})
+
+	return err
+}
+
+// Append adds a log entry to the trace sink
+func Append(entry *log.Entry) error {
+	ctx, conn, err := connect()
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	client := pb.NewTraceSinkClient(conn)
+
+	_, err = client.Append(ctx, &pb.AppendRequest{Entry: entry})
+	return err
+}
+
+// GetPolicy obtains the current trace sink policy and returns it
+func GetPolicy() (*pb.GetPolicyResponse, error) {
+	ctx, conn, err := connect()
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	client := pb.NewTraceSinkClient(conn)
+
+	policy, err := client.GetPolicy(ctx, &pb.GetPolicyRequest{})
+
+	return policy, err
+}
+
+// GetTraces retrieves up to the specified limit of trace entries, from the
+// specified starting point.  It will always wait for at least one
+// non-internal entry before returning.
+func GetTraces(start int64, maxCount int64) <-chan TraceData {
+	ch := make(chan TraceData)
+
+	go func(res chan<- TraceData) {
+		ctx, conn, err := connect()
+		if err != nil {
+			res <- TraceData{
+				Traces: nil,
+				Err:  err,
+			}
+			return
+		}
+
+		defer func() { _ = conn.Close() }()
+
+		client := pb.NewTraceSinkClient(conn)
+
+		rsp, err := client.GetAfter(ctx, &pb.GetAfterRequest{
+			Id:         start,
+			MaxEntries: maxCount,
+			Wait:       true,
+		})
+
+		res <- TraceData{Traces: rsp, Err: nil}
+	}(ch)
+
+	return ch
+}
+
+// connect is a helper function that sets up the communication context for
+// the grpc client.
+func connect() (context.Context, *grpc.ClientConn, error) {
+	conn, err := grpc.Dial(dialName, dialOpts...)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: These are placeholder metadata items.  Need to provide the actual ones
+	//       we intend to use.
+	md := metadata.Pairs(
+		"timestamp", time.Now().Format(time.StampNano),
+		"client-id", "web-api-client-us-east-1",
+		"user-id", "some-test-user-id",
+	)
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
+
+	return ctx, conn, nil
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -73,6 +73,11 @@ type Endpoint struct {
 	Port     uint16
 }
 
+// String provides a formatted 'host:port' string for the endpoint
+func (e *Endpoint) String() string {
+	return fmt.Sprintf("%s:%d", e.Hostname, e.Port)
+}
+
 // ControllerType is a helper type describes the controllerd configuration settings
 type ControllerType struct {
 	// Exposed GRPC endpoint

--- a/internal/services/frontend/common_test.go
+++ b/internal/services/frontend/common_test.go
@@ -82,7 +82,7 @@ func commonSetup() {
 	}
 
 	if err := tracing_sink.Register(s); err != nil {
-		log.Fatalf("Failed to register tracking sink: %v", err)
+		log.Fatalf("Failed to register tracing sink: %v", err)
 	}
 
 	go func() {

--- a/internal/services/frontend/common_test.go
+++ b/internal/services/frontend/common_test.go
@@ -27,8 +27,10 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 
 	ts "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
+	tsc "github.com/Jim3Things/CloudChamber/internal/clients/trace_sink"
 	"github.com/Jim3Things/CloudChamber/internal/config"
 	stepper "github.com/Jim3Things/CloudChamber/internal/services/stepper_actor"
+	"github.com/Jim3Things/CloudChamber/internal/services/tracing_sink"
 	ctrc "github.com/Jim3Things/CloudChamber/internal/tracing/client"
 	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters"
 	strc "github.com/Jim3Things/CloudChamber/internal/tracing/server"
@@ -79,6 +81,10 @@ func commonSetup() {
 		log.Fatalf("Failed to register stepper actor: %v", err)
 	}
 
+	if err := tracing_sink.Register(s); err != nil {
+		log.Fatalf("Failed to register tracking sink: %v", err)
+	}
+
 	go func() {
 		if err := s.Serve(lis); err != nil {
 			log.Fatalf("Server exited with error: %v", err)
@@ -89,6 +95,11 @@ func commonSetup() {
 		grpc.WithContextDialer(bufDialer),
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(ctrc.Interceptor))
+
+	tsc.InitSinkClient("bufnet",
+		grpc.WithContextDialer(bufDialer),
+		grpc.WithInsecure(),
+		grpc.WithUnaryInterceptor(ctrc.InfraInterceptor))
 
 	// Finally, start the test web service, which all tests will use
 	if err := initService(&config.GlobalConfig{

--- a/internal/services/frontend/frontend.go
+++ b/internal/services/frontend/frontend.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/Jim3Things/CloudChamber/internal/clients/store"
 	ts "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
+	tsc "github.com/Jim3Things/CloudChamber/internal/clients/trace_sink"
 	"github.com/Jim3Things/CloudChamber/internal/config"
 	ct "github.com/Jim3Things/CloudChamber/internal/tracing/client"
 	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
@@ -164,14 +165,16 @@ func initService(cfg *config.GlobalConfig) error {
 	server.cookieStore.Options.Secure = false
 	server.cookieStore.Options.HttpOnly = false
 
-	// Initialize the simulated time (stepper) service client
+	// Initialize the service clients
 	ts.InitTimestamp(
-		fmt.Sprintf(
-			"%s:%d",
-			cfg.SimSupport.EP.Hostname,
-			cfg.SimSupport.EP.Port),
+		cfg.SimSupport.EP.String(),
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(ct.Interceptor))
+
+	tsc.InitSinkClient(
+		cfg.SimSupport.EP.String(),
+		grpc.WithInsecure(),
+		grpc.WithUnaryInterceptor(ct.InfraInterceptor))
 
 	if err := initHandlers(); err != nil {
 		return err

--- a/internal/services/frontend/logs.go
+++ b/internal/services/frontend/logs.go
@@ -1,22 +1,91 @@
 package frontend
 
 import (
-	"fmt"
+	"context"
 	"net/http"
 
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+
+	tsc "github.com/Jim3Things/CloudChamber/internal/clients/trace_sink"
+	"github.com/Jim3Things/CloudChamber/internal/tracing"
+	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 )
 
 func logsAddRoutes(routeBase *mux.Router) {
 	router := routeBase.PathPrefix("/logs").Subrouter()
 
-	router.HandleFunc("", handlerLogsRoot).Methods("GET")
-	router.HandleFunc("/", handlerLogsRoot).Methods("GET")
+	router.HandleFunc("", handlerLogsGetAfter).Queries("from", "{from}", "for", "{for}").Methods("GET")
+	router.HandleFunc("/policy", handlerLogsGetPolicy).Methods("GET")
 }
 
-func handlerLogsRoot(w http.ResponseWriter, _ *http.Request) {
+// handlerLogsGetAfter processes an incoming REST request to retrieve trace
+// entries within the specified range.
+func handlerLogsGetAfter(w http.ResponseWriter, r *http.Request) {
+	_ = st.WithInfraSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
 
-	_, _ = fmt.Fprintf(w, "Logs (Root)")
+		vars := mux.Vars(r)
+		from := vars["from"]
+		count := vars["for"]
+
+		err := doSessionHeader(
+			ctx, w, r,
+			func(ctx context.Context, session *sessions.Session) error {
+				return ensureEstablishedSession(session)
+			})
+
+		if err != nil {
+			return httpError(ctx, w, err)
+		}
+
+		fromId, err := ensureNumber("from", from)
+		if err != nil {
+			return httpError(ctx, w, err)
+		}
+
+		maxSize, err := ensurePositiveNumber("for", count)
+		if err != nil {
+			return httpError(ctx, w, err)
+		}
+
+		ch := tsc.GetTraces(fromId, maxSize)
+
+		data := <- ch
+		if data.Err != nil {
+			return httpError(ctx, w, data.Err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		p := jsonpb.Marshaler{}
+		return p.Marshal(w, data.Traces)
+	})
 }
 
+// handlerLogsGetPolicy processes an incoming REST request to obtain the
+// current trace_sink policy.
+func handlerLogsGetPolicy(w http.ResponseWriter, r *http.Request) {
+	_ = st.WithInfraSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) error {
 
+		err := doSessionHeader(
+			ctx, w, r,
+			func(ctx context.Context, session *sessions.Session) error {
+				return ensureEstablishedSession(session)
+			})
+
+		if err != nil {
+			return httpError(ctx, w, err)
+		}
+
+		policy, err := tsc.GetPolicy()
+		if err != nil {
+			return httpError(ctx, w, err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		p := jsonpb.Marshaler{}
+		return p.Marshal(w, policy)
+	})
+}

--- a/internal/services/frontend/logs_test.go
+++ b/internal/services/frontend/logs_test.go
@@ -1,0 +1,208 @@
+package frontend
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	tsc "github.com/Jim3Things/CloudChamber/internal/clients/trace_sink"
+	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters/unit_test"
+	"github.com/Jim3Things/CloudChamber/pkg/protos/log"
+	pb "github.com/Jim3Things/CloudChamber/pkg/protos/trace_sink"
+)
+
+const (
+	logsURI = "/api/logs"
+)
+
+func testLogsPath() string { return baseURI + logsURI }
+
+func testLogsGetPolicy(t *testing.T, cookies []*http.Cookie) (*pb.GetPolicyResponse, []*http.Cookie) {
+	request := httptest.NewRequest("GET", fmt.Sprintf("%s%s", testLogsPath(), "/policy"), nil)
+	response := doHTTP(request, cookies)
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+
+	res := &pb.GetPolicyResponse{}
+	err := getJSONBody(response, res)
+
+	assert.Nilf(t, err, "Unexpected error, err: %v", err)
+
+	return res, response.Cookies()
+}
+
+func testLogsGetAfter(t *testing.T, start int64, maxCount int64, cookies []*http.Cookie) (*pb.GetAfterResponse, []*http.Cookie) {
+	path := fmt.Sprintf("%s?from=%d&for=%d", testLogsPath(), start, maxCount)
+	request := httptest.NewRequest("GET", path, nil)
+	response := doHTTP(request, cookies)
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+
+	res := &pb.GetAfterResponse{}
+	err := getJSONBody(response, res)
+
+	assert.Nilf(t, err, "Unexpected error, err: %v", err)
+
+	return res, response.Cookies()
+}
+
+func TestLogsGetPolicy(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
+	err := tsc.Reset()
+	require.Nil(t, err)
+
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+
+	res, cookies := testLogsGetPolicy(t, response.Cookies())
+	assert.Equal(t, int64(100), res.MaxEntriesHeld)
+	assert.Equal(t, int64(-1), res.FirstId)
+
+	doLogout(t, randomCase(adminAccountName), cookies)
+}
+
+func TestLogsGetPolicyNoSession(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
+	err := tsc.Reset()
+	require.Nil(t, err)
+
+	request := httptest.NewRequest("GET", fmt.Sprintf("%s%s", testLogsPath(), "/policy"), nil)
+	response := doHTTP(request, nil)
+
+	assert.Equal(t, http.StatusForbidden, response.StatusCode)
+	assert.Nil(t, err)
+}
+
+func TestLogsGetAfterNoSession(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
+	err := tsc.Reset()
+	require.Nil(t, err)
+
+	path := fmt.Sprintf("%s?from=0&for=100", testLogsPath())
+	request := httptest.NewRequest("GET", path, nil)
+	response := doHTTP(request, nil)
+
+	assert.Equal(t, http.StatusForbidden, response.StatusCode)
+	assert.Nil(t, err)
+}
+
+func TestLogsGetAfterBadStart(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
+	err := tsc.Reset()
+	require.Nil(t, err)
+
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+
+	path := fmt.Sprintf("%s?from=%s&for=%d", testLogsPath(), "bogus", 100)
+	request := httptest.NewRequest("GET", path, nil)
+	response = doHTTP(request, response.Cookies())
+
+	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+
+	doLogout(t, randomCase(adminAccountName), response.Cookies())
+}
+
+func TestLogsGetAfterBadCount(t *testing.T) {
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
+	err := tsc.Reset()
+	require.Nil(t, err)
+
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+
+	path := fmt.Sprintf("%s?from=%d&for=%s", testLogsPath(), -1, "bogus")
+	request := httptest.NewRequest("GET", path, nil)
+	response = doHTTP(request, response.Cookies())
+
+	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+
+	doLogout(t, randomCase(adminAccountName), response.Cookies())
+}
+
+func TestLogsGetAfter(t *testing.T) {
+	var cookies2 []*http.Cookie
+
+	unit_test.SetTesting(t)
+	defer unit_test.SetTesting(nil)
+
+	entry := &log.Entry{
+		Name:           "test",
+		SpanID:         "0000",
+		ParentID:       "1111",
+		Status:         "ok",
+		StackTrace:     "yyyy",
+		Event:          []*log.Event {
+			{
+				Tick:       0,
+				Severity:   1,
+				Name:       "testEvent",
+				Text:       "xyzzy",
+				StackTrace: "zzzz",
+				Impacted:   nil,
+			},
+		},
+		Infrastructure: false,
+	}
+
+	err := tsc.Reset()
+	require.Nil(t, err)
+
+	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
+	afterHit := false
+
+	go func(cookies []*http.Cookie) {
+		var res *pb.GetAfterResponse
+
+		res, cookies2 = testLogsGetAfter(t, -1, 10, response.Cookies())
+
+		require.Equal(t, 1, len(res.Entries))
+
+		assert.Equal(t, int64(0), res.Entries[0].Id)
+
+		resEntry := res.Entries[0].Entry
+		assert.Equal(t, entry.Name, resEntry.Name)
+		assert.Equal(t, entry.SpanID, resEntry.SpanID)
+		assert.Equal(t, entry.ParentID, resEntry.ParentID)
+		assert.Equal(t, entry.Infrastructure, resEntry.Infrastructure)
+		assert.Equal(t, entry.Status, resEntry.Status)
+		assert.Equal(t, entry.StackTrace, resEntry.StackTrace)
+
+		require.Equal(t, len(entry.Event), len(resEntry.Event))
+
+		resEvent := resEntry.Event[0]
+		event := entry.Event[0]
+
+		assert.Equal(t, event.Name, resEvent.Name)
+		assert.Equal(t, event.StackTrace, resEvent.StackTrace)
+		assert.Equal(t, event.Impacted, resEvent.Impacted)
+		assert.Equal(t, event.Text, resEvent.Text)
+		assert.Equal(t, event.Tick, resEvent.Tick)
+		assert.Equal(t, event.Severity, resEvent.Severity)
+
+		afterHit = true
+	}(response.Cookies())
+
+	time.Sleep(time.Duration(100) * time.Millisecond)
+	assert.False(t, afterHit)
+
+	err = tsc.Append(entry)
+	require.Nil(t, err)
+
+	time.Sleep(time.Duration(1) * time.Second)
+	assert.True(t, afterHit)
+
+	doLogout(t, randomCase(adminAccountName), cookies2)
+}

--- a/internal/services/frontend/stepper.go
+++ b/internal/services/frontend/stepper.go
@@ -184,9 +184,10 @@ func handleWaitFor(w http.ResponseWriter, r *http.Request) {
 			return httpError(ctx, w, err)
 		}
 
-		afterTick, err := strconv.ParseInt(after, 10, 64)
-		if err != nil || afterTick < 0 {
-			return httpError(ctx, w, NewErrInvalidStepperAfter(after))
+
+		afterTick, err := ensurePositiveNumber("after", after)
+		if err != nil {
+			return httpError(ctx, w, err)
 		}
 
 		ch, err := clients.After(&ct.Timestamp{Ticks: afterTick + 1})

--- a/internal/services/tracing_sink/sink.go
+++ b/internal/services/tracing_sink/sink.go
@@ -149,7 +149,12 @@ func (s *server) GetAfter(ctx context.Context, request *pb.GetAfterRequest) (*pb
 			return resp.err
 		}
 
-		resp = <- s.wait(id, request.MaxEntries)
+		ch := s.wait(id, request.MaxEntries)
+
+		s.mutex.Unlock()
+		resp = <- ch
+		s.mutex.Lock()
+
 		return resp.err
 	})
 

--- a/internal/services/tracing_sink/sink.go
+++ b/internal/services/tracing_sink/sink.go
@@ -131,9 +131,6 @@ func (s *server) Append(ctx context.Context, request *pb.AppendRequest) (*empty.
 // caller also specifies the maximum number of entries to return in one call,
 // and whether or not to wait if there are not entries currently outstanding.
 func (s *server) GetAfter(ctx context.Context, request *pb.GetAfterRequest) (*pb.GetAfterResponse, error) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
 	var resp waitResponse
 
 	err := st.WithInfraSpan(ctx, tracing.MethodName(1), func(ctx context.Context) error {
@@ -141,19 +138,24 @@ func (s *server) GetAfter(ctx context.Context, request *pb.GetAfterRequest) (*pb
 			return err
 		}
 
+		s.mutex.Lock()
+
 		// If we either can't wait, or there are active traces to return,
 		// do so now.
 		id := request.Id + 1
 		if !request.Wait || (id < int64(s.nextNonInternalId)) {
 			resp = s.processWaiter(request.Id + 1, request.MaxEntries)
+
+			s.mutex.Unlock()
+
 			return resp.err
 		}
 
 		ch := s.wait(id, request.MaxEntries)
 
 		s.mutex.Unlock()
+
 		resp = <- ch
-		s.mutex.Lock()
 
 		return resp.err
 	})

--- a/internal/tracing/client/tracing.go
+++ b/internal/tracing/client/tracing.go
@@ -12,13 +12,56 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func Interceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+// Interceptor is a function that traces the client side activity for a grpc
+// call.
+func Interceptor(
+	ctx context.Context,
+	method string,
+	req,
+	reply interface{},
+	cc *grpc.ClientConn,
+	invoker grpc.UnaryInvoker,
+	opts ...grpc.CallOption) error {
+	return commonInterceptor(
+		ctx, method, req, reply, cc, invoker,
+		trace.SpanKindClient,
+		opts...)
+}
+
+// InfraInterceptor is a function that traces the client side activity for a
+// grpc infrastructure call.  These traces use an 'internal' span designator,
+// so that they can be filtered during display later.
+func InfraInterceptor(
+	ctx context.Context,
+	method string,
+	req,
+	reply interface{},
+	cc *grpc.ClientConn,
+	invoker grpc.UnaryInvoker,
+	opts ...grpc.CallOption) error {
+		return commonInterceptor(
+			ctx, method, req, reply, cc, invoker,
+			trace.SpanKindInternal,
+			opts...)
+}
+
+// commonInterceptor performs the logic to encase the grpc call itself in a
+// trace span, and to record the final status.
+func commonInterceptor(
+	ctx context.Context,
+	method string,
+	req,
+	reply interface{},
+	cc *grpc.ClientConn,
+	invoker grpc.UnaryInvoker,
+	kind trace.SpanKind,
+	opts ...grpc.CallOption) error {
 	requestMetadata, _ := metadata.FromOutgoingContext(ctx)
 	metadataCopy := requestMetadata.Copy()
 
 	tr := global.TraceProvider().Tracer("client")
 
-	ctx, span := tr.Start(ctx, method)
+	ctx, span := tr.Start(ctx, method, trace.WithSpanKind(kind))
 	defer span.End()
 
 	grpctrace.Inject(ctx, &metadataCopy)
@@ -30,6 +73,7 @@ func Interceptor(ctx context.Context, method string, req, reply interface{}, cc 
 	return err
 }
 
+// setTraceStatus records the final status for a trace span.
 func setTraceStatus(ctx context.Context, span trace.Span, err error) {
 	// Spans assume a status of "OK", so we only need to update the
 	// status if it is an error.

--- a/internal/tracing/setup/config.go
+++ b/internal/tracing/setup/config.go
@@ -61,7 +61,6 @@ func SetFileWriter(name string) error {
 
 // SetEndpoint supplies the endpoint to the trace sink service for the
 // 'production' trace exporter variant
-func SetEndpoint(host string, port uint16) error {
-	endpoint := fmt.Sprintf("%s:%d", host, port)
+func SetEndpoint(endpoint string) error {
 	return production.SetEndpoint(endpoint, grpc.WithInsecure())
 }


### PR DESCRIPTION
- Add log entry retrieval to frontend
- Add trace_sink client
- Add Stringer interface to Endpoint
- Add more general error handling for numeric values in query fields
- Add infrastructure client interceptor for grpc
- Fix deadlock in trace_sink
