### PR TITLE
Functional trace ID grouping in io_writer exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,7 @@ run_tests: $(PROTO_GEN_FILES) $(VERSION_MARKER)
 	go test $(PROJECT)/internal/services/stepper_actor
 	go test $(PROJECT)/internal/services/tracing_sink
 	go test $(PROJECT)/internal/tracing/exporters/common
+	go test $(PROJECT)/internal/tracing/exporters/io_writer
 
 
 .PHONY : clean

--- a/cmd/sim_supportd/main.go
+++ b/cmd/sim_supportd/main.go
@@ -29,7 +29,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	setup.Init(exporters.IoWriter, exporters.Production)
+	setup.Init(exporters.IoWriter)
 
 	version.Trace()
 

--- a/internal/services/frontend/DBInventory.go
+++ b/internal/services/frontend/DBInventory.go
@@ -167,11 +167,11 @@ func InitDBInventory() error {
 
 // GetMemoData returns the maximum number of blades held in any rack
 // in the inventory.
-func (m *DBInventory) GetMemoData() (int64, *common.BladeCapacity) {
+func (m *DBInventory) GetMemoData() (int, int64, *common.BladeCapacity) {
 	m.Mutex.Lock()
 	defer m.Mutex.Unlock()
 
-	return m.MaxBladeCount, m.MaxCapacity
+	return len(m.Zone.Racks), m.MaxBladeCount, m.MaxCapacity
 }
 
 // Scan the set of known blades the store, invoking the supplied

--- a/internal/services/frontend/inventory.go
+++ b/internal/services/frontend/inventory.go
@@ -55,18 +55,21 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 
-		maxBlades, maxCapacity := dbInventory.GetMemoData()
+		rackCount, maxBlades, maxCapacity := dbInventory.GetMemoData()
 		res := &pb.ExternalZoneSummary{
 			Racks:         make(map[string]*pb.ExternalRackSummary),
 			MaxBladeCount: maxBlades,
 			MaxCapacity:   maxCapacity,
 		}
 
+		// Pick up the current time to avoid repeatedly fetching the same value
+		tick := common.Tick(ctx)
+
 		st.Infof(
 			ctx,
-			common.Tick(ctx),
+			tick,
 			"Listing all %d racks, max blades/rack=%d, max blade capacity=%v",
-			len(res.Racks),
+			rackCount,
 			res.MaxBladeCount,
 			res.MaxCapacity)
 
@@ -80,7 +83,7 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 
 			res.Racks[name] = &pb.ExternalRackSummary{Uri: target}
 
-			st.Infof(ctx, common.Tick(ctx), "   Listing rack %q at %q", name, target)
+			st.Infof(ctx, tick, "   Listing rack %q at %q", name, target)
 
 			return nil
 		})
@@ -133,21 +136,27 @@ func handlerBladesList(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		rackID := vars["rackID"] // captured the key value in rackID variable
 
+		// Pick up the current time to avoid repeatedly fetching the same value
+		tick := common.Tick(ctx)
+
 		if _, err = fmt.Fprintf(w, "Blades in %q (List)\n", rackID); err != nil {
 			return httpError(ctx, w, err)
 		}
+
 		b := r.URL.String()
 		if !strings.HasSuffix(b, "/") {
 			b += "/"
 		}
+
 		return dbInventory.ScanBladesInRack(rackID, func(bladeID int64) error {
 
 			target := fmt.Sprintf("%s%d", b, bladeID)
-			st.Infof(ctx, common.Tick(ctx), " Listing blades '%d' at %q", bladeID, target)
+			st.Infof(ctx, tick, " Listing blades '%d' at %q", bladeID, target)
 
 			if _, err = fmt.Fprintln(w, target); err != nil {
 				return httpError(ctx, w, err)
 			}
+
 			return nil
 		})
 	})
@@ -179,6 +188,7 @@ func handlerBladeRead(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return httpError(ctx, w, err)
 		}
+
 		st.Infof(ctx, common.Tick(ctx), "Returning details for blade %d  in rack %q:  %v", bladeID, rackID, blade)
 
 		p := jsonpb.Marshaler{}

