### PR TITLE
Properly reference the timestamp  package by the correct name

### DIFF
--- a/internal/clients/store/store.go
+++ b/internal/clients/store/store.go
@@ -78,7 +78,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	clients "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
+	"github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
 	"github.com/Jim3Things/CloudChamber/internal/config"
 	"github.com/Jim3Things/CloudChamber/internal/tracing"
 )
@@ -202,7 +202,7 @@ func (store *Store) disconnected(ctx context.Context) error {
 //
 func Initialize(cfg *config.GlobalConfig) {
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	storeRoot.DefaultEndpoints = []string{
@@ -358,7 +358,7 @@ func (store *Store) Initialize(
 	traceFlags TraceFlags,
 	namespaceSuffix string) error {
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	if err := store.connected(ctx); err != nil {
@@ -422,7 +422,7 @@ func (store *Store) logEtcdResponseError(ctx context.Context, err error) {
 //
 func (store *Store) SetTraceFlags(traceLevel TraceFlags) {
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	store.TraceFlags = traceLevel
@@ -440,7 +440,7 @@ func (store *Store) GetTraceFlags() TraceFlags { return store.TraceFlags }
 //
 func (store *Store) SetAddress(endpoints []string) error {
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	if err := store.connected(ctx); err != nil {
@@ -465,7 +465,7 @@ func (store *Store) GetAddress() []string { return store.Endpoints }
 //
 func (store *Store) SetTimeoutConnect(timeout time.Duration) error {
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	if err := store.connected(ctx); err != nil {
@@ -491,7 +491,7 @@ func (store *Store) GetTimeoutConnect() time.Duration { return store.TimeoutConn
 //
 func (store *Store) SetTimeoutRequest(timeout time.Duration) error {
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	store.TimeoutRequest = timeout
@@ -513,7 +513,7 @@ func (store *Store) GetTimeoutRequest() time.Duration { return store.TimeoutRequ
 //
 func (store *Store) SetNamespaceSuffix(suffix string) error {
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	if err := store.connected(ctx); err != nil {
@@ -539,7 +539,7 @@ func (store *Store) GetNamespaceSuffix() string { return store.NamespaceSuffix }
 //
 func (store *Store) Connect() error {
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	if err := store.connected(ctx); err != nil {
@@ -585,7 +585,7 @@ func (store *Store) Connect() error {
 //
 func (store *Store) Disconnect() {
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	if nil == store.Client {
@@ -622,7 +622,7 @@ type ClusterMember struct {
 //
 func (store *Store) GetClusterMembers() (result *Cluster, err error) {
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	if err = store.disconnected(ctx); err != nil {
@@ -676,7 +676,7 @@ func (store *Store) GetClusterMembers() (result *Cluster, err error) {
 //
 func (store *Store) UpdateClusterConnections() error {
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	if err := store.disconnected(ctx); err != nil {
@@ -698,7 +698,7 @@ func (store *Store) UpdateClusterConnections() error {
 //
 func (store *Store) SetWatch(key string) error {
 	_, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	return ErrStoreNotImplemented("SetWatch")
@@ -712,7 +712,7 @@ func (store *Store) SetWatch(key string) error {
 //
 func (store *Store) SetWatchMultiple(key []string) error {
 	_, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	return ErrStoreNotImplemented("SetWatchMultiple")
@@ -723,7 +723,7 @@ func (store *Store) SetWatchMultiple(key []string) error {
 //
 func (store *Store) SetWatchWithPrefix(keyPrefix string) error {
 	_, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	return ErrStoreNotImplemented("SetWatchWithPrefix")
@@ -892,7 +892,7 @@ func checkConditions(stm concurrency.STM, req *Request) error {
 //
 func (store *Store) ListWithPrefix(ctx context.Context, keyPrefix string) (response *Response, err error) {
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	if err = store.disconnected(ctx); err != nil {
@@ -948,7 +948,7 @@ func (store *Store) ListWithPrefix(ctx context.Context, keyPrefix string) (respo
 //
 func (store *Store) DeleteWithPrefix(ctx context.Context, keyPrefix string) (response *Response, err error) {
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	if err = store.disconnected(ctx); err != nil {
@@ -985,7 +985,7 @@ func (store *Store) DeleteWithPrefix(ctx context.Context, keyPrefix string) (res
 //
 func (store *Store) ReadTxn(ctx context.Context, request *Request) (response *Response, err error) {
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	if err = store.disconnected(ctx); err != nil {
@@ -1060,7 +1060,7 @@ func (store *Store) ReadTxn(ctx context.Context, request *Request) (response *Re
 //
 func (store *Store) WriteTxn(ctx context.Context, request *Request) (response *Response, err error) {
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	if err = store.disconnected(ctx); err != nil {
@@ -1122,7 +1122,7 @@ func (store *Store) WriteTxn(ctx context.Context, request *Request) (response *R
 //
 func (store *Store) DeleteTxn(ctx context.Context, request *Request) (response *Response, err error) {
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	if err = store.disconnected(ctx); err != nil {

--- a/internal/clients/store/store_test.go
+++ b/internal/clients/store/store_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	clients "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
+	"github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
 	"github.com/Jim3Things/CloudChamber/internal/tracing"
 )
 
@@ -261,7 +261,7 @@ func TestStoreWriteReadTxn(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteReadTxn"
@@ -303,7 +303,7 @@ func TestStoreWriteReadTxnRequired(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteReadTxnRequired"
@@ -358,7 +358,7 @@ func TestStoreWriteReadTxnOptional(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteReadTxnOptional"
@@ -414,7 +414,7 @@ func TestStoreWriteReadMultipleTxn(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteReadMultipleTxn"
@@ -458,7 +458,7 @@ func TestStoreWriteReadMultipleTxnRequired(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteReadMultipleTxnRequired"
@@ -526,7 +526,7 @@ func TestStoreWriteReadMultipleTxnOptional(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteReadMultipleTxnOptional"
@@ -581,7 +581,7 @@ func TestStoreWriteReadMultipleTxnPartial(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteReadMultipleTxnPartial"
@@ -657,7 +657,7 @@ func TestStoreWriteDeleteTxn(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteDeleteTxn"
@@ -728,7 +728,7 @@ func TestStoreWriteDeleteTxnDeleteAbsent(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteDeleteTxnDeleteAbsent"
@@ -806,7 +806,7 @@ func TestStoreWriteDeleteMultipleTxnRequired(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteDeleteMultipleTxnRequired"
@@ -899,7 +899,7 @@ func TestStoreWriteDeleteMultipleTxnOptional(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteDeleteMultipleTxnOptional"
@@ -979,7 +979,7 @@ func TestStoreWriteDeleteMultipleTxnPartialRequired(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteDeleteMultipleTxnPartial"
@@ -1111,7 +1111,7 @@ func TestStoreWriteDeleteMultipleTxnPartialOptional(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteDeleteMultipleTxnPartialOptional"
@@ -1188,7 +1188,7 @@ func TestStoreWriteDeleteWithPrefix(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteDeleteWithPrefix"
@@ -1253,7 +1253,7 @@ func TestStoreWriteReadDeleteWithoutConnect(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteReadDeleteWithoutConnect"
@@ -1415,7 +1415,7 @@ func TestStoreWriteMultipleTxnCreate(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteMultipleTxnCreate"
@@ -1478,7 +1478,7 @@ func TestStoreWriteMultipleTxnOverwrite(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteMultipleTxnOverwrite"
@@ -1544,7 +1544,7 @@ func TestStoreWriteMultipleTxnCompareEqual(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreWriteMultipleTxnCompareEqual"
@@ -1616,7 +1616,7 @@ func TestStoreListWithPrefix(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreListWithPrefix"
@@ -1680,7 +1680,7 @@ func TestStoreListWithPrefixEmptySet(t *testing.T) {
 	defer utf.Close()
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	testName := "TestStoreListWithPrefixEmptySet"

--- a/internal/clients/store/storeapi.go
+++ b/internal/clients/store/storeapi.go
@@ -8,8 +8,7 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	"google.golang.org/protobuf/runtime/protoiface"
-
-	clients "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
+	"github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
 	"github.com/Jim3Things/CloudChamber/internal/tracing"
 )
 
@@ -116,7 +115,7 @@ func (store *Store) CreateWithEncode(
 	n string,
 	m protoiface.MessageV1) (revision int64, err error) {
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	prefix := getNamespacePrefixFromKeyRoot(r)
@@ -164,7 +163,7 @@ func (store *Store) CreateWithEncode(
 //
 func (store *Store) Create(ctx context.Context, r KeyRoot, n string, v string) (revision int64, err error) {
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	prefix := getNamespacePrefixFromKeyRoot(r)
@@ -222,7 +221,7 @@ func (store *Store) ReadWithDecode(
 	revision = RevisionInvalid
 
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	prefix := getNamespacePrefixFromKeyRoot(kr)
@@ -291,7 +290,7 @@ func (store *Store) Read(ctx context.Context, kr KeyRoot, n string) (value *stri
 	revision = RevisionInvalid
 
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	prefix := getNamespacePrefixFromKeyRoot(kr)
@@ -353,7 +352,7 @@ func (store *Store) UpdateWithEncode(
 	rev int64,
 	m protoiface.MessageV1) (revision int64, err error) {
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	prefix := getNamespacePrefixFromKeyRoot(kr)
@@ -404,7 +403,7 @@ func (store *Store) UpdateWithEncode(
 //
 func (store *Store) Delete(ctx context.Context, r KeyRoot, n string, rev int64) (revision int64, err error) {
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	prefix := getNamespacePrefixFromKeyRoot(r)
@@ -464,7 +463,7 @@ func (store *Store) Delete(ctx context.Context, r KeyRoot, n string, rev int64) 
 //
 func (store *Store) List(ctx context.Context, r KeyRoot) (records *map[string]Record, revision int64, err error) {
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithContextValue(clients.EnsureTickInContext))
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
 	prefix := getNamespacePrefixFromKeyRoot(r)

--- a/internal/clients/timestamp/StepperTestClientSuite.go
+++ b/internal/clients/timestamp/StepperTestClientSuite.go
@@ -1,4 +1,4 @@
-package clients
+package timestamp
 
 import (
 	"context"

--- a/internal/clients/timestamp/grpc.go
+++ b/internal/clients/timestamp/grpc.go
@@ -1,4 +1,4 @@
-package clients
+package timestamp
 
 import (
 	"context"

--- a/internal/clients/timestamp/timer.go
+++ b/internal/clients/timestamp/timer.go
@@ -1,4 +1,4 @@
-package clients
+package timestamp
 
 import (
 	"context"

--- a/internal/clients/timestamp/timer_test.go
+++ b/internal/clients/timestamp/timer_test.go
@@ -1,4 +1,4 @@
-package clients
+package timestamp
 
 import (
 	"context"

--- a/internal/clients/timestamp/timestamp.go
+++ b/internal/clients/timestamp/timestamp.go
@@ -1,7 +1,7 @@
 // This module provides the basic client methods for using the simulated time
 // service.
 
-package clients
+package timestamp
 
 import (
 	"context"

--- a/internal/clients/timestamp/timestamp_test.go
+++ b/internal/clients/timestamp/timestamp_test.go
@@ -1,4 +1,4 @@
-package clients
+package timestamp
 
 import (
 	"context"

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/spf13/viper"
 
-	clients "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
+	"github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
 	"github.com/Jim3Things/CloudChamber/internal/tracing"
 	pb "github.com/Jim3Things/CloudChamber/pkg/protos/services"
 )
@@ -234,7 +234,7 @@ func ReadGlobalConfig(path string) (*GlobalConfig, error) {
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Read Cloud Chamber Configuration"),
 		tracing.AsInternal(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	if err := viper.ReadInConfig(); err != nil {

--- a/internal/services/frontend/DBUsers.go
+++ b/internal/services/frontend/DBUsers.go
@@ -34,7 +34,7 @@ type DBUsers struct {
 func InitDBUsers(ctx context.Context, cfg *config.GlobalConfig) (err error) {
 	ctx, span := tracing.StartSpan(ctx,
 		tracing.WithName("Initialize User DB Connection"),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 

--- a/internal/services/frontend/inventory.go
+++ b/internal/services/frontend/inventory.go
@@ -46,7 +46,7 @@ func inventoryAddRoutes(routeBase *mux.Router) {
 func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Get Cluster Inventory List of Racks"),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 
@@ -103,7 +103,7 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 func handlerRackRead(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Get Rack Details"),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 
@@ -140,7 +140,7 @@ func handlerRackRead(w http.ResponseWriter, r *http.Request) {
 func handlerBladesList(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Get List of Blades in Selected Rack"),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 
@@ -180,7 +180,7 @@ func handlerBladesList(w http.ResponseWriter, r *http.Request) {
 func handlerBladeRead(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Get Blade Details"),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 

--- a/internal/services/frontend/logs.go
+++ b/internal/services/frontend/logs.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 
-	clients "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
+	"github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
 	tsc "github.com/Jim3Things/CloudChamber/internal/clients/trace_sink"
 	"github.com/Jim3Things/CloudChamber/internal/tracing"
 )
@@ -25,7 +25,7 @@ func logsAddRoutes(routeBase *mux.Router) {
 func handlerLogsGetAfter(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Get Traces After..."),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 
@@ -77,7 +77,7 @@ func handlerLogsGetAfter(w http.ResponseWriter, r *http.Request) {
 func handlerLogsGetPolicy(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Get Traces After..."),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 

--- a/internal/services/frontend/ping.go
+++ b/internal/services/frontend/ping.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 
-	clients "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
+	"github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
 	"github.com/Jim3Things/CloudChamber/internal/tracing"
 )
 
@@ -30,7 +30,7 @@ func handlerPing(w http.ResponseWriter, r *http.Request) {
 
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Ping Session"),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 

--- a/internal/services/frontend/users.go
+++ b/internal/services/frontend/users.go
@@ -77,7 +77,7 @@ func usersAddRoutes(routeBase *mux.Router) {
 func handlerUsersList(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Get User List"),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 
@@ -131,7 +131,7 @@ func handlerUsersList(w http.ResponseWriter, r *http.Request) {
 func handlerUserCreate(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Create New User"),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 
@@ -179,7 +179,7 @@ func handlerUserCreate(w http.ResponseWriter, r *http.Request) {
 func handlerUserRead(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Get User Details"),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 
@@ -229,7 +229,7 @@ func handlerUserRead(w http.ResponseWriter, r *http.Request) {
 func handlerUserUpdate(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Update User Details"),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 
@@ -316,7 +316,7 @@ func handlerUserUpdate(w http.ResponseWriter, r *http.Request) {
 func handlerUserDelete(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Delete User"),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 
@@ -350,7 +350,7 @@ func handlerUserDelete(w http.ResponseWriter, r *http.Request) {
 func handlerUserOperation(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Perform User Operation"),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 
@@ -394,7 +394,7 @@ func handlerUserOperation(w http.ResponseWriter, r *http.Request) {
 func handlerUserSetPassword(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Perform User Operation"),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 

--- a/internal/services/tracing_sink/sink.go
+++ b/internal/services/tracing_sink/sink.go
@@ -131,12 +131,12 @@ func (s *TraceSinkServer) GetAfter(ctx context.Context, request *pb.GetAfterRequ
 	var err error = nil
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 
 	defer func() {
 		// Pick up the current time to avoid repeatedly fetching the same value
-		ctx = common.ContextWithTick(ctx, clients.Tick(ctx))
+		ctx = common.ContextWithTick(ctx, timestamp.Tick(ctx))
 
 		if err != nil {
 			tracing.Warn(ctx, "GetAfter failed: %v", err)
@@ -183,7 +183,7 @@ func (s *TraceSinkServer) GetPolicy(ctx context.Context, _ *pb.GetPolicyRequest)
 	var resp *pb.GetPolicyResponse
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.EnsureTickInContext),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.AsInternal())
 	defer span.End()
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	clients "github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
+	"github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
 	"github.com/Jim3Things/CloudChamber/internal/tracing"
 )
 
@@ -49,7 +49,7 @@ func Show() {
 //
 func Trace() {
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(clients.OutsideTime))
+		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
 	tracing.Info(ctx, "===== Starting %q at %s =====", fmt.Sprint(os.Args), time.Now().Format(time.RFC1123Z))


### PR DESCRIPTION
As a holdover from our naive past, the timestamp package was improperly named the "clients" package. This change corrects that and updates all the references.