### PR TITLE
Scaffolding for the trace function trees

### DIFF
--- a/cmd/controllerd/main.go
+++ b/cmd/controllerd/main.go
@@ -45,7 +45,7 @@ func main() {
 	}
 
 	if *showConfig {
-		fmt.Println(config.ToString(cfg))
+		fmt.Println(cfg)
 		os.Exit(0)
 	}
 

--- a/cmd/inventoryd/main.go
+++ b/cmd/inventoryd/main.go
@@ -41,7 +41,7 @@ func main() {
 	}
 
 	if *showConfig {
-		fmt.Println(config.ToString(cfg))
+		fmt.Println(cfg)
 		os.Exit(0)
 	}
 

--- a/cmd/sim_supportd/main.go
+++ b/cmd/sim_supportd/main.go
@@ -39,7 +39,7 @@ func main() {
 	}
 
 	if *showConfig {
-		fmt.Println(config.ToString(cfg))
+		fmt.Println(cfg)
 		os.Exit(0)
 	}
 

--- a/cmd/web_server/main.go
+++ b/cmd/web_server/main.go
@@ -42,7 +42,7 @@ func main() {
 	}
 
 	if *showConfig {
-		fmt.Println(config.ToString(cfg))
+		fmt.Println(cfg)
 		os.Exit(0)
 	}
 

--- a/internal/common/Tick.go
+++ b/internal/common/Tick.go
@@ -1,13 +1,15 @@
 package common
 
 import (
+	"context"
+
 	"github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
 )
 
 // Tick provides the current simulated time Tick, or '-1' if the simulated time
 // cannot be retrieved (e.g. during startup)