--- a/internal/services/frontend/inventory.go
+++ b/internal/services/frontend/inventory.go
@@ -57,7 +57,7 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 
 		rackCount, maxBlades, maxCapacity := dbInventory.GetMemoData()
 		res := &pb.ExternalZoneSummary{
-			Racks:         make(map[string]*pb.ExternalRackSummary),
+			Racks:         make(map[string]*pb.ExternalRackSummary, rackCount),
 			MaxBladeCount: maxBlades,
 			MaxCapacity:   maxCapacity,
 		}

--- a/internal/services/frontend/users.go
+++ b/internal/services/frontend/users.go
@@ -85,6 +85,9 @@ func handlerUsersList(w http.ResponseWriter, r *http.Request) {
 			return httpError(ctx, w, err)
 		}
 
+		// Pick up the current time to avoid repeatedly fetching the same value
+		tick := common.Tick(ctx)
+
 		b := r.URL.String()
 		if !strings.HasSuffix(b, "/") {
 			b += "/"
@@ -101,7 +104,7 @@ func handlerUsersList(w http.ResponseWriter, r *http.Request) {
 				protected = " (protected)"
 			}
 
-			st.Infof(ctx, common.Tick(ctx), "   Listing user %q: %q%s", entry.Name, target, protected)
+			st.Infof(ctx, tick, "   Listing user %q: %q%s", entry.Name, target, protected)
 
 			users.Users = append(users.Users, &pb.UserListEntry{
 				Name:      entry.Name,

--- a/internal/tracing/exporters/io_writer/exporter.go
+++ b/internal/tracing/exporters/io_writer/exporter.go
@@ -3,7 +3,6 @@ package io_writer
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"sync"
 
@@ -53,6 +52,8 @@ var (
 	// queue holds the trace entries that have arrived prior to establishing
 	// the IO writer to use.
 	queue = common.NewDeferrable(0)
+
+	spanSet = newSpans()
 )
 
 // SetLogFileWriter establishes the IO writer to use to output the trace entries.
@@ -109,12 +110,8 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *export.SpanData) {
 	}
 }
 
-func processOneEntry(entry *log.Entry, deferred bool) error {
-	_, _ = outputWriter.Write([]byte(fmt.Sprintf("\n%s\n", common.FormatEntry(entry, deferred))))
-
-	for _, event := range entry.Event {
-		_, _ = outputWriter.Write([]byte(fmt.Sprintf("%s    \n", common.FormatEvent(event, "    "))))
-	}
+func processOneEntry(entry *log.Entry, _ bool) error {
+	spanSet.add(entry, outputWriter)
 
 	return nil
 }

--- a/internal/tracing/exporters/io_writer/spans.go
+++ b/internal/tracing/exporters/io_writer/spans.go
@@ -1,0 +1,137 @@
+package io_writer
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"go.opentelemetry.io/otel/api/trace"
+
+	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters/common"
+	"github.com/Jim3Things/CloudChamber/pkg/protos/log"
+)
+
+const (
+	tab = "    "
+)
+
+type activeEntry struct {
+	root string
+	open map[string]bool
+	closed map[string]bool
+}
+
+type spans struct {
+	m sync.Mutex
+
+	// active is keyed by traceID, with values of the currently incomplete
+	// spanIDs for that trace.
+	active map[string]*activeEntry
+
+	// known is keyed by spanID, and contains the associated log entry, or nil
+	// if the entry is derived from the parent span ID for a span that has not
+	// yet emitted its state.
+	known map[string]*log.Entry
+}
+
+func newSpans() *spans {
+	return &spans{
+		m:      sync.Mutex{},
+		active: make(map[string]*activeEntry),
+		known:  make(map[string]*log.Entry),
+	}
+}
+
+func (s *spans) getOrAddActive(traceID string) *activeEntry {
+	entry, ok := s.active[traceID]
+	if ok {
+		return entry
+	}
+
+	// new entry
+	entry = &activeEntry{
+		root:   "",
+		open:   make(map[string]bool),
+		closed: make(map[string]bool),
+	}
+
+	s.active[traceID] = entry
+	return entry
+}
+
+func (s *spans) emit(a *activeEntry, spanID string, io io.Writer, indent string) {
+	entry, ok := s.known[spanID]
+	if !ok { panic(fmt.Sprintf("Missing span: %q", spanID))}
+
+	spanHeader := fmt.Sprintf("\n%s\n", common.FormatEntry(entry, false, indent))
+	_, _ = io.Write([]byte(spanHeader))
+	for _, e := range entry.Event {
+		if e.SpanStart {
+			s.emit(a, e.SpanId, io, indent + tab)
+			delete(s.known, e.SpanId)
+			delete(a.closed, e.SpanId)
+		} else {
+			_, _ = io.Write([]byte(common.FormatEvent(e, indent + tab)))
+		}
+	}
+}
+
+// add is the point where a log entry is added to the set of active spans.  If
+// it results in full closure of the parent span then that subtree is emitted
+// to the IO writer and discarded.
+func (s *spans) add(entry *log.Entry, io io.Writer) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	traceID := entry.TraceID
+	spanID := entry.SpanID
+	parentID := entry.ParentID
+
+	_, err := trace.SpanIDFromHex(parentID)
+	hasParent := err == nil
+
+	// First, let's record this span as a known span
+	s.known[spanID] = entry
+
+	// Then, let's see if we have an active trace.  Create one if not.
+	a := s.getOrAddActive(traceID)
+
+	// add this entry, if not already present to the active entry's open list
+	a.open[spanID] = true
+
+	if !hasParent {
+		a.root = spanID
+	} else {
+		// add this entry's parent to active, if not in the known list
+		if _, ok := s.known[parentID]; !ok {
+			a.open[parentID] = true
+		}
+	}
+
+	// go through the full set of entries.  For each span start:
+	// - add that child ID to the trace ID set, if not already known
+	for _, e := range entry.Event {
+		if e.SpanStart {
+			if _, ok := a.closed[e.SpanId]; !ok {
+				a.open[e.SpanId] = true
+			}
+		}
+	}
+
+	// move this span ID from the active entry's open list to the closed list.
+	delete(a.open, spanID)
+	a.closed[spanID] = true
+
+	if len(a.open) == 0 {
+		// if active entry's open list is now empty:
+		// - issue emit on it
+		// - remove the trace ID when emit returns
+		s.emit(a, a.root, io, "")
+		delete(s.known, a.root)
+		delete(a.closed, a.root)
+
+		// Ensure that the closed list is empty
+		if len(a.closed) != 0 { panic(fmt.Sprintf("Expected all closed, %v", a))}
+		delete(s.active, traceID)
+	}
+}

