### PR TITLE
Simplify span handling, add infrastructure inheritence

### DIFF
--- a/internal/clients/store/storeapi.go
+++ b/internal/clients/store/storeapi.go
@@ -7,7 +7,8 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 
-	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+    "github.com/Jim3Things/CloudChamber/internal/tracing"
+    st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 
 	"google.golang.org/protobuf/runtime/protoiface"
 )
@@ -117,7 +118,7 @@ func (store *Store) CreateWithEncode(
 	err = st.WithSpan(ctx, func(ctx context.Context) (err error) {
 		prefix := getNamespacePrefixFromKeyRoot(r)
 
-		st.Infof(ctx, -1, "Request to create new %q under prefix %q", n, prefix)
+		tracing.Infof(ctx, -1, "Request to create new %q under prefix %q", n, prefix)
 
 		if err = store.disconnected(ctx); err != nil {
 			return err
@@ -151,7 +152,7 @@ func (store *Store) CreateWithEncode(
 			return err
 		}
 
-		st.Infof(ctx, -1, "Created record for %q under prefix %q with revision %v", n, prefix, resp.Revision)
+		tracing.Infof(ctx, -1, "Created record for %q under prefix %q with revision %v", n, prefix, resp.Revision)
 
 		revision = resp.Revision
 
@@ -167,7 +168,7 @@ func (store *Store) Create(ctx context.Context, r KeyRoot, n string, v string) (
 	err = st.WithSpan(ctx, func(ctx context.Context) (err error) {
 		prefix := getNamespacePrefixFromKeyRoot(r)
 
-		st.Infof(ctx, -1, "Request to create new %q under prefix %q", n, prefix)
+		tracing.Infof(ctx, -1, "Request to create new %q under prefix %q", n, prefix)
 
 		if err = store.disconnected(ctx); err != nil {
 			return err
@@ -195,7 +196,7 @@ func (store *Store) Create(ctx context.Context, r KeyRoot, n string, v string) (
 			return err
 		}
 
-		st.Infof(ctx, -1, "Created record for %q under prefix %q with revision %v", n, prefix, resp.Revision)
+		tracing.Infof(ctx, -1, "Created record for %q under prefix %q with revision %v", n, prefix, resp.Revision)
 
 		revision = resp.Revision
 
@@ -225,7 +226,7 @@ func (store *Store) ReadWithDecode(
 	err = st.WithSpan(ctx, func(ctx context.Context) (err error) {
 		prefix := getNamespacePrefixFromKeyRoot(kr)
 
-		st.Infof(ctx, -1, "Request to read and decode %q under prefix %q", n, prefix)
+		tracing.Infof(ctx, -1, "Request to read and decode %q under prefix %q", n, prefix)
 
 		if err = store.disconnected(ctx); err != nil {
 			return err
@@ -269,7 +270,7 @@ func (store *Store) ReadWithDecode(
 				return err
 			}
 
-			st.Infof(
+			tracing.Infof(
 				ctx, -1,
 				"found and decoded record for %q under prefix %q with revision %v and value %q",
 				n, prefix, rev, val)
@@ -299,7 +300,7 @@ func (store *Store) Read(ctx context.Context, kr KeyRoot, n string) (value *stri
 	err = st.WithSpan(ctx, func(ctx context.Context) (err error) {
 		prefix := getNamespacePrefixFromKeyRoot(kr)
 
-		st.Infof(ctx, -1, "Request to read value of %q under prefix %q", n, prefix)
+		tracing.Infof(ctx, -1, "Request to read value of %q under prefix %q", n, prefix)
 
 		if err = store.disconnected(ctx); err != nil {
 			return err
@@ -338,7 +339,7 @@ func (store *Store) Read(ctx context.Context, kr KeyRoot, n string) (value *stri
 		case 1:
 			rev = response.Records[k].Revision
 			val = response.Records[k].Value
-			st.Infof(ctx, -1, "found record for %q under prefix %q, with revision %v and value %q", n, prefix, rev, val)
+			tracing.Infof(ctx, -1, "found record for %q under prefix %q, with revision %v and value %q", n, prefix, rev, val)
 
 			revision = rev
 			value = &val
@@ -361,7 +362,7 @@ func (store *Store) UpdateWithEncode(
 	err = st.WithSpan(ctx, func(ctx context.Context) (err error) {
 		prefix := getNamespacePrefixFromKeyRoot(kr)
 
-		st.Infof(ctx, -1, "Request to update %q under prefix %q", n, prefix)
+		tracing.Infof(ctx, -1, "Request to update %q under prefix %q", n, prefix)
 
 		if err = store.disconnected(ctx); err != nil {
 			return err
@@ -396,7 +397,7 @@ func (store *Store) UpdateWithEncode(
 			return err
 		}
 
-		st.Infof(
+		tracing.Infof(
 			ctx, -1,
 			"Updated record %q under prefix %q from revision %v to revision %v",
 			n, prefix, rev, resp.Revision)
@@ -415,7 +416,7 @@ func (store *Store) Delete(ctx context.Context, r KeyRoot, n string, rev int64) 
 	err = st.WithSpan(ctx, func(ctx context.Context) (err error) {
 		prefix := getNamespacePrefixFromKeyRoot(r)
 
-		st.Infof(ctx, -1, "Request to delete %q under prefix %q", n, prefix)
+		tracing.Infof(ctx, -1, "Request to delete %q under prefix %q", n, prefix)
 
 		if err = store.disconnected(ctx); err != nil {
 			return err
@@ -453,7 +454,7 @@ func (store *Store) Delete(ctx context.Context, r KeyRoot, n string, rev int64) 
 			return err
 		}
 
-		st.Infof(
+		tracing.Infof(
 			ctx, -1,
 			"Deleted record for %q under prefix %q with revision %v resulting in store revision %v",
 			n, prefix, rev, resp.Revision)
@@ -480,7 +481,7 @@ func (store *Store) List(ctx context.Context, r KeyRoot) (records *map[string]Re
 	err = st.WithSpan(ctx, func(ctx context.Context) (err error) {
 		prefix := getNamespacePrefixFromKeyRoot(r)
 
-		st.Infof(ctx, -1, "Request to list keys under prefix %q", prefix)
+		tracing.Infof(ctx, -1, "Request to list keys under prefix %q", prefix)
 
 		if err = store.disconnected(ctx); err != nil {
 			return err
@@ -504,10 +505,10 @@ func (store *Store) List(ctx context.Context, r KeyRoot) (records *map[string]Re
 
 			recs[name] = Record{Revision: record.Revision, Value: record.Value}
 
-			st.Infof(ctx, -1, "found record with key %q for name %q with revision %v", k, name, record.Revision)
+			tracing.Infof(ctx, -1, "found record with key %q for name %q with revision %v", k, name, record.Revision)
 		}
 
-		st.Infof(ctx, -1, "returned %v records at store revision %v", len(response.Records), response.Revision)
+		tracing.Infof(ctx, -1, "returned %v records at store revision %v", len(response.Records), response.Revision)
 
 		records = &recs
 		revision = response.Revision

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -13,7 +13,8 @@ import (
 
 	"github.com/spf13/viper"
 
-	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+    "github.com/Jim3Things/CloudChamber/internal/tracing"
+    st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 	pb "github.com/Jim3Things/CloudChamber/pkg/protos/services"
 )
 
@@ -225,7 +226,7 @@ func ReadGlobalConfig(path string) (*GlobalConfig, error) {
 		if err := viper.ReadInConfig(); err != nil {
 			if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 				// Config file not found; we'll just use the default values
-				st.Infof(
+				tracing.Infof(
 					ctx,
 					-1,
 					"No config file found at %s/%s (%s), applying defaults.",
@@ -234,16 +235,16 @@ func ReadGlobalConfig(path string) (*GlobalConfig, error) {
 					defaultConfigType)
 			} else {
 				// Config file was found but another error was produced
-				return st.Errorf(ctx, -1, "fatal error reading config file: %s", err)
+				return tracing.Errorf(ctx, -1, "fatal error reading config file: %s", err)
 			}
 		} else {
 			// Fill in the global configuration object from the configuration file
 			if err = viper.UnmarshalExact(cfg); err != nil {
-				return st.Errorf(ctx, -1, "unable to decode into struct, %v", err)
+				return tracing.Errorf(ctx, -1, "unable to decode into struct, %v", err)
 			}
 		}
 
-		st.Infof(ctx, -1,
+		tracing.Infof(ctx, -1,
 			"Configuration Read: \n%v", cfg)
 
 		return nil

--- a/internal/services/frontend/DBUsers.go
+++ b/internal/services/frontend/DBUsers.go
@@ -17,8 +17,9 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/Jim3Things/CloudChamber/internal/clients/store"
+	"github.com/Jim3Things/CloudChamber/internal/common"
 	"github.com/Jim3Things/CloudChamber/internal/config"
-	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+	"github.com/Jim3Things/CloudChamber/internal/tracing"
 	pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
 )
 
@@ -31,62 +32,66 @@ type DBUsers struct {
 
 // InitDBUsers is a method to initialize the users store.  For now this is only a map in memory.
 func InitDBUsers(ctx context.Context, cfg *config.GlobalConfig) (err error) {
-	err = st.WithSpan(ctx, func(ctx context.Context) (err error) {
-		if dbUsers == nil {
-			dbUsers = &DBUsers{
-				Store: store.NewStore(),
-			}
-		}
+	ctx, span := tracing.StartSpan(ctx,
+		tracing.WithName("Initialize User DB Connection"),
+		tracing.AsInternal())
+	defer span.End()
 
-		if err = dbUsers.Store.Connect(); err != nil {
-			return err
-		}
+	// Pick up the current time to avoid repeatedly fetching the same value
+	tick := common.Tick(ctx)
 
-		passwordHash, err := bcrypt.GenerateFromPassword([]byte(cfg.WebServer.SystemAccountPassword), bcrypt.DefaultCost)
+	if dbUsers == nil {
+		dbUsers = &DBUsers{
+			Store: store.NewStore(),
+		}
+	}
+
+	if err = dbUsers.Store.Connect(); err != nil {
+		return err
+	}
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(cfg.WebServer.SystemAccountPassword), bcrypt.DefaultCost)
+
+	if err != nil {
+		return err
+	}
+
+	_, err = dbUsers.Create(ctx, &pb.User{
+		Name:              cfg.WebServer.SystemAccount,
+		PasswordHash:      passwordHash,
+		Enabled:           true,
+		CanManageAccounts: true,
+		NeverDelete:       true})
+
+	// If the SystemAccount already exists we need to do a couple of things.
+	//
+	// First, check to see if the password is the same and if not, issue a warning message
+	// to help troubleshoot the inability to use the SystemAccount with the expected password.
+	//
+	// Secondly, eat the "already exists" failure as there is no need to prevent startup
+	// if the account is already present.
+	//
+	if err == ErrUserAlreadyExists(cfg.WebServer.SystemAccount) {
+		existingUser, _, err := dbUsers.Read(ctx, cfg.WebServer.SystemAccount)
 
 		if err != nil {
-			return err
+			return tracing.Error(ctx, tick, ErrUnableToVerifySystemAccount{
+				Name: cfg.WebServer.SystemAccount,
+				Err:  err,
+			})
 		}
 
-		_, err = dbUsers.Create(ctx, &pb.User{
-			Name:              cfg.WebServer.SystemAccount,
-			PasswordHash:      passwordHash,
-			Enabled:           true,
-			CanManageAccounts: true,
-			NeverDelete:       true})
-
-		// If the SystemAccount already exists we need to do a couple of things.
-		//
-		// First, check to see if the password is the same and if not, issue a warning message
-		// to help troubleshoot the inability to use the SystemAccount with the expected password.
-		//
-		// Secondly, eat the "already exists" failure as there is no need to prevent startup
-		// if the account is already present.
-		//
-		if err == ErrUserAlreadyExists(cfg.WebServer.SystemAccount) {
-			existingUser, _, err := dbUsers.Read(ctx, cfg.WebServer.SystemAccount)
-
-			if err != nil {
-				return st.Error(ctx, -1, ErrUnableToVerifySystemAccount{
-					Name: cfg.WebServer.SystemAccount,
-					Err:  err,
-				})
-			}
-
-			if err = bcrypt.CompareHashAndPassword(
-				existingUser.GetPasswordHash(),
-				[]byte(cfg.WebServer.SystemAccountPassword)); err != nil {
-				st.Infof(
-					ctx, -1,
-					"CloudChamber: standard %q account is not using using configured password - error %v",
-					cfg.WebServer.SystemAccount, err)
-			}
-
-			return nil
+		if err = bcrypt.CompareHashAndPassword(
+			existingUser.GetPasswordHash(),
+			[]byte(cfg.WebServer.SystemAccountPassword)); err != nil {
+			tracing.Infof(
+				ctx, tick,
+				"CloudChamber: standard %q account is not using using configured password - error %v",
+				cfg.WebServer.SystemAccount, err)
 		}
 
-		return err
-	})
+		return nil
+	}
 
 	return err
 }

--- a/internal/services/frontend/frontend.go
+++ b/internal/services/frontend/frontend.go
@@ -32,7 +32,8 @@ import (
 	ts "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
 	tsc "github.com/Jim3Things/CloudChamber/internal/clients/trace_sink"
 	"github.com/Jim3Things/CloudChamber/internal/config"
-	ct "github.com/Jim3Things/CloudChamber/internal/tracing/client"
+    "github.com/Jim3Things/CloudChamber/internal/tracing"
+    ct "github.com/Jim3Things/CloudChamber/internal/tracing/client"
 	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 )
 
@@ -95,7 +96,7 @@ func normalizeURL(next http.Handler) http.Handler {
 func traceRequest(spanName string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = st.WithNamedSpan(context.Background(), spanName, func(ctx context.Context) error {
-			st.Infof(ctx, -1, "%s for path %q", r.Method, r.URL.String())
+			tracing.Infof(ctx, -1, "%s for path %q", r.Method, r.URL.String())
 			next.ServeHTTP(w, r)
 			return nil
 		})

--- a/internal/services/frontend/inventory.go
+++ b/internal/services/frontend/inventory.go
@@ -17,7 +17,8 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/Jim3Things/CloudChamber/internal/common"
-	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+    "github.com/Jim3Things/CloudChamber/internal/tracing"
+    st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 	pb "github.com/Jim3Things/CloudChamber/pkg/protos/inventory"
 )
 
@@ -65,7 +66,7 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 		// Pick up the current time to avoid repeatedly fetching the same value
 		tick := common.Tick(ctx)
 
-		st.Infof(
+		tracing.Infof(
 			ctx,
 			tick,
 			"Listing all %d racks, max blades/rack=%d, max blade capacity=%v",
@@ -83,7 +84,7 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 
 			res.Racks[name] = &pb.ExternalRackSummary{Uri: target}
 
-			st.Infof(ctx, tick, "   Listing rack %q at %q", name, target)
+			tracing.Infof(ctx, tick, "   Listing rack %q at %q", name, target)
 
 			return nil
 		})
@@ -115,7 +116,7 @@ func handlerRackRead(w http.ResponseWriter, r *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 
-		st.Infof(ctx, common.Tick(ctx), "Returning details for rack %q: %v", rackID, u)
+		tracing.Infof(ctx, common.Tick(ctx), "Returning details for rack %q: %v", rackID, u)
 
 		// Get the user entry, and serialize it to json
 		// (export userPublic to json and return that as the body)
@@ -151,7 +152,7 @@ func handlerBladesList(w http.ResponseWriter, r *http.Request) {
 		return dbInventory.ScanBladesInRack(rackID, func(bladeID int64) error {
 
 			target := fmt.Sprintf("%s%d", b, bladeID)
-			st.Infof(ctx, tick, " Listing blades '%d' at %q", bladeID, target)
+			tracing.Infof(ctx, tick, " Listing blades '%d' at %q", bladeID, target)
 
 			if _, err = fmt.Fprintln(w, target); err != nil {
 				return httpError(ctx, w, err)
@@ -189,7 +190,7 @@ func handlerBladeRead(w http.ResponseWriter, r *http.Request) {
 			return httpError(ctx, w, err)
 		}
 
-		st.Infof(ctx, common.Tick(ctx), "Returning details for blade %d  in rack %q:  %v", bladeID, rackID, blade)
+		tracing.Infof(ctx, common.Tick(ctx), "Returning details for blade %d  in rack %q:  %v", bladeID, rackID, blade)
 
 		p := jsonpb.Marshaler{}
 		return p.Marshal(w, blade)

--- a/internal/services/stepper_actor/actor.go
+++ b/internal/services/stepper_actor/actor.go
@@ -102,5 +102,5 @@ func (act *Actor) TraceOnReceive(ctx context.Context) {
 	sn := act.mgr.GetStateName()
 	mn := tracing.MethodName(2)
 
-	log.Infof(ctx, act.latest, "[In Stepper Actor/%s/%s]", sn, mn)
+	tracing.Infof(ctx, act.latest, "[In Stepper Actor/%s/%s]", sn, mn)
 }

--- a/internal/services/stepper_actor/sm.go
+++ b/internal/services/stepper_actor/sm.go
@@ -1,22 +1,22 @@
 package stepper
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"math/rand"
-	"time"
+    "context"
+    "errors"
+    "fmt"
+    "math/rand"
+    "time"
 
-	"github.com/AsynkronIT/protoactor-go/actor"
-	"github.com/AsynkronIT/protoactor-go/scheduler"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/duration"
-	"github.com/golang/protobuf/ptypes/empty"
+    "github.com/AsynkronIT/protoactor-go/actor"
+    "github.com/AsynkronIT/protoactor-go/scheduler"
+    "github.com/golang/protobuf/ptypes"
+    "github.com/golang/protobuf/ptypes/duration"
+    "github.com/golang/protobuf/ptypes/empty"
 
-	"github.com/Jim3Things/CloudChamber/internal/sm"
-	trace "github.com/Jim3Things/CloudChamber/internal/tracing/server"
-	pb "github.com/Jim3Things/CloudChamber/pkg/protos/services"
-	"github.com/Jim3Things/CloudChamber/pkg/protos/common"
+    "github.com/Jim3Things/CloudChamber/internal/sm"
+    "github.com/Jim3Things/CloudChamber/internal/tracing"
+    "github.com/Jim3Things/CloudChamber/pkg/protos/common"
+    pb "github.com/Jim3Things/CloudChamber/pkg/protos/services"
 )
 
 const (
@@ -192,7 +192,7 @@ func (s *AutoStepStateImpl) Enter(ctx context.Context) error {
 	}
 
 	if delay <= 0 {
-		return trace.Errorf(ctx, holder.latest, "delay must be greater than zero, but was %d", delay)
+		return tracing.Errorf(ctx, holder.latest, "delay must be greater than zero, but was %d", delay)
 	}
 
 	s.delay = delay
@@ -250,7 +250,7 @@ func (s *AutoStepStateImpl) Leave() {
 // processing for a subset of the possible messages.  The pattern is to first
 // handle those, and then call this method to handle the rest.
 func (act *Actor) ApplyDefaultActions(ctx context.Context) {
-	trace.OnEnter(ctx, act.latest, "Applying Default Actions")
+	tracing.OnEnter(ctx, act.latest, "Applying Default Actions")
 	ca := sm.ActorContext(ctx)
 
 	if !isSystemMessage(ctx) {
@@ -383,7 +383,7 @@ func (act *Actor) checkForExpiry(ctx context.Context) {
 
 	k, v := act.waiters.Min()
 	if k == nil {
-		trace.Info(ctx, act.latest, "No waiters found")
+		tracing.Info(ctx, act.latest, "No waiters found")
 		return
 	}
 

--- a/internal/services/tracing_sink/sink.go
+++ b/internal/services/tracing_sink/sink.go
@@ -14,7 +14,8 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/Jim3Things/CloudChamber/internal/common"
-	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+    "github.com/Jim3Things/CloudChamber/internal/tracing"
+    st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 	"github.com/Jim3Things/CloudChamber/pkg/protos/log"
 	pb "github.com/Jim3Things/CloudChamber/pkg/protos/services"
 )
@@ -160,9 +161,9 @@ func (s *server) GetAfter(ctx context.Context, request *pb.GetAfterRequest) (*pb
 	})
 
 	if err != nil {
-		st.Infof(ctx, common.Tick(ctx), "GetAfter failed with err=%v", err)
+		tracing.Infof(ctx, common.Tick(ctx), "GetAfter failed with err=%v", err)
 	} else {
-		st.Infof(
+		tracing.Infof(
 			ctx, common.Tick(ctx),
 			"GetAfter returning; %d entries, missed=%v, lastID=%d",
 			len(resp.res.Entries), resp.res.Missed, resp.res.LastId)
@@ -185,7 +186,7 @@ func (s *server) GetPolicy(ctx context.Context, _ *pb.GetPolicyRequest) (*pb.Get
 			FirstId:        int64(s.getFirstId() - 1),
 		}
 
-		st.Infof(
+		tracing.Infof(
 			ctx, common.Tick(ctx),
 			"GetPolicy returning; firstId=%d, maxEntriesHeld=%d",
 			resp.FirstId, resp.MaxEntriesHeld)

--- a/internal/sm/sm.go
+++ b/internal/sm/sm.go
@@ -9,6 +9,7 @@ import (
 	"github.com/AsynkronIT/protoactor-go/actor"
 	trc "go.opentelemetry.io/otel/api/trace"
 
+	"github.com/Jim3Things/CloudChamber/internal/tracing"
 	trace "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 	"github.com/Jim3Things/CloudChamber/pkg/protos/common"
 )
@@ -49,13 +50,13 @@ type SM struct {
 // Common method to change the current state.  Leave the old state, try to
 // enter the new state, and declare that state as current if successful.
 func (sm *SM) ChangeState(ctx context.Context, latest int64, newState int) error {
-	trace.Infof(ctx, latest, "Change state to %q", sm.StateNames[newState])
+	tracing.Infof(ctx, latest, "Change state to %q", sm.StateNames[newState])
 	cur := sm.States[sm.Current]
 	cur.Leave()
 
 	cur = sm.States[newState]
 	if err := cur.Enter(ctx); err != nil {
-		return trace.Error(ctx, latest, err)
+		return tracing.Error(ctx, latest, err)
 	}
 
 	sm.Current = newState
@@ -67,7 +68,7 @@ func (sm *SM) ChangeState(ctx context.Context, latest int64, newState int) error
 func (sm *SM) Initialize(ctx context.Context, firstState int) error {
 	cur := sm.States[firstState]
 	if err := cur.Enter(ctx); err != nil {
-		return trace.Error(ctx, 0, err)
+		return tracing.Error(ctx, 0, err)
 	}
 
 	sm.Current = firstState

--- a/internal/tracing/server/actor_interceptor.go
+++ b/internal/tracing/server/actor_interceptor.go
@@ -12,8 +12,8 @@ import (
 	trc "go.opentelemetry.io/otel/api/trace"
 
 	"github.com/Jim3Things/CloudChamber/internal/tracing"
-	pb "github.com/Jim3Things/CloudChamber/pkg/protos/services"
 	"github.com/Jim3Things/CloudChamber/pkg/protos/common"
+	pb "github.com/Jim3Things/CloudChamber/pkg/protos/services"
 )
 
 // +++ Logging interceptors
@@ -23,7 +23,7 @@ import (
 // span is terminated when the actor returns.
 func ReceiveLogger(next actor.ReceiverFunc) actor.ReceiverFunc {
 	return func(c actor.ReceiverContext, envelope *actor.MessageEnvelope) {
-		tr := global.TraceProvider().Tracer("server")
+		tr := global.TraceProvider().Tracer("")
 
 		ctxIn := annotatedContext(context.Background(), envelope)
 
@@ -45,7 +45,7 @@ func ReceiveLogger(next actor.ReceiverFunc) actor.ReceiverFunc {
 
 		hdr, msg, pid := actor.UnwrapEnvelope(envelope)
 
-		Infof(ctx, -1, "Receive pid: %v, hdr: %v, msg: %v", pid, hdr, dumpMessage(msg))
+		tracing.Infof(ctx, -1, "Receive pid: %v, hdr: %v, msg: %v", pid, hdr, dumpMessage(msg))
 
 		next(c, envelope)
 	}
@@ -58,7 +58,7 @@ func SendLogger(next actor.SenderFunc) actor.SenderFunc {
 		ctx := trc.ContextWithSpan(context.Background(), GetSpan(c.Self()))
 		hdr, msg, pid := actor.UnwrapEnvelope(envelope)
 
-		Info(ctx, -1, fmt.Sprintf("Sending pid: %v, hdr: %v, msg: %v", pid, hdr, dumpMessage(msg)))
+		tracing.Info(ctx, -1, fmt.Sprintf("Sending pid: %v, hdr: %v, msg: %v", pid, hdr, dumpMessage(msg)))
 
 		next(c, target, envelope)
 	}

--- a/internal/tracing/spanEx.go
+++ b/internal/tracing/spanEx.go
@@ -1,0 +1,204 @@
+package tracing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	log2 "log"
+
+	"go.opentelemetry.io/otel/api/global"
+	"go.opentelemetry.io/otel/api/kv"
+	"go.opentelemetry.io/otel/api/trace"
+
+	"github.com/Jim3Things/CloudChamber/pkg/protos/log"
+)
+
+// spanEx extends the OpenTelemetry Span structure with additional features
+// needed by CloudChamber
+type spanEx struct {
+	// Original OpenTelemetry span
+	trace.Span
+
+	// isInternal is true if this span started with SpanKindInternal.
+	isInternal bool
+}
+
+// Mask applies the policy that a child span of a span that is marked as
+// infrastructure (span kind is internal) should also be market as internal.
+func (s *spanEx) Mask(kind trace.SpanKind) trace.SpanKind {
+	if s.isInternal {
+		return trace.SpanKindInternal
+	}
+
+	return kind
+}
+
+// startSpanConfig defines the attributes used when starting a new span, and
+// that can be overridden by the caller.
+type startSpanConfig struct {
+	name       string
+	kind       trace.SpanKind
+	stackTrace string
+	tick       int64
+}
+
+// StartSpanOption denotes optional decoration methods used on StartSpan
+type StartSpanOption func(*startSpanConfig)
+
+// WithName adds the supplied value as the name of the span under creation
+func WithName(name string) StartSpanOption {
+	return func(cfg *startSpanConfig) {
+		cfg.name = name
+	}
+}
+
+// WithKind sets the span kind for the span under creation.  This will be
+// overridden if the parent span is of SpanKindInternal.
+func WithKind(kind trace.SpanKind) StartSpanOption {
+	return func(cfg *startSpanConfig) {
+		cfg.kind = kind
+	}
+}
+
+// WithTick sets the start time for the span to a specific simulated time.
+func WithTick(tick int64) StartSpanOption {
+	return func(cfg *startSpanConfig) {
+		cfg.tick = tick
+	}
+}
+
+// AsInternal sets the span as an infrastructure (or internal) span kind.
+func AsInternal() StartSpanOption {
+	return func(cfg *startSpanConfig) {
+		cfg.kind = trace.SpanKindInternal
+	}
+}
+
+// StartSpan creates a new tracing span, with the attributes and linkages
+// that the Cloud Chamber logging system expects
+func StartSpan(
+	ctx context.Context,
+	options ...StartSpanOption) (context.Context, trace.Span) {
+	cfg := startSpanConfig{
+		name:       MethodName(2),
+		kind:       trace.SpanKindServer,
+		stackTrace: StackTrace(),
+		tick:       -1,
+	}
+
+	for _, opt := range options {
+		opt(&cfg)
+	}
+
+	parent := trace.SpanFromContext(ctx)
+
+	if spanEx, ok := parent.(spanEx); ok {
+		cfg.kind = spanEx.Mask(cfg.kind)
+	}
+
+	tr := global.TraceProvider().Tracer("")
+
+	ctxChild, span := tr.Start(ctx, cfg.name,
+		trace.WithSpanKind(cfg.kind),
+		trace.WithAttributes(kv.String(StackTraceKey, cfg.stackTrace)))
+
+	if parent.SpanContext().HasSpanID() {
+		parent.AddEvent(
+			ctxChild,
+			cfg.name,
+			kv.Int64(StepperTicksKey, cfg.tick),
+			kv.Int64(SeverityKey, int64(log.Severity_Info)),
+			kv.String(StackTraceKey, StackTrace()),
+			kv.String(ChildSpanKey, span.SpanContext().SpanID.String()))
+	}
+
+	ccSpan := spanEx{
+		Span:       span,
+		isInternal: cfg.kind == trace.SpanKindInternal,
+	}
+
+	return trace.ContextWithSpan(ctxChild, ccSpan), ccSpan
+}
+
+// There should be an Xxx and Xxxf method for every severity level, plus some
+// specific scenario functions (such as OnEnter to log an information entry
+// about arrival at a specific method).
+//
+// Note: The set of methods that are implemented below are based on what is
+// currently needed.  Others will be added as required.
+
+// Info posts a simple informational trace event
+func Info(ctx context.Context, tick int64, msg string) {
+	trace.SpanFromContext(ctx).AddEvent(
+		ctx,
+		MethodName(2),
+		kv.Int64(StepperTicksKey, tick),
+		kv.Int64(SeverityKey, int64(log.Severity_Info)),
+		kv.String(StackTraceKey, StackTrace()),
+		kv.String(MessageTextKey, msg))
+}
+
+// Infof posts an informational trace event with complex formatting
+func Infof(ctx context.Context, tick int64, f string, a ...interface{}) {
+	trace.SpanFromContext(ctx).AddEvent(
+		ctx,
+		MethodName(2),
+		kv.Int64(StepperTicksKey, tick),
+		kv.Int64(SeverityKey, int64(log.Severity_Info)),
+		kv.String(StackTraceKey, StackTrace()),
+		kv.String(MessageTextKey, fmt.Sprintf(f, a...)))
+}
+
+// OnEnter posts an informational trace event describing the entry into a
+// function
+func OnEnter(ctx context.Context, tick int64, msg string) {
+	trace.SpanFromContext(ctx).AddEvent(
+		ctx,
+		fmt.Sprintf("On %q entry", MethodName(2)),
+		kv.Int64(StepperTicksKey, tick),
+		kv.Int64(SeverityKey, int64(log.Severity_Info)),
+		kv.String(StackTraceKey, StackTrace()),
+		kv.String(MessageTextKey, msg))
+}
+
+// Error posts a simple error trace event
+func Error(ctx context.Context, tick int64, a interface{}) error {
+	if msg, ok := a.(string); ok {
+		return logError(ctx, tick, errors.New(msg))
+	}
+
+	if err, ok := a.(error); ok {
+		return logError(ctx, tick, err)
+	}
+
+	panic("Invalid Error call - no valid arguments found")
+}
+
+// Errorf posts an error trace event with a complex string formatting
+func Errorf(ctx context.Context, tick int64, f string, a ...interface{}) error {
+	return logError(ctx, tick, fmt.Errorf(f, a...))
+}
+
+// Fatalf traces the error, and then terminates the process.
+func Fatalf(ctx context.Context, tick int64, f string, a ...interface{}) {
+	log2.Fatal(Errorf(ctx, tick, f, a...))
+}
+
+// --- Exported trace invocation methods
+
+// +++ Helper functions
+
+// logError writes a specific error trace event
+func logError(ctx context.Context, tick int64, err error) error {
+	trace.SpanFromContext(ctx).AddEvent(
+		ctx,
+		fmt.Sprintf("Error from %q", MethodName(3)),
+		kv.Int64(StepperTicksKey, tick),
+		kv.Int64(SeverityKey, int64(log.Severity_Error)),
+		kv.String(StackTraceKey, StackTrace()),
+		kv.String(MessageTextKey, err.Error()))
+
+	return err
+}
+
+// --- Helper functions

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,7 +9,8 @@ import (
 	"os"
 	"time"
 
-	st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
+    "github.com/Jim3Things/CloudChamber/internal/tracing"
+    st "github.com/Jim3Things/CloudChamber/internal/tracing/server"
 )
 
 //go:generate go run generator/generate.go
@@ -48,14 +49,14 @@ func Show() {
 //
 func Trace() {
 	_ = st.WithSpan(context.Background(), func(ctx context.Context) (err error) {
-		st.Infof(
+		tracing.Infof(
 			ctx,
 			-1,
 			"===== Starting %q at %s =====",
 			fmt.Sprint(os.Args),
 			time.Now().Format(time.RFC1123Z))
 
-		st.Info(ctx, -1, toString())
+		tracing.Info(ctx, -1, toString())
 		return nil
 	})
 }


### PR DESCRIPTION
This adds a wrapped span that is used to inherit the infrastructure attribute on spans, it adds a non-WithSpan sequence, modifies users.go & DBUsers.go to use that, with some cleanup of the http error handling.

The new start span, and the existing trace event methods, are moved to a common tracing level.  The client and server subdirectories will move to contain client and service interceptors, as the WithSpan variants are removed.