### PR TITLE
Minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,8 +189,8 @@ endif
 
 PROTOC_BASE = protoc --proto_path=. --proto_path=$(GOPATH)/src
 
-PROTOC_PBUF = $(PROTOC_BASE) --go_out=$(GOPATH)/src 
-PROTOC_GRPC = $(PROTOC_BASE) --go_out=plugins=grpc:$(GOPATH)/src 
+PROTOC_PBUF = $(PROTOC_BASE) --go_out=$(GOPATH)/src
+PROTOC_GRPC = $(PROTOC_BASE) --go_out=plugins=grpc:$(GOPATH)/src
 
 
 CP = cp
@@ -240,6 +240,7 @@ run_tests: $(PROTO_GEN_FILES) $(VERSION_MARKER)
 	go test $(PROJECT)/internal/clients/timestamp
 	go test $(PROJECT)/internal/services/frontend
 	go test $(PROJECT)/internal/services/stepper_actor
+	go test $(PROJECT)/internal/services/tracing_sink
 	go test $(PROJECT)/internal/tracing/exporters/common
 
 

--- a/internal/clients/timestamp/timestamp.go
+++ b/internal/clients/timestamp/timestamp.go
@@ -87,7 +87,7 @@ func Now() (*ct.Timestamp, error) {
 
 // Delay until the simulated time meets or exceeds the specified deadline.
 // Completion is asynchronous, even if no delay is required.
-func After(deadline *ct.Timestamp) (<-chan TimeData, error) {
+func After(deadline *ct.Timestamp) <-chan TimeData {
 	ch := make(chan TimeData)
 
 	go func(res chan<- TimeData) {
@@ -113,7 +113,7 @@ func After(deadline *ct.Timestamp) (<-chan TimeData, error) {
 		res <- TimeData{Time: rsp, Err: nil}
 	}(ch)
 
-	return ch, nil
+	return ch
 }
 
 func Status() (*pb.StatusResponse, error) {

--- a/internal/clients/timestamp/timestamp_test.go
+++ b/internal/clients/timestamp/timestamp_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/Jim3Things/CloudChamber/internal/common/channels"
 	"github.com/Jim3Things/CloudChamber/internal/services/stepper_actor"
 	ctrc "github.com/Jim3Things/CloudChamber/internal/tracing/client"
 	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters"
@@ -93,28 +94,23 @@ func TestTimestamp_After(t *testing.T) {
 	now, err := Now()
 	assert.Nil(t, err)
 	assert.Equal(t, int64(0), now.Ticks)
-	afterHit := false
 
-	go func(deadline int64) {
-		ch, err := After(&ct.Timestamp{Ticks: deadline})
-		assert.Nil(t, err)
+	ch := make(chan bool)
 
-		data := <-ch
-		afterHit = true
+	go func(deadline int64, res chan<- bool) {
+		data := <- After(&ct.Timestamp{Ticks: deadline})
 
 		assert.Nil(t, data.Err)
 		assert.GreaterOrEqual(t, deadline, data.Time.Ticks)
-	}(3)
+		res <- true
+	}(3, ch)
 
 	assert.Nil(t, Advance())
-	time.Sleep(time.Duration(2) * time.Second)
-	assert.False(t, afterHit)
+	assert.True(t, channels.DoNotCompleteWithin(ch, time.Duration(2) * time.Second))
 
 	assert.Nil(t, Advance())
-	time.Sleep(time.Duration(2) * time.Second)
-	assert.False(t, afterHit)
+	assert.True(t, channels.DoNotCompleteWithin(ch, time.Duration(2) * time.Second))
 
 	assert.Nil(t, Advance())
-	time.Sleep(time.Duration(2) * time.Second)
-	assert.True(t, afterHit)
+	assert.True(t, channels.CompleteWithin(ch, time.Duration(2) * time.Second))
 }

--- a/internal/common/channels/channels.go
+++ b/internal/common/channels/channels.go
@@ -1,0 +1,29 @@
+package channels
+
+import (
+	"time"
+)
+
+// CompleteWithin ensures that a channel either produces a result within the
+// specified time, or it times out.
+func CompleteWithin(ch <-chan bool, delay time.Duration) bool {
+	select {
+	case <-ch:
+		return true
+	case <-time.After(delay):
+		return false
+	}
+}
+
+// DoNotCompleteWithin ensures that the channel does not produce a result
+// before the specified time.  When this function returns with success no
+// value will have been read from the supplied channel.
+func DoNotCompleteWithin(ch <-chan bool, delay time.Duration) bool {
+	select {
+	case <-ch:
+		return false
+
+	case <-time.After(delay):
+		return true
+	}
+}

--- a/internal/services/frontend/cloudchamber.yaml
+++ b/internal/services/frontend/cloudchamber.yaml
@@ -1,0 +1,86 @@
+# Cloud Chamber service configuration values
+
+# control management service (controllerd)
+controller:
+  # GRPC endpoint
+  EP:
+    Port: 8081
+    Hostname: localhost
+
+# simulated inventory service (inventoryd)
+inventory:
+  # GRPC endpoint
+  EP:
+    port: 8082
+    hostname: localhost
+
+# simulation support services (sim_supportd)
+simSupport:
+  # GRPC endpoint
+  EP:
+    port: 8083
+    hostname: localhost
+
+# store interactions and etcd instance connection parameters
+store:
+  # trace level to use for interactions with the store and
+  # etcd
+  traceLevel: 1
+
+  # timeout in seconds to allow when attempting to establish
+  # a connection to the etcd instance
+  connectTimeout: 5
+
+  # timeout in seconds to allow when sending a request to
+  # etcd instance
+  requestTimeout: 5
+
+  # Client and peer endpoint addresses and ports for an external
+  # instance of etcd.
+  #
+  # Currently the use of an etcd cluster is not supported. When
+  # they are, this will become a list/array of endpoints.
+  etcdService:
+    hostname: localhost
+    port: 2379
+
+  # Test specific configuration.
+  #
+  # Setting UseTestNamespace to 1 will instruct the store to use
+  # a pre-defined test namespace which optionally can be deleted
+  # prior to running the any tests. Only the test namespace is
+  # affected by any cleanining.
+  #
+  # If UseUniqueInstance is set to 1, the tests will write to a
+  # unique namespace to isolate test results from run to run.
+  #
+  # If PreCleanStore is set to 1, the test will clean the store
+  # of existing tests using the same namespace. Effectively this
+  # means just the standard namespace as any unique namespaces
+  # will not match.
+  #
+  Test:
+    UseTestNamespace: 1
+    UseUniqueInstance: 0
+    PreCleanStore: 1
+
+# front end service, client web server
+webServer:
+  # front end (exposed http) endpoint
+  fe:
+    port: 8080
+    hostname: localhost
+
+  # back end (GRPC internal notifications) endpoint
+  be:
+    port: 8084
+    hostname: localhost
+
+  # file system path to the static files and scripts
+  rootFilePath: c:\CloudChamber\Files
+
+  # pre-defined account
+  systemAccount: Admin
+
+  # .. and its password (a really bad pattern here, but we'll use it for now)
+  systemAccountPassword: AdminPassword

--- a/internal/services/frontend/common_test.go
+++ b/internal/services/frontend/common_test.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -102,41 +103,15 @@ func commonSetup() {
 		grpc.WithUnaryInterceptor(ctrc.InfraInterceptor))
 
 	// Finally, start the test web service, which all tests will use
-	if err := initService(&config.GlobalConfig{
-		Controller: config.ControllerType{},
-		Inventory:  config.InventoryType{},
-		SimSupport: config.SimSupportType{
-			EP: config.Endpoint{
-				Hostname: "localhost",
-				Port:     8083,
-			},
-			StepperPolicy: "manual",
-		},
-		WebServer: config.WebServerType{
-			RootFilePath:          "C:\\CloudChamber",
-			SystemAccount:         adminAccountName,
-			SystemAccountPassword: adminPassword,
-			FE: config.Endpoint{
-				Hostname: "localhost",
-				Port:     8080,
-			},
-			BE: config.Endpoint{},
-		},
-		Store: config.StoreType{
-			ConnectTimeout: config.StoreDefaultConnectTimeout,
-			RequestTimeout: config.StoreDefaultRequestTimeout,
-			TraceLevel:     config.StoreDefaultTraceLevel,
-			EtcdService: config.Endpoint{
-				Hostname: config.StoreDefaultEtcdSvcHostname,
-				Port:     config.StoreDefaultEtcdSvcPort,
-			},
-			Test: config.StoreTypeTest{
-				UseTestNamespace:  true,
-				UseUniqueInstance: false,
-				PreCleanStore:     true,
-			},
-		},
-	}); err != nil {
+	configPath := flag.String("config", ".", "path to the configuration file")
+	flag.Parse()
+
+	cfg, err := config.ReadGlobalConfig(*configPath)
+	if err != nil {
+		log.Fatalf("failed to process the global configuration: %v", err)
+	}
+
+	if err = initService(cfg); err != nil {
 		log.Fatalf("Error initializing service: %v", err)
 	}
 

--- a/internal/services/frontend/stepper_test.go
+++ b/internal/services/frontend/stepper_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	ts "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
+	"github.com/Jim3Things/CloudChamber/internal/common/channels"
 	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters/unit_test"
 	pb "github.com/Jim3Things/CloudChamber/pkg/protos/Stepper"
 	"github.com/Jim3Things/CloudChamber/pkg/protos/common"
@@ -292,7 +293,6 @@ func TestStepperSetManualBadRate(t *testing.T) {
 }
 
 func TestStepperAfter(t *testing.T) {
-	var afterHit = false
 	var cookies2 []*http.Cookie
 
 	unit_test.SetTesting(t)
@@ -305,16 +305,18 @@ func TestStepperAfter(t *testing.T) {
 
 	res, cookies := testStepperGetNow(t, cookies)
 
-	go func(after int64, cookies []*http.Cookie) {
+	ch := make(chan bool)
+
+	go func(ch chan<- bool, after int64, cookies []*http.Cookie) {
 		res, cookies2 = testStepperAfter(t, after, cookies)
 
 		assert.Less(t, after, res.Ticks)
-		afterHit = true
-	}(res.Ticks, cookies)
+		ch <- true
+	}(ch, res.Ticks, cookies)
 
 	_, _ = testStepperAdvance(t, cookies)
-	time.Sleep(time.Duration(2) * time.Second)
-	assert.True(t, afterHit)
+
+	assert.True(t, channels.CompleteWithin(ch, time.Duration(2) * time.Second))
 
 	doLogout(t, randomCase(adminAccountName), cookies2)
 }

--- a/internal/services/stepper_actor/stepper_test.go
+++ b/internal/services/stepper_actor/stepper_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/Jim3Things/CloudChamber/internal/common/channels"
 	clienttrace "github.com/Jim3Things/CloudChamber/internal/tracing/client"
 	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters"
 	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters/unit_test"
@@ -48,22 +49,6 @@ func init() {
 
 func bufDialer(_ context.Context, _ string) (net.Conn, error) {
 	return lis.Dial()
-}
-
-func checkForEarlyCompletion(t *testing.T, ch <-chan bool, delay int, name string) {
-	select {
-	case <-ch:
-		assert.Failf(t, "%s completed early", name)
-	case <-time.After(time.Duration(delay) * time.Second):
-	}
-}
-
-func checkForLateCompletion(t *testing.T, ch <-chan bool, delay int, name string) {
-	select {
-	case <-ch:
-	case <-time.After(time.Duration(delay) * time.Second):
-		assert.Failf(t, "%s did not complete on time", name)
-	}
 }
 
 func callNow(t *testing.T, ctx context.Context) int64 {
@@ -331,14 +316,15 @@ func TestStepper_Manual(t *testing.T) {
 		res <- true
 	}(ch)
 
-	checkForEarlyCompletion(t, ch, 1, "Delay")
+	assert.True(t, channels.DoNotCompleteWithin(ch, time.Duration(1) * time.Second))
 	testGetStatus(t, ctx, 1, pb.StepperPolicy_Manual, &duration.Duration{Seconds: 0}, 1)
 
 	callStep(t, ctx, 2)
-	checkForEarlyCompletion(t, ch, 1, "Delay")
+	assert.True(t, channels.DoNotCompleteWithin(ch, time.Duration(1) * time.Second))
 
 	callStep(t, ctx, 3)
-	checkForLateCompletion(t, ch, 1, "Delay")
+	assert.True(t, channels.CompleteWithin(ch, time.Duration(1) * time.Second))
+
 	testGetStatus(t, ctx, 3, pb.StepperPolicy_Manual, &duration.Duration{Seconds: 0}, 0)
 
 	t.Log("DelayManual subtest complete")


### PR DESCRIPTION
- Use a test yaml file for frontend tests, rather than hand-crafted struct
- Use channel timeouts for test delays, put into common package
- Move setting the return cookies on stepper wait-for until after the wait completes
- Add sink tests to makefile test target