--- a/internal/tracing/exporters/io_writer/spans.go
+++ b/internal/tracing/exporters/io_writer/spans.go
@@ -162,7 +162,13 @@ func (s *spans) add(entry *log.Entry, io io.Writer) {
 
 		// Ensure that the closed list is empty
 		if len(a.closed) != 0 {
-			stdLog.Fatalf("Expected all closed, %v", a)
+			msg := fmt.Sprintf("Expected all closed, %v: ", a)
+			for id, _ := range a.closed {
+				sp, ok := s.known[id]
+				msg = fmt.Sprintf("%s (%v)%v ", msg, ok, sp)
+			}
+
+			stdLog.Fatal(msg)
 		}
 
 		delete(s.active, traceID)

--- a/internal/tracing/exporters/io_writer/spans.go
+++ b/internal/tracing/exporters/io_writer/spans.go
@@ -46,7 +46,7 @@ type activeEntry struct {
 	// yet completed an export operation.
 	open map[string]bool
 
-	// closed as the SpanIDs that have been found an have completed their
+	// closed are the SpanIDs that have been found an have completed their
 	// export operation
 	closed map[string]bool
 }

--- a/internal/tracing/exporters/io_writer/spans_test.go
+++ b/internal/tracing/exporters/io_writer/spans_test.go
@@ -1,0 +1,384 @@
+package io_writer
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Jim3Things/CloudChamber/pkg/protos/log"
+)
+
+func TestSingleRoot(t *testing.T) {
+	s := newSpans()
+
+	io := bytes.Buffer{}
+
+	entry := &log.Entry{
+		Name:           "root",
+		SpanID:         "0102030405060708",
+		ParentID:       "0000000000000000",
+		TraceID:        "11020304050607080102030405060708",
+		Status:         "ok",
+		StackTrace:     "stacks",
+		Event:          []*log.Event{
+			{
+				Tick:       0,
+				Severity:   0,
+				Name:       "test1",
+				Text:       "text1",
+				StackTrace: "stack1",
+				Impacted:   nil,
+				SpanStart:  false,
+				SpanId:     "",
+			},
+			{
+				Tick:       1,
+				Severity:   0,
+				Name:       "test2",
+				Text:       "text2",
+				StackTrace: "stack2",
+				Impacted:   nil,
+				SpanStart:  false,
+				SpanId:     "",
+			},
+		},
+		Infrastructure: false,
+	}
+
+	s.add(entry, &io)
+
+	assert.Equal(t,
+		"\n[0102030405060708:0000000000000000] ok root:\n"+
+		"    stacks\n\n"+
+		"      @   0: [D] (test1) text1\n"+
+		"        stack1\n" +
+		"      @   1: [D] (test2) text2\n" +
+		"        stack2\n", io.String())
+
+	assert.Equal(t, 0, len(s.known))
+	assert.Equal(t, 0, len(s.active))
+}
+
+func TestDoubleRoot(t *testing.T) {
+	s := newSpans()
+
+	io := bytes.Buffer{}
+
+	entry := &log.Entry{
+		Name:           "root",
+		SpanID:         "0102030405060708",
+		ParentID:       "0000000000000000",
+		TraceID:        "11020304050607080102030405060708",
+		Status:         "ok",
+		StackTrace:     "stacks",
+		Event:          []*log.Event{
+			{
+				Tick:       0,
+				Severity:   0,
+				Name:       "test1",
+				Text:       "text1",
+				StackTrace: "stack1",
+				Impacted:   nil,
+				SpanStart:  false,
+				SpanId:     "",
+			},
+			{
+				Tick:       1,
+				Severity:   0,
+				Name:       "test2",
+				Text:       "text2",
+				StackTrace: "stack2",
+				Impacted:   nil,
+				SpanStart:  false,
+				SpanId:     "",
+			},
+		},
+		Infrastructure: false,
+	}
+
+	entry2 := &log.Entry{
+		Name:           "root",
+		SpanID:         "1102030405060708",
+		ParentID:       "0000000000000000",
+		TraceID:        "11020304050607080102030405060708",
+		Status:         "ok",
+		StackTrace:     "stacks",
+		Event:          []*log.Event{
+			{
+				Tick:       2,
+				Severity:   0,
+				Name:       "test3",
+				Text:       "text3",
+				StackTrace: "stack3",
+				Impacted:   nil,
+				SpanStart:  false,
+				SpanId:     "",
+			},
+			{
+				Tick:       3,
+				Severity:   0,
+				Name:       "test4",
+				Text:       "text4",
+				StackTrace: "stack4",
+				Impacted:   nil,
+				SpanStart:  false,
+				SpanId:     "",
+			},
+		},
+		Infrastructure: false,
+	}
+
+	s.add(entry, &io)
+
+	assert.Equal(t,
+		"\n[0102030405060708:0000000000000000] ok root:\n"+
+		"    stacks\n\n"+
+		"      @   0: [D] (test1) text1\n"+
+		"        stack1\n" +
+		"      @   1: [D] (test2) text2\n" +
+		"        stack2\n", io.String())
+
+	assert.Equal(t, 0, len(s.known))
+	assert.Equal(t, 0, len(s.active))
+
+	io = bytes.Buffer{}
+	s.add(entry2, &io)
+
+	assert.Equal(t,
+		"\n[1102030405060708:0000000000000000] ok root:\n"+
+		"    stacks\n\n"+
+		"      @   2: [D] (test3) text3\n"+
+		"        stack3\n" +
+		"      @   3: [D] (test4) text4\n" +
+		"        stack4\n",
+			io.String())
+
+	assert.Equal(t, 0, len(s.known))
+	assert.Equal(t, 0, len(s.active))
+}
+
+func TestSimpleChildFirst(t *testing.T) {
+	traceID := "11020304050607080102030405060708"
+	s := newSpans()
+
+	io := bytes.Buffer{}
+
+	entry := &log.Entry{
+		Name:           "root",
+		SpanID:         "0102030405060708",
+		ParentID:       "0000000000000000",
+		TraceID:        traceID,
+		Status:         "ok",
+		StackTrace:     "stacks",
+		Event:          []*log.Event{
+			{
+				Tick:       0,
+				Severity:   0,
+				Name:       "test1",
+				Text:       "text1",
+				StackTrace: "stack1",
+				Impacted:   nil,
+				SpanStart:  false,
+				SpanId:     "",
+			},
+			{
+				Tick:       1,
+				Severity:   0,
+				Name:       "test2",
+				Text:       "text2",
+				StackTrace: "stack2",
+				Impacted:   nil,
+				SpanStart:  true,
+				SpanId:     "1102030405060708",
+			},
+			{
+				Tick:       1,
+				Severity:   0,
+				Name:       "test2",
+				Text:       "text2",
+				StackTrace: "stack2",
+				Impacted:   nil,
+				SpanStart:  false,
+				SpanId:     "",
+			},
+		},
+		Infrastructure: false,
+	}
+
+	entry2 := &log.Entry{
+		Name:           "root",
+		SpanID:         "1102030405060708",
+		ParentID:       "0102030405060708",
+		TraceID:        traceID,
+		Status:         "ok",
+		StackTrace:     "stacks",
+		Event:          []*log.Event{
+			{
+				Tick:       2,
+				Severity:   0,
+				Name:       "test3",
+				Text:       "text3",
+				StackTrace: "stack3",
+				Impacted:   nil,
+				SpanStart:  false,
+				SpanId:     "",
+			},
+			{
+				Tick:       3,
+				Severity:   0,
+				Name:       "test4",
+				Text:       "text4",
+				StackTrace: "stack4",
+				Impacted:   nil,
+				SpanStart:  false,
+				SpanId:     "",
+			},
+		},
+		Infrastructure: false,
+	}
+
+	s.add(entry2, &io)
+
+	assert.Equal(t, 0, len(io.String()))
+	assert.Equal(t, 1, len(s.known))
+	assert.Equal(t, 1, len(s.active))
+
+	a := s.active[traceID]
+	assert.Equal(t, 1, len(a.open))
+	assert.Equal(t, 1, len(a.closed))
+
+	io = bytes.Buffer{}
+	s.add(entry, &io)
+
+	assert.Equal(t,
+		"\n[0102030405060708:0000000000000000] ok root:\n"+
+			"    stacks\n\n"+
+			"      @   0: [D] (test1) text1\n"+
+			"        stack1\n" +
+		"\n    [1102030405060708:0102030405060708] ok root:\n"+
+			"        stacks\n\n"+
+			"          @   2: [D] (test3) text3\n"+
+			"            stack3\n" +
+			"          @   3: [D] (test4) text4\n" +
+			"            stack4\n"+
+		"      @   1: [D] (test2) text2\n" +
+			"        stack2\n",
+		io.String())
+
+	assert.Equal(t, 0, len(s.known))
+	assert.Equal(t, 0, len(s.active))
+
+}
+
+func TestSimpleChildLast(t *testing.T) {
+	traceID := "11020304050607080102030405060708"
+	s := newSpans()
+
+	io := bytes.Buffer{}
+
+	entry := &log.Entry{
+		Name:           "root",
+		SpanID:         "0102030405060708",
+		ParentID:       "0000000000000000",
+		TraceID:        traceID,
+		Status:         "ok",
+		StackTrace:     "stacks",
+		Event:          []*log.Event{
+			{
+				Tick:       0,
+				Severity:   0,
+				Name:       "test1",
+				Text:       "text1",
+				StackTrace: "stack1",
+				Impacted:   nil,
+				SpanStart:  false,
+				SpanId:     "",
+			},
+			{
+				Tick:       1,
+				Severity:   0,
+				Name:       "test2",
+				Text:       "text2",
+				StackTrace: "stack2",
+				Impacted:   nil,
+				SpanStart:  true,
+				SpanId:     "1102030405060708",
+			},
+			{
+				Tick:       1,
+				Severity:   0,
+				Name:       "test2",
+				Text:       "text2",
+				StackTrace: "stack2",
+				Impacted:   nil,
+				SpanStart:  false,
+				SpanId:     "",
+			},
+		},
+		Infrastructure: false,
+	}
+
+	entry2 := &log.Entry{
+		Name:           "root",
+		SpanID:         "1102030405060708",
+		ParentID:       "0102030405060708",
+		TraceID:        traceID,
+		Status:         "ok",
+		StackTrace:     "stacks",
+		Event:          []*log.Event{
+			{
+				Tick:       2,
+				Severity:   0,
+				Name:       "test3",
+				Text:       "text3",
+				StackTrace: "stack3",
+				Impacted:   nil,
+				SpanStart:  false,
+				SpanId:     "",
+			},
+			{
+				Tick:       3,
+				Severity:   0,
+				Name:       "test4",
+				Text:       "text4",
+				StackTrace: "stack4",
+				Impacted:   nil,
+				SpanStart:  false,
+				SpanId:     "",
+			},
+		},
+		Infrastructure: false,
+	}
+
+	s.add(entry, &io)
+
+	assert.Equal(t, 0, len(io.String()))
+	assert.Equal(t, 1, len(s.known))
+	assert.Equal(t, 1, len(s.active))
+
+	a := s.active[traceID]
+	assert.Equal(t, 1, len(a.open))
+	assert.Equal(t, 1, len(a.closed))
+
+	io = bytes.Buffer{}
+	s.add(entry2, &io)
+
+	assert.Equal(t,
+		"\n[0102030405060708:0000000000000000] ok root:\n"+
+			"    stacks\n\n"+
+			"      @   0: [D] (test1) text1\n"+
+			"        stack1\n" +
+			"\n    [1102030405060708:0102030405060708] ok root:\n"+
+			"        stacks\n\n"+
+			"          @   2: [D] (test3) text3\n"+
+			"            stack3\n" +
+			"          @   3: [D] (test4) text4\n" +
+			"            stack4\n"+
+			"      @   1: [D] (test2) text2\n" +
+			"        stack2\n",
+		io.String())
+
+	assert.Equal(t, 0, len(s.known))
+	assert.Equal(t, 0, len(s.active))
+}

