### PR TITLE
Fix issue with lack of output in log files

### DIFF
--- a/configs/cloudchamber.yaml
+++ b/configs/cloudchamber.yaml
@@ -8,7 +8,7 @@ controller:
     Hostname: localhost
 
   # trace file for local text tracing
-  Tracefile: .\controller_trace.txt
+  TraceFile: stdout
 
 # simulated inventory service (inventoryd)
 inventory:
@@ -18,7 +18,7 @@ inventory:
     hostname: localhost
 
   # trace file for local text tracing
-  Tracefile: .\inventory_trace.txt
+  TraceFile: stdout
 
 # simulation support services (sim_supportd)
 simSupport:
@@ -28,7 +28,7 @@ simSupport:
     hostname: localhost
 
   # trace file for local text tracing
-  Tracefile: .\sim_support_trace.txt
+  TraceFile: stdout
 
   # Starting Stepper Policy Mode
   # valid strings are 'manual' or 'automatic'.  The latter
@@ -91,7 +91,7 @@ webServer:
     hostname: localhost
 
   # trace file for local text tracing
-  Tracefile: .\web_server_trace.txt
+  TraceFile: stdout
 
   # file system path to the static files and scripts
   rootFilePath: .

--- a/scripts/StartCloudChamber.cmd
+++ b/scripts/StartCloudChamber.cmd
@@ -108,8 +108,7 @@ rem
 echo.
 echo Starting %TARGETBIN%
 
-start %TARGETBIN% -config=%2 2>&1 >%CLOUDCHAMBERLOGS%\%BINARY:~0,-4%-%UpdateDateTime%.log
-
+start cmd /c "%TARGETBIN% -config=%2 2>&1 >%CLOUDCHAMBERLOGS%\%BINARY:~0,-4%.log"
 goto :StartBinaryExit
 
 


### PR DESCRIPTION
Two parts

- the service executables were not emmitting any output to stdout and/or stderr so the re-direction of the output to a log file was failing.

- the redirection in the StartCloudChamber.cmd script was re-directing the output from the wrong source. The existing code was re-directing stdout/stderr from the current command line, i.e. from the "start" command itself. What it needed to do was start the service in a new command interpreter and then redirect the stdout/stderr channels from this new interpreter to the target log files.

Also removed the use of the date/time portion of the logfile name as it wasn't sufficiently robust with respect to international date formats.
