### PR TITLE
Fix edge timing issue in forwarder.

### DIFF
--- a/internal/tracing/exporters/exporters.go
+++ b/internal/tracing/exporters/exporters.go
@@ -132,7 +132,7 @@ func (e *Exporter) Close() {
 func (e *Exporter) processLoop(ch chan interface{}) {
 	early := true
 
-	for !e.closed {
+	for {
 		msg := <-ch
 
 		switch pkt := msg.(type) {
@@ -149,6 +149,7 @@ func (e *Exporter) processLoop(ch chan interface{}) {
 			e.closed = true
 
 			pkt.ch <- true
+			return
 		}
 	}
 }


### PR DESCRIPTION
If the goroutine stalls for long enough after issuing the close-ack it can find that the forwarder is open again and we can end up with two active forwarders.