--- a/internal/tracing/exporters/production/exporter.go
+++ b/internal/tracing/exporters/production/exporter.go
@@ -223,6 +223,7 @@ func scheduleReconnect() {
 			log.Fatalf("unexpected change in state while waiting for the backoff interval.  State is %v", state)
 		}
 
+		state = disconnected
 		attemptConnection()
 	})
 }

--- a/internal/tracing/exporters/unit_test/exporter.go
+++ b/internal/tracing/exporters/unit_test/exporter.go
@@ -75,7 +75,7 @@ func flushSaved(ctx context.Context) {
 
 // Send one entry to the output channel
 func processOneEntry(entry *log.Entry, deferred bool) {
-	testContext.Log(common.FormatEntry(entry, deferred))
+	testContext.Log(common.FormatEntry(entry, deferred, ""))
 
 	for _, event := range entry.Event {
 		testContext.Log(common.FormatEvent(event, ""))

--- a/test/Milestone1/TestClient/main.go
+++ b/test/Milestone1/TestClient/main.go
@@ -46,7 +46,7 @@ func main() {
 	}
 
 	if *showConfig {
-		fmt.Println(config.ToString(cfg))
+		fmt.Println(cfg)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
This modifies the io_writer to produce a functional grouping (tree) of spans by trace id and parent/child relationship.

This includes a few other points:
- grpc client shims now carry the caller's context to ensure the call site is in the right place
- scan methods that repeatedly call Now() instead use a cached tick count
- GRPC server interceptor and actor_interceptor start root spans with links to the caller
- RecordError has been replaced with an event to avoid multiple span entries for the same span ID
- production tracing for sim_support has been turned off.  There are some recursive loops in the tracing that need future work.