-func Tick() int64 {
-	now, err := clients.Now()
+func Tick(ctx context.Context) int64 {
+	now, err := clients.Now(ctx)
 	if err != nil {
 		return -1
 	}

--- a/internal/services/frontend/inventory.go
+++ b/internal/services/frontend/inventory.go
@@ -64,7 +64,7 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 
 		st.Infof(
 			ctx,
-			common.Tick(),
+			common.Tick(ctx),
 			"Listing all %d racks, max blades/rack=%d, max blade capacity=%v",
 			len(res.Racks),
 			res.MaxBladeCount,
@@ -80,7 +80,7 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 
 			res.Racks[name] = &pb.ExternalRackSummary{Uri: target}
 
-			st.Infof(ctx, common.Tick(), "   Listing rack %q at %q", name, target)
+			st.Infof(ctx, common.Tick(ctx), "   Listing rack %q at %q", name, target)
 
 			return nil
 		})
@@ -112,7 +112,7 @@ func handlerRackRead(w http.ResponseWriter, r *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 
-		st.Infof(ctx, common.Tick(), "Returning details for rack %q: %v", rackID, u)
+		st.Infof(ctx, common.Tick(ctx), "Returning details for rack %q: %v", rackID, u)
 
 		// Get the user entry, and serialize it to json
 		// (export userPublic to json and return that as the body)
@@ -143,7 +143,7 @@ func handlerBladesList(w http.ResponseWriter, r *http.Request) {
 		return dbInventory.ScanBladesInRack(rackID, func(bladeID int64) error {
 
 			target := fmt.Sprintf("%s%d", b, bladeID)
-			st.Infof(ctx, common.Tick(), " Listing blades '%d' at %q", bladeID, target)
+			st.Infof(ctx, common.Tick(ctx), " Listing blades '%d' at %q", bladeID, target)
 
 			if _, err = fmt.Fprintln(w, target); err != nil {
 				return httpError(ctx, w, err)
@@ -179,7 +179,7 @@ func handlerBladeRead(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return httpError(ctx, w, err)
 		}
-		st.Infof(ctx, common.Tick(), "Returning details for blade %d  in rack %q:  %v", bladeID, rackID, blade)
+		st.Infof(ctx, common.Tick(ctx), "Returning details for blade %d  in rack %q:  %v", bladeID, rackID, blade)
 
 		p := jsonpb.Marshaler{}
 		return p.Marshal(w, blade)

--- a/internal/services/frontend/logs.go
+++ b/internal/services/frontend/logs.go
@@ -48,7 +48,7 @@ func handlerLogsGetAfter(w http.ResponseWriter, r *http.Request) {
 			return httpError(ctx, w, err)
 		}
 
-		ch := tsc.GetTraces(fromId, maxSize)
+		ch := tsc.GetTraces(ctx, fromId, maxSize)
 
 		data := <-ch
 		if data.Err != nil {
@@ -77,7 +77,7 @@ func handlerLogsGetPolicy(w http.ResponseWriter, r *http.Request) {
 			return httpError(ctx, w, err)
 		}
 
-		policy, err := tsc.GetPolicy()
+		policy, err := tsc.GetPolicy(ctx)
 		if err != nil {
 			return httpError(ctx, w, err)
 		}

--- a/internal/services/frontend/logs_test.go
+++ b/internal/services/frontend/logs_test.go
@@ -1,6 +1,7 @@
 package frontend
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -42,25 +43,25 @@ func testLogsGetAfter(
 	start int64,
 	maxCount int64,
 	cookies []*http.Cookie) (*pb.GetAfterResponse, []*http.Cookie) {
-		path := fmt.Sprintf("%s?from=%d&for=%d", testLogsPath(), start, maxCount)
-		request := httptest.NewRequest("GET", path, nil)
-		response := doHTTP(request, cookies)
+	path := fmt.Sprintf("%s?from=%d&for=%d", testLogsPath(), start, maxCount)
+	request := httptest.NewRequest("GET", path, nil)
+	response := doHTTP(request, cookies)
 
-		assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
 
-		res := &pb.GetAfterResponse{}
-		err := getJSONBody(response, res)
+	res := &pb.GetAfterResponse{}
+	err := getJSONBody(response, res)
 
-		assert.Nilf(t, err, "Unexpected error, err: %v", err)
+	assert.Nilf(t, err, "Unexpected error, err: %v", err)
 
-		return res, response.Cookies()
+	return res, response.Cookies()
 }
 
 func TestLogsGetPolicy(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
 
-	err := tsc.Reset()
+	err := tsc.Reset(context.Background())
 	require.Nil(t, err)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
@@ -76,7 +77,7 @@ func TestLogsGetPolicyNoSession(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
 
-	err := tsc.Reset()
+	err := tsc.Reset(context.Background())
 	require.Nil(t, err)
 
 	request := httptest.NewRequest("GET", fmt.Sprintf("%s%s", testLogsPath(), "/policy"), nil)
@@ -90,7 +91,7 @@ func TestLogsGetAfterNoSession(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
 
-	err := tsc.Reset()
+	err := tsc.Reset(context.Background())
 	require.Nil(t, err)
 
 	path := fmt.Sprintf("%s?from=0&for=100", testLogsPath())
@@ -105,7 +106,7 @@ func TestLogsGetAfterBadStart(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
 
-	err := tsc.Reset()
+	err := tsc.Reset(context.Background())
 	require.Nil(t, err)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
@@ -123,7 +124,7 @@ func TestLogsGetAfterBadCount(t *testing.T) {
 	unit_test.SetTesting(t)
 	defer unit_test.SetTesting(nil)
 
-	err := tsc.Reset()
+	err := tsc.Reset(context.Background())
 	require.Nil(t, err)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
@@ -144,12 +145,12 @@ func TestLogsGetAfter(t *testing.T) {
 	defer unit_test.SetTesting(nil)
 
 	entry := &log.Entry{
-		Name:           "test",
-		SpanID:         "0000",
-		ParentID:       "1111",
-		Status:         "ok",
-		StackTrace:     "yyyy",
-		Event:          []*log.Event {
+		Name:       "test",
+		SpanID:     "0000",
+		ParentID:   "1111",
+		Status:     "ok",
+		StackTrace: "yyyy",
+		Event: []*log.Event{
 			{
 				Tick:       0,
 				Severity:   1,
@@ -162,7 +163,7 @@ func TestLogsGetAfter(t *testing.T) {
 		Infrastructure: false,
 	}
 
-	err := tsc.Reset()
+	err := tsc.Reset(context.Background())
 	require.Nil(t, err)
 
 	response := doLogin(t, randomCase(adminAccountName), adminPassword, nil)
@@ -201,12 +202,12 @@ func TestLogsGetAfter(t *testing.T) {
 		ch <- true
 	}(ch, response.Cookies())
 
-	assert.True(t, channels.DoNotCompleteWithin(ch, time.Duration(100) * time.Millisecond))
+	assert.True(t, channels.DoNotCompleteWithin(ch, time.Duration(100)*time.Millisecond))
 
-	err = tsc.Append(entry)
+	err = tsc.Append(context.Background(), entry)
 	require.Nil(t, err)
 
-	assert.True(t, channels.CompleteWithin(ch, time.Duration(1) * time.Second))
+	assert.True(t, channels.CompleteWithin(ch, time.Duration(1)*time.Second))
 
 	doLogout(t, randomCase(adminAccountName), cookies2)
 }

--- a/internal/services/frontend/stepper.go
+++ b/internal/services/frontend/stepper.go
@@ -46,7 +46,7 @@ func handleGetStatus(w http.ResponseWriter, r *http.Request) {
 			return httpError(ctx, w, err)
 		}
 
-		stat, err := clients.Status()
+		stat, err := clients.Status(ctx)
 		if err != nil {
 			return httpError(ctx, w, err)
 		}
@@ -86,13 +86,13 @@ func handleAdvance(w http.ResponseWriter, r *http.Request) {
 
 		// Advance the time the request number of ticks
 		for i := 0; i < count; i++ {
-			if err = clients.Advance(); err != nil {
+			if err = clients.Advance(ctx); err != nil {
 				return httpError(ctx, w, err)
 			}
 		}
 
 		// .. and get the current time to return in the body of the response
-		now, err := clients.Now()
+		now, err := clients.Now(ctx)
 		if err != nil {
 			return httpError(ctx, w, err)
 		}
@@ -158,7 +158,7 @@ func handleSetMode(w http.ResponseWriter, r *http.Request) {
 			return httpError(ctx, w, NewErrInvalidStepperMode(args[0]))
 		}
 
-		if err = clients.SetPolicy(policy, delay, match); err != nil {
+		if err = clients.SetPolicy(ctx, policy, delay, match); err != nil {
 			return httpError(ctx, w, NewErrStepperFailedToSetPolicy())
 		}
 
@@ -188,7 +188,7 @@ func handleWaitFor(w http.ResponseWriter, r *http.Request) {
 				return err
 			}
 
-			data = <-clients.After(&ct.Timestamp{Ticks: afterTick + 1})
+			data = <-clients.After(ctx, &ct.Timestamp{Ticks: afterTick + 1})
 			if data.Err != nil {
 				return data.Err
 			}
@@ -216,7 +216,7 @@ func handleGetNow(w http.ResponseWriter, r *http.Request) {
 			return httpError(ctx, w, err)
 		}
 
-		now, err := clients.Now()
+		now, err := clients.Now(ctx)
 		if err != nil {
 			return httpError(ctx, w, err)
 		}

--- a/internal/services/frontend/stepper_test.go
+++ b/internal/services/frontend/stepper_test.go
@@ -1,6 +1,7 @@
 package frontend
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -12,8 +13,8 @@ import (
 	ts "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
 	"github.com/Jim3Things/CloudChamber/internal/common/channels"
 	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters/unit_test"
-	pb "github.com/Jim3Things/CloudChamber/pkg/protos/services"
 	"github.com/Jim3Things/CloudChamber/pkg/protos/common"
+	pb "github.com/Jim3Things/CloudChamber/pkg/protos/services"
 )
 
 const (
@@ -23,7 +24,7 @@ const (
 func testStepperPath() string { return baseURI + stepperURI }
 
 func testStepperReset(t *testing.T) {
-	err := ts.Reset()
+	err := ts.Reset(context.Background())
 	assert.Nilf(t, err, "Unexpected error when resetting the stepper service)")
 }
 
@@ -34,7 +35,7 @@ func testStepperSetManual(t *testing.T, match int64, cookies []*http.Cookie) []*
 	response := doHTTP(request, cookies)
 
 	assert.Equal(t, http.StatusOK, response.StatusCode)
-	assert.Equal(t, fmt.Sprintf("%v", match + 1), response.Header.Get("ETag"))
+	assert.Equal(t, fmt.Sprintf("%v", match+1), response.Header.Get("ETag"))
 
 	return response.Cookies()
 }
@@ -122,7 +123,7 @@ func TestStepperSetManual(t *testing.T) {
 	assert.Equal(t, int32(0), res.MeasuredDelay.Nanos, "Unexpected delay")
 	assert.Equal(t, int64(0), res.Now.Ticks, "Unexpected current time")
 	assert.Equal(t, int64(0), res.WaiterCount, "Unexpected active waiter count")
-	assert.Equal(t, stat.Epoch + 1, res.Epoch, "Unexpected epoch value")
+	assert.Equal(t, stat.Epoch+1, res.Epoch, "Unexpected epoch value")
 
 	doLogout(t, randomCase(adminAccountName), cookies)
 }
@@ -146,7 +147,10 @@ func TestStepperSetModeInvalid(t *testing.T) {
 
 	body, err := getBody(response)
 	assert.Nil(t, err)
-	assert.Equal(t, "CloudChamber: mode \"badChoice\" is invalid.  Supported modes are 'manual' and 'automatic'\n", string(body))
+	assert.Equal(
+		t,
+		"CloudChamber: mode \"badChoice\" is invalid.  Supported modes are 'manual' and 'automatic'\n",
+		string(body))
 
 	res, cookies = testStepperGetStatus(t, response.Cookies())
 	assert.Equal(t, pb.StepperPolicy_Manual, res.Policy, "Unexpected policy")
@@ -185,7 +189,7 @@ func TestStepperSetModeBadEpoch(t *testing.T) {
 	assert.Equal(t, int32(0), res.MeasuredDelay.Nanos, "Unexpected delay")
 	assert.Equal(t, int64(0), res.Now.Ticks, "Unexpected current time")
 	assert.Equal(t, int64(0), res.WaiterCount, "Unexpected active waiter count")
-	assert.Equal(t, stat.Epoch + 1, res.Epoch, "Unexpected epoch")
+	assert.Equal(t, stat.Epoch+1, res.Epoch, "Unexpected epoch")
 
 	doLogout(t, randomCase(adminAccountName), cookies)
 }
@@ -205,7 +209,11 @@ func TestStepperAdvanceOne(t *testing.T) {
 
 	res2, cookies := testStepperAdvance(t, cookies)
 
-	assert.Equal(t, int64(1), res2.Ticks-res.Ticks, "time expected to advance by 1, old: %d, new: %d", res.Ticks, res2.Ticks)
+	assert.Equal(
+		t,
+		int64(1), res2.Ticks-res.Ticks,
+		"time expected to advance by 1, old: %d, new: %d",
+		res.Ticks, res2.Ticks)
 
 	doLogout(t, randomCase(adminAccountName), cookies)
 }
@@ -230,7 +238,11 @@ func TestStepperAdvanceTwo(t *testing.T) {
 
 	assert.Nilf(t, err, "Unexpected error, err: %v", err)
 
-	assert.Equal(t, int64(2), res2.Ticks-res.Ticks, "time expected to advance by 1, old: %d, new: %d", res.Ticks, res2.Ticks)
+	assert.Equal(
+		t,
+		int64(2), res2.Ticks-res.Ticks,
+		"time expected to advance by 2, old: %d, new: %d",
+		res.Ticks, res2.Ticks)
 
 	doLogout(t, randomCase(adminAccountName), response.Cookies())
 }
@@ -251,7 +263,10 @@ func TestStepperAdvanceNotANumber(t *testing.T) {
 	body, err := getBody(response)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "CloudChamber: requested rate \"two\" could not be parsed as a positive decimal number\n", string(body))
+	assert.Equal(
+		t,
+		"CloudChamber: requested rate \"two\" could not be parsed as a positive decimal number\n",
+		string(body))
 
 	doLogout(t, randomCase(adminAccountName), response.Cookies())
 }
@@ -316,7 +331,7 @@ func TestStepperAfter(t *testing.T) {
 
 	_, _ = testStepperAdvance(t, cookies)
 
-	assert.True(t, channels.CompleteWithin(ch, time.Duration(2) * time.Second))
+	assert.True(t, channels.CompleteWithin(ch, time.Duration(2)*time.Second))
 
 	doLogout(t, randomCase(adminAccountName), cookies2)
 }

--- a/internal/services/tracing_sink/sink.go
+++ b/internal/services/tracing_sink/sink.go
@@ -24,7 +24,7 @@ type server struct {
 	pb.UnimplementedTraceSinkServer
 
 	// mutex protects access to the rest of the state
-	mutex   sync.Mutex
+	mutex sync.Mutex
 
 	// entries is the set of known trace entries, ordered by arrival
 	entries *list.List
@@ -37,10 +37,10 @@ type server struct {
 	// maxHeld contains the maximum number of trace entries that are kept.  As
 	// more arrive, the oldest ones are removed in order stay within this
 	// limit.
-	maxHeld           int
+	maxHeld int
 
 	// nextId is the trace entry id that will be used on the next Append call
-	nextId            int
+	nextId int
 
 	// nextNonInternalId is the trace entry id that immediately follows the
 	// last trace entry that was not marked internal.
@@ -160,10 +160,10 @@ func (s *server) GetAfter(ctx context.Context, request *pb.GetAfterRequest) (*pb
 	})
 
 	if err != nil {
-		st.Infof(ctx, common.Tick(), "GetAfter failed with err=%v", err)
+		st.Infof(ctx, common.Tick(ctx), "GetAfter failed with err=%v", err)
 	} else {
 		st.Infof(
-			ctx, common.Tick(),
+			ctx, common.Tick(ctx),
 			"GetAfter returning; %d entries, missed=%v, lastID=%d",
 			len(resp.res.Entries), resp.res.Missed, resp.res.LastId)
 	}
@@ -186,7 +186,7 @@ func (s *server) GetPolicy(ctx context.Context, _ *pb.GetPolicyRequest) (*pb.Get
 		}
 
 		st.Infof(
-			ctx, common.Tick(),
+			ctx, common.Tick(ctx),
 			"GetPolicy returning; firstId=%d, maxEntriesHeld=%d",
 			resp.FirstId, resp.MaxEntriesHeld)
 
@@ -198,7 +198,7 @@ func (s *server) GetPolicy(ctx context.Context, _ *pb.GetPolicyRequest) (*pb.Get
 
 // Reset is a test support function that forcibly resets the instance's state
 // to its initial values.
-func (s *server) Reset(_ context.Context, _ *pb.ResetRequest) (*empty.Empty, error)  {
+func (s *server) Reset(_ context.Context, _ *pb.ResetRequest) (*empty.Empty, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/internal/tracing/client/tracing.go
+++ b/internal/tracing/client/tracing.go
@@ -4,12 +4,15 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/api/global"
+	"go.opentelemetry.io/otel/api/kv"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/instrumentation/grpctrace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+
+	"github.com/Jim3Things/CloudChamber/internal/tracing"
 )
 
 // Interceptor is a function that traces the client side activity for a grpc
@@ -39,16 +42,16 @@ func InfraInterceptor(
 	cc *grpc.ClientConn,
 	invoker grpc.UnaryInvoker,
 	opts ...grpc.CallOption) error {
-		return commonInterceptor(
-			ctx, method, req, reply, cc, invoker,
-			trace.SpanKindInternal,
-			opts...)
+	return commonInterceptor(
+		ctx, method, req, reply, cc, invoker,
+		trace.SpanKindInternal,
+		opts...)
 }
 
 // commonInterceptor performs the logic to encase the grpc call itself in a
 // trace span, and to record the final status.
 func commonInterceptor(
-	ctx context.Context,
+	ctxIn context.Context,
 	method string,
 	req,
 	reply interface{},
@@ -56,13 +59,25 @@ func commonInterceptor(
 	invoker grpc.UnaryInvoker,
 	kind trace.SpanKind,
 	opts ...grpc.CallOption) error {
-	requestMetadata, _ := metadata.FromOutgoingContext(ctx)
+	requestMetadata, _ := metadata.FromOutgoingContext(ctxIn)
 	metadataCopy := requestMetadata.Copy()
+
+	parent := trace.SpanFromContext(ctxIn)
 
 	tr := global.TraceProvider().Tracer("client")
 
-	ctx, span := tr.Start(ctx, method, trace.WithSpanKind(kind))
+	ctx, span := tr.Start(ctxIn, method,
+		trace.WithSpanKind(kind),
+		trace.WithAttributes(kv.String(tracing.StackTraceKey, tracing.StackTrace())))
 	defer span.End()
+
+	if parent.SpanContext().HasSpanID() {
+		parent.AddEvent(
+			ctx,
+			tracing.MethodName(2),
+			kv.String(tracing.StackTraceKey, tracing.StackTrace()),
+			kv.String(tracing.ChildSpanKey, span.SpanContext().SpanID.String()))
+	}
 
 	grpctrace.Inject(ctx, &metadataCopy)
 	ctx = metadata.NewOutgoingContext(ctx, metadataCopy)

--- a/internal/tracing/constants.go
+++ b/internal/tracing/constants.go
@@ -1,14 +1,15 @@
 package tracing
 
 const (
-	StepperTicksKey   = "cc-stepper-ticks"
-	Reason            = "cc-reason"
-	MessageTextKey    = "cc-message-text"
-	StackTraceKey     = "cc-stack-trace"
-	SeverityKey       = "cc-severity"
+	StepperTicksKey = "cc-stepper-ticks"
+	Reason          = "cc-reason"
+	MessageTextKey  = "cc-message-text"
+	StackTraceKey   = "cc-stack-trace"
+	SeverityKey     = "cc-severity"
+	ChildSpanKey    = "cc-child-span"
 
 	// Envelope keys
-	SourceTraceID     = "cc-starting-span-trace-id"
-	SourceSpanID      = "cc-starting-span-span-id"
-	SourceTraceFlgs   = "cc-starting-span-trace-flags"
+	SourceTraceID   = "cc-starting-span-trace-id"
+	SourceSpanID    = "cc-starting-span-span-id"
+	SourceTraceFlgs = "cc-starting-span-trace-flags"
 )

--- a/internal/tracing/exporters/io_writer/exporter.go
+++ b/internal/tracing/exporters/io_writer/exporter.go
@@ -110,10 +110,10 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *export.SpanData) {
 }
 
 func processOneEntry(entry *log.Entry, deferred bool) error {
-	_, _ = outputWriter.Write([]byte(fmt.Sprintf("%s\n\n", common.FormatEntry(entry, deferred))))
+	_, _ = outputWriter.Write([]byte(fmt.Sprintf("\n%s\n", common.FormatEntry(entry, deferred))))
 
 	for _, event := range entry.Event {
-		_, _ = outputWriter.Write([]byte(fmt.Sprintf("%s\n\n", common.FormatEvent(event))))
+		_, _ = outputWriter.Write([]byte(fmt.Sprintf("%s    \n", common.FormatEvent(event, "    "))))
 	}
 
 	return nil

--- a/internal/tracing/exporters/unit_test/exporter.go
+++ b/internal/tracing/exporters/unit_test/exporter.go
@@ -78,6 +78,6 @@ func processOneEntry(entry *log.Entry, deferred bool) {
 	testContext.Log(common.FormatEntry(entry, deferred))
 
 	for _, event := range entry.Event {
-		testContext.Log(common.FormatEvent(event))
+		testContext.Log(common.FormatEvent(event, ""))
 	}
 }

--- a/pkg/protos/log/entry.proto
+++ b/pkg/protos/log/entry.proto
@@ -67,6 +67,12 @@ message event {
 
     // The set of modules impacted, and the type of impact.
     repeated module impacted = 6;
+
+    // True, if this event denotes a start child span
+    bool span_start = 7;
+
+    // Child's span ID.  Ignored if span_start is false.
+    string span_id = 8;
 }
 
 // Describe a full correlated span, consisting of zero or more events.
@@ -77,16 +83,17 @@ message entry {
     // The IDs for the span, and its parent
     string spanID = 2;
     string parentID = 3;
+    string traceID = 4;
 
     // Final status of the span
-    string status = 4;
+    string status = 5;
 
     // Formatted stack trace
-    string stack_trace = 5;
+    string stack_trace = 6;
 
     // The set of events emitted by this span
-    repeated event event = 6;
+    repeated event event = 7;
 
     // True, if this span represents internal-only operations.
-    bool infrastructure = 7;
+    bool infrastructure = 8;
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,10 +9,7 @@ import (
 	"os"
 	"time"
 
-	"go.opentelemetry.io/otel/api/global"
-	"go.opentelemetry.io/otel/api/trace"
-
-	"github.com/Jim3Things/CloudChamber/internal/tracing"
+	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 )
 
 //go:generate go run generator/generate.go
@@ -50,19 +47,15 @@ func Show() {
 // startup of the service, and the version information associated with it.
 //
 func Trace() {
-	tr := global.TraceProvider().Tracer("")
-
-	_ = tr.WithSpan(context.Background(), tracing.MethodName(1), func(ctx context.Context) (err error) {
-		span := trace.SpanFromContext(ctx)
-
-		span.AddEvent(
+	_ = st.WithSpan(context.Background(), func(ctx context.Context) (err error) {
+		st.Infof(
 			ctx,
-			fmt.Sprintf(
-				"===== Starting %q at %s =====",
-				fmt.Sprint(os.Args),
-				time.Now().Format(time.RFC1123Z)))
+			-1,
+			"===== Starting %q at %s =====",
+			fmt.Sprint(os.Args),
+			time.Now().Format(time.RFC1123Z))
 
-		span.AddEvent(ctx, toString())
+		st.Info(ctx, -1, toString())
 		return nil
 	})
 }


### PR DESCRIPTION
- Add start span tracking
- Connect up the client parent/child span ID tracking
- (this includes adding the current context as an argument to client libraries)
- Move all tracing to go through our wrappers