### PR TITLE
Inventory simulation - step 2

### DIFF
--- a/internal/common/guarded.go
+++ b/internal/common/guarded.go
@@ -1,0 +1,32 @@
+package common
+
+// Guarded provides basic support for access gated by last sequence value.  It
+// maintains the last sequence number used, and has functions that can be used
+// to refuse access based on out of order sequencing, as well as the maintenance
+// of the guard value itself.
+type Guarded struct {
+	// Guard is the last sequence number used
+	Guard int64
+}
+
+// Pass checks that the provided check value is not earlier than the guard.  If
+// it passes, the guard is updated with supplied current sequence value from
+// the at parameter.  This allows for checks based on values the caller last
+// saw, and for updates to provide something close to a linear sequence across
+// guarded objects.  Pass returns true if the check passes, and false if it
+// didn't.
+func (g *Guarded) Pass(check int64, at int64) bool {
+	if check < g.Guard {
+		return false
+	}
+
+	g.Guard = at
+	return true
+}
+
+// AdvanceGuard updates the guard value if the new value is greater than the
+// value the object already holds.
+func (g *Guarded) AdvanceGuard(at int64) {
+	g.Guard = MaxInt64(g.Guard, at)
+}
+

--- a/internal/services/inventory/cable.go
+++ b/internal/services/inventory/cable.go
@@ -1,0 +1,87 @@
+package inventory
+
+import (
+	"errors"
+
+	"github.com/Jim3Things/CloudChamber/internal/common"
+)
+
+var (
+	errStuck = errors.New("cable is faulted")
+	errTooLate = errors.New("cable modified after the requested time")
+)
+
+// cable describes the active state of a connecting cable from the one element
+// to a connected blade.  The connecting cable may be a power cable from the
+// PDU, a network cable from the TOR, or some other control cable.
+type cable struct {
+	common.Guarded
+
+	// on is true if the cable is actually connected and 'functioning' (i.e.
+	// providing power, if a PDU power cable)
+	on bool
+
+	// faulted is true if the cable connection is broken in such a way that the
+	// on state cannot be changed, and cannot be reliably determined for
+	// control.
+	faulted bool
+}
+
+
+func newCable(on bool, faulted bool, at int64) *cable {
+	return &cable{
+		Guarded: common.Guarded{
+			Guard: at,
+		},
+		on: on,
+		faulted: faulted,
+	}
+}
+
+// set
+func (c *cable) set(offOn bool, guard int64, at int64) (bool, error) {
+	if c.faulted {
+		return false, errStuck
+	}
+
+	if !c.Pass(guard, at) {
+		return false, errTooLate
+	}
+
+	startState := c.on
+	c.on = offOn
+
+	return c.on != startState, nil
+}
+
+func (c *cable) fault(offOn bool, guard int64, at int64) error {
+	if !c.Pass(guard, at) {
+		return errTooLate
+	}
+
+	c.faulted = true
+	c.on = offOn
+
+	return nil
+}
+
+func (c *cable) fix(guard int64, at int64) error {
+	if !c.Pass(guard, at) {
+		return errTooLate
+	}
+
+	c.faulted = false
+
+	return nil
+}
+
+func (c *cable) force(offOn bool, guard int64, at int64) (bool, error) {
+	if !c.Pass(guard, at) {
+		return false, errTooLate
+	}
+
+	startState := c.on
+
+	c.on = offOn
+	return c.on != startState, nil
+}

--- a/internal/services/inventory/cable.go
+++ b/internal/services/inventory/cable.go
@@ -27,7 +27,8 @@ type cable struct {
 	faulted bool
 }
 
-
+// newCable creates a new cable instance with the specified state and guard
+// values.
 func newCable(on bool, faulted bool, at int64) *cable {
 	return &cable{
 		Guarded: common.Guarded{
@@ -38,7 +39,9 @@ func newCable(on bool, faulted bool, at int64) *cable {
 	}
 }
 
-// set
+// set changes the on/off state for the cable, contingent upon the guard being
+// met and the cable not being faulted.  It returns whether the cable state
+// changed, and an error if the conditions for changing were not met.
 func (c *cable) set(offOn bool, guard int64, at int64) (bool, error) {
 	if c.faulted {
 		return false, errStuck
@@ -54,6 +57,8 @@ func (c *cable) set(offOn bool, guard int64, at int64) (bool, error) {
 	return c.on != startState, nil
 }
 
+// fault sets the cable to faulted, as well as the actual underlying state.  It
+// also requires that the guard check be met.
 func (c *cable) fault(offOn bool, guard int64, at int64) error {
 	if !c.Pass(guard, at) {
 		return errTooLate
@@ -65,6 +70,7 @@ func (c *cable) fault(offOn bool, guard int64, at int64) error {
 	return nil
 }
 
+// fix is the inverse of fault, in that it clears the faulted state.
 func (c *cable) fix(guard int64, at int64) error {
 	if !c.Pass(guard, at) {
 		return errTooLate
@@ -75,6 +81,7 @@ func (c *cable) fix(guard int64, at int64) error {
 	return nil
 }
 
+// force sets the underlying state of the cable, even if it is faulted.
 func (c *cable) force(offOn bool, guard int64, at int64) (bool, error) {
 	if !c.Pass(guard, at) {
 		return false, errTooLate

--- a/internal/services/inventory/inventory.go
+++ b/internal/services/inventory/inventory.go
@@ -6,27 +6,24 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/Jim3Things/CloudChamber/internal/config"
+	"github.com/Jim3Things/CloudChamber/internal/tracing"
 	pb "github.com/Jim3Things/CloudChamber/pkg/protos/services"
 )
 
 type server struct {
 	pb.UnimplementedInventoryServer
 
-	racks map[string]rack
+	racks map[string]*rack
 }
 
 func Register(svc *grpc.Server, cfg *config.GlobalConfig) error {
 	s := &server {
-
+		racks: make(map[string]*rack),
 	}
 
-	// Read the configuration to get the inventory link
-
-	// Read the inventory
-
-	// For each rack, create a rack item, supplying the tor, pdu, and blade
-
-	// Start each rack (this gives us a channel and a goroutine)
+	if err := s.initializeRacks(cfg.Inventory.InventoryDefinition); err != nil {
+		return err
+	}
 
 	pb.RegisterInventoryServer(svc, s)
 
@@ -49,3 +46,25 @@ func (s *server) GetCurrentStatus(context.Context, *pb.InventoryStatusMsg) (*pb.
 	return nil, nil
 }
 
+func (s *server) initializeRacks(path string) error {
+	ctx, span := tracing.StartSpan(context.Background(), tracing.WithName("Initializing the simulated inventory"))
+	defer span.End()
+
+	zone, err := config.ReadInventoryDefinition(path)
+	if err != nil {
+		return err
+	}
+
+	for name, r := range zone.Racks {
+		// For each rack, create a rack item, supplying the tor, pdu, and blade
+		tracing.Info(ctx, "Adding rack %q", name)
+		s.racks[name] = newRack(ctx, r)
+
+		// Start each rack (this gives us a channel and a goroutine)
+		if err = s.racks[name].start(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/services/inventory/pdu.go
+++ b/internal/services/inventory/pdu.go
@@ -24,11 +24,6 @@ type pdu struct {
 	sm *sm.SimpleSM
 }
 
-// Receive handles incoming messages for the PDU.
-func (p *pdu) Receive(ctx context.Context, msg interface{}, ch chan interface{}) {
-	p.sm.Receive(ctx, msg, ch)
-}
-
 const (
 	// pduWorkingState is the state ID for the PDU powered on and working
 	// state.
@@ -70,6 +65,11 @@ func (p *pdu) fixConnection(ctx context.Context, id int64) {
 	p.sm.AdvanceGuard(at)
 
 	p.cables[id] = newCable(false, false, at)
+}
+
+// Receive handles incoming messages for the PDU.
+func (p *pdu) Receive(ctx context.Context, msg interface{}, ch chan interface{}) {
+	p.sm.Receive(ctx, msg, ch)
 }
 
 // newStatusReport is a helper function to construct a status response for this

--- a/internal/services/inventory/pdu.go
+++ b/internal/services/inventory/pdu.go
@@ -72,14 +72,6 @@ func (p *pdu) fixConnection(ctx context.Context, id int64) {
 	p.cables[id] = newCable(false, false, at)
 }
 
-// forwardToBlade is a helper function that forwards a message to the target
-// blade in the containing rack.
-func (p *pdu) forwardToBlade(ctx context.Context, id int64, msg interface{}, ch chan interface{}) {
-	if b, ok := p.holder.blades[id]; ok {
-		b.Receive(ctx, msg, ch)
-	}
-}
-
 // newStatusReport is a helper function to construct a status response for this
 // PDU.
 func (p *pdu) newStatusReport(
@@ -174,7 +166,7 @@ func (s *pduWorking) changePower(
 					if changed && err == nil {
 						// power is on to this blade.  Turn it off, but tell
 						// the blade to not reply, as this is a side effect.
-						p.forwardToBlade(ctx, i, power, nil)
+						p.holder.forwardToBlade(ctx, i, power, nil)
 					}
 				}
 
@@ -198,7 +190,7 @@ func (s *pduWorking) changePower(
 				sm.AdvanceGuard(occursAt)
 
 				if changed {
-					p.forwardToBlade(ctx, id, power, ch)
+					p.holder.forwardToBlade(ctx, id, power, ch)
 				}
 
 				ch <- successResponse(target, occursAt)

--- a/internal/services/inventory/pdu_test.go
+++ b/internal/services/inventory/pdu_test.go
@@ -52,6 +52,7 @@ func (ts *PduTestSuite) TestCreatePdu() {
 
 	for _, c := range p.cables {
 		assert.False(c.on)
+		assert.False(c.faulted)
 	}
 }
 
@@ -246,6 +247,7 @@ func (ts *PduTestSuite) TestPowerOnBlade() {
 	assert.Equal(common.TickFromContext(ctx), r.pdu.sm.Guard)
 	assert.Equal(common.TickFromContext(ctx), r.pdu.cables[0].Guard)
 	assert.True(r.pdu.cables[0].on)
+	assert.False(r.pdu.cables[0].faulted)
 
 	assert.Equal("working", r.pdu.sm.Current.Name())
 }

--- a/internal/services/inventory/pdu_test.go
+++ b/internal/services/inventory/pdu_test.go
@@ -50,8 +50,8 @@ func (ts *PduTestSuite) TestCreatePdu() {
 
 	assert.Equal("working", p.sm.Current.Name())
 
-	for _, cable := range p.cables {
-		assert.False(cable.on)
+	for _, c := range p.cables {
+		assert.False(c.on)
 	}
 }
 
@@ -67,10 +67,7 @@ func (ts *PduTestSuite) TestBadPowerTarget() {
 	ctx = common.ContextWithTick(ctx, 2)
 
 	for i := range r.pdu.cables {
-		r.pdu.cables[i] = cableState{
-			on: true,
-			at: 0,
-		}
+		r.pdu.cables[i] = newCable(true, false, 0)
 	}
 
 	rsp := make(chan interface{})
@@ -104,8 +101,8 @@ func (ts *PduTestSuite) TestBadPowerTarget() {
 
 	assert.Equal("working", r.pdu.sm.Current.Name())
 
-	for _, cable := range r.pdu.cables {
-		assert.True(cable.on)
+	for _, c := range r.pdu.cables {
+		assert.True(c.on)
 	}
 
 	assert.Equal("invalid target specified, request ignored", reason.Failed)
@@ -151,8 +148,8 @@ func (ts *PduTestSuite) TestPowerOffPdu() {
 	assert.Equal(msg.Target, repairResp.Source)
 	assert.Equal(common.TickFromContext(ctx), repairResp.At.Ticks)
 
-	for _, cable := range r.pdu.cables {
-		assert.False(cable.on)
+	for _, c := range r.pdu.cables {
+		assert.False(c.on)
 	}
 
 	assert.Equal("off", r.pdu.sm.Current.Name())
@@ -198,8 +195,8 @@ func (ts *PduTestSuite) TestPowerOnPdu() {
 	assert.Equal(msg.Target, repairResp.Source)
 	assert.Equal(common.TickFromContext(ctx), repairResp.At.Ticks)
 
-	for _, cable := range r.pdu.cables {
-		assert.False(cable.on)
+	for _, c := range r.pdu.cables {
+		assert.False(c.on)
 	}
 
 	assert.Equal("working", r.pdu.sm.Current.Name())
@@ -246,11 +243,163 @@ func (ts *PduTestSuite) TestPowerOnBlade() {
 
 	assert.Equal(msg.Target, repairResp.Source)
 	assert.Equal(common.TickFromContext(ctx), repairResp.At.Ticks)
-	assert.Equal(common.TickFromContext(ctx), r.pdu.sm.At)
-	assert.Equal(common.TickFromContext(ctx), r.pdu.cables[0].at)
+	assert.Equal(common.TickFromContext(ctx), r.pdu.sm.Guard)
+	assert.Equal(common.TickFromContext(ctx), r.pdu.cables[0].Guard)
 	assert.True(r.pdu.cables[0].on)
 
 	assert.Equal("working", r.pdu.sm.Current.Name())
+}
+
+func (ts *PduTestSuite) TestPowerOnBladeTooLate() {
+	require := ts.Require()
+	assert := ts.Assert()
+
+	startTime := int64(1)
+	ctx := common.ContextWithTick(context.Background(), startTime)
+
+	rackDef := createDummyRack(2)
+
+	r := newRack(ctx, rackDef)
+	ctx = common.ContextWithTick(ctx, 2)
+
+	rsp := make(chan interface{})
+
+	msg := &services.InventoryRepairMsg{
+		Target: &services.InventoryAddress{
+			Rack:    "",
+			Element: &services.InventoryAddress_BladeId{
+				BladeId: 0,
+			},
+		},
+		After:  &ct.Timestamp{Ticks: startTime - 1},
+		Action: &services.InventoryRepairMsg_Power{
+			Power: true,
+		},
+	}
+
+	go func() {
+		r.pdu.Receive(ctx, msg, rsp)
+	}()
+
+	res := common.CompleteWithinInterface(rsp, time.Duration(1) * time.Second)
+	assert.NotNil(res)
+
+	repairResp, ok := res.(*services.InventoryRepairResp)
+	require.True(ok)
+
+	_, ok = repairResp.Rsp.(*services.InventoryRepairResp_Dropped)
+	require.True(ok)
+
+	assert.Equal(msg.Target, repairResp.Source)
+	assert.Equal(common.TickFromContext(ctx), repairResp.At.Ticks)
+	assert.Equal(startTime, r.pdu.sm.Guard)
+	assert.Equal(startTime, r.pdu.cables[0].Guard)
+	assert.False(r.pdu.cables[0].on)
+
+	assert.Equal("working", r.pdu.sm.Current.Name())
+}
+
+func (ts *PduTestSuite) TestStuckCable() {
+	require := ts.Require()
+	assert := ts.Assert()
+
+	ctx := common.ContextWithTick(context.Background(), 1)
+
+	rackDef := createDummyRack(2)
+
+	r := newRack(ctx, rackDef)
+
+	startTime := common.TickFromContext(ctx)
+	require.Nil(r.pdu.cables[0].fault(false, startTime, startTime))
+	ctx = common.ContextWithTick(ctx, 2)
+
+	rsp := make(chan interface{})
+
+	msg := &services.InventoryRepairMsg{
+		Target: &services.InventoryAddress{
+			Rack:    "",
+			Element: &services.InventoryAddress_BladeId{
+				BladeId: 0,
+			},
+		},
+		After:  &ct.Timestamp{Ticks: common.TickFromContext(ctx)},
+		Action: &services.InventoryRepairMsg_Power{
+			Power: true,
+		},
+	}
+
+	go func() {
+		r.pdu.Receive(ctx, msg, rsp)
+	}()
+
+	res := common.CompleteWithinInterface(rsp, time.Duration(1) * time.Second)
+	assert.NotNil(res)
+
+	repairResp, ok := res.(*services.InventoryRepairResp)
+	require.True(ok)
+
+	resp, ok := repairResp.Rsp.(*services.InventoryRepairResp_Failed)
+	require.True(ok)
+	assert.Equal(resp.Failed, "cable is faulted")
+
+	assert.Equal(msg.Target, repairResp.Source)
+	assert.Equal(common.TickFromContext(ctx), repairResp.At.Ticks)
+	assert.Equal(startTime, r.pdu.sm.Guard)
+	assert.Equal(startTime, r.pdu.cables[0].Guard)
+	assert.False(r.pdu.cables[0].on)
+	assert.Equal(true, r.pdu.cables[0].faulted)
+
+	assert.Equal("working", r.pdu.sm.Current.Name())
+}
+
+func (ts *PduTestSuite) TestStuckCablePduOff() {
+	require := ts.Require()
+	assert := ts.Assert()
+
+	ctx := common.ContextWithTick(context.Background(), 1)
+
+	rackDef := createDummyRack(2)
+
+	r := newRack(ctx, rackDef)
+
+	startTime := common.TickFromContext(ctx)
+	require.Nil(r.pdu.cables[0].fault(true, startTime, startTime))
+	ctx = common.ContextWithTick(ctx, 2)
+
+	rsp := make(chan interface{})
+
+	msg := &services.InventoryRepairMsg{
+		Target: &services.InventoryAddress{
+			Rack:    "",
+			Element: &services.InventoryAddress_Pdu{},
+		},
+		After:  &ct.Timestamp{Ticks: common.TickFromContext(ctx)},
+		Action: &services.InventoryRepairMsg_Power{
+			Power: false,
+		},
+	}
+
+	go func() {
+		r.pdu.Receive(ctx, msg, rsp)
+	}()
+
+	res := common.CompleteWithinInterface(rsp, time.Duration(1) * time.Second)
+	assert.NotNil(res)
+
+	repairResp, ok := res.(*services.InventoryRepairResp)
+	require.True(ok)
+
+	_, ok = repairResp.Rsp.(*services.InventoryRepairResp_Dropped)
+	require.True(ok)
+
+	assert.Equal(msg.Target, repairResp.Source)
+	assert.Equal(common.TickFromContext(ctx), repairResp.At.Ticks)
+
+	for _, c := range r.pdu.cables {
+		assert.False(c.on)
+	}
+
+	assert.Equal("off", r.pdu.sm.Current.Name())
 }
 
 func TestPduTestSuite(t *testing.T) {

--- a/internal/services/inventory/rack.go
+++ b/internal/services/inventory/rack.go
@@ -70,3 +70,11 @@ type rackFailed struct {
 }
 
 func (s *rackFailed) Name() string { return "failed" }
+
+// forwardToBlade is a helper function that forwards a message to the target
+// blade in this rack.
+func (r *rack) forwardToBlade(ctx context.Context, id int64, msg interface{}, ch chan interface{}) {
+	if b, ok := r.blades[id]; ok {
+		b.Receive(ctx, msg, ch)
+	}
+}

--- a/internal/services/inventory/rack.go
+++ b/internal/services/inventory/rack.go
@@ -24,7 +24,7 @@ const (
 func newRack(ctx context.Context, def *pb.ExternalRack) *rack {
 	r := &rack{
 		ch:     make(chan interface{}),
-		tor:    newTor(def.Tor),
+		tor:    nil,
 		pdu:    nil,
 		blades: make(map[int64]*blade),
 		sm:     nil,
@@ -36,6 +36,7 @@ func newRack(ctx context.Context, def *pb.ExternalRack) *rack {
 	)
 
 	r.pdu = newPdu(def.Pdu, r)
+	r.tor = newTor(def.Tor, r)
 
 	for i, item := range def.Blades {
 		r.blades[i] = newBlade(item)
@@ -43,7 +44,7 @@ func newRack(ctx context.Context, def *pb.ExternalRack) *rack {
 		// These two calls are temporary fixups until the inventory definition
 		// includes the tor and pdu connectors
 		r.pdu.fixConnection(ctx, i)
-		r.tor.fixConnection(i)
+		r.tor.fixConnection(ctx, i)
 	}
 
 	return r

--- a/internal/services/inventory/rack.go
+++ b/internal/services/inventory/rack.go
@@ -41,7 +41,7 @@ func newRack(ctx context.Context, def *pb.ExternalRack) *rack {
 	for i, item := range def.Blades {
 		r.blades[i] = newBlade(item)
 
-		// These two calls are temporary fixups until the inventory definition
+		// These two calls are temporary fix-ups until the inventory definition
 		// includes the tor and pdu connectors
 		r.pdu.fixConnection(ctx, i)
 		r.tor.fixConnection(ctx, i)

--- a/internal/services/inventory/tor.go
+++ b/internal/services/inventory/tor.go
@@ -5,7 +5,10 @@ import (
 
 	"github.com/Jim3Things/CloudChamber/internal/common"
 	"github.com/Jim3Things/CloudChamber/internal/sm"
+	"github.com/Jim3Things/CloudChamber/internal/tracing"
+	ct "github.com/Jim3Things/CloudChamber/pkg/protos/common"
 	pb "github.com/Jim3Things/CloudChamber/pkg/protos/inventory"
+	"github.com/Jim3Things/CloudChamber/pkg/protos/services"
 )
 
 type tor struct {
@@ -15,14 +18,21 @@ type tor struct {
 	sm *sm.SimpleSM
 }
 
-func newTor(ext *pb.ExternalTor, r *rack) *tor {
+const (
+	torWorkingState int = iota
+	torStuckState
+)
+
+func newTor(_ *pb.ExternalTor, r *rack) *tor {
 	t := &tor {
 		cables: make(map[int64]*cable),
 		holder: r,
 		sm: nil,
 	}
 
-	t.sm = sm.NewSimpleSM(t)
+	t.sm = sm.NewSimpleSM(t,
+		sm.WithFirstState(torWorkingState, &torWorking{}),
+		sm.WithState(torStuckState, &torStuck{}))
 
 	return t
 }
@@ -35,6 +45,112 @@ func (t *tor) fixConnection(ctx context.Context, id int64) {
 	t.cables[id] = newCable(false, false, at)
 }
 
+// newStatusReport is a helper function to construct a status response for this
+// PDU.
+func (t *tor) newStatusReport(
+	ctx context.Context,
+	target *services.InventoryAddress) *services.InventoryStatusResp {
+	return nil
+}
+
 type torWorking struct {
 	sm.NullState
 }
+
+func (s *torWorking) Receive(ctx context.Context, sm *sm.SimpleSM, msg interface{}, ch chan interface{}) {
+	t := sm.Parent.(*tor)
+
+	switch msg := msg.(type) {
+	case *services.InventoryRepairMsg:
+		if connect, ok := msg.GetAction().(*services.InventoryRepairMsg_Connect); ok {
+			s.changeConnection(ctx, sm, msg.Target, msg.After, connect, ch)
+			return
+		}
+
+		// Any other type of repair command, the tor ignores.
+		ch <- droppedResponse(msg.Target, common.TickFromContext(ctx))
+		return
+
+	case *services.InventoryStatusMsg:
+		ch <- t.newStatusReport(ctx, msg.Target)
+		return
+
+	default:
+		// Invalid message.  This should not happen, and we have no way to
+		// send an error back.  Panic.
+		tracing.Fatal(ctx, "Invalid message received: %v", msg)
+		return
+	}
+}
+
+func (s *torWorking) changeConnection(
+	ctx context.Context,
+	sm *sm.SimpleSM,
+	target *services.InventoryAddress,
+	after *ct.Timestamp,
+	connect *services.InventoryRepairMsg_Connect,
+	ch chan interface{}) {
+	t := sm.Parent.(*tor)
+
+	occursAt := common.TickFromContext(ctx)
+
+
+	switch elem := target.Element.(type) {
+	case *services.InventoryAddress_BladeId:
+		id := elem.BladeId
+
+		if _, ok := t.cables[id]; ok {
+			if changed, err := t.cables[id].set(connect.Connect, after.Ticks, occursAt); err == nil {
+				sm.AdvanceGuard(occursAt)
+
+				if changed {
+					t.holder.forwardToBlade(ctx, id, connect, ch)
+				}
+
+				ch <- successResponse(target, occursAt)
+			} else if err == errStuck {
+				ch <- failedResponse(target, occursAt, err.Error())
+			} else {
+				ch <- droppedResponse(target, occursAt)
+			}
+
+			return
+		}
+
+	default:
+		ch <- failedResponse(
+			target, occursAt, "invalid target specified, request ignored")
+	}
+}
+
+func (s *torWorking) Name() string { return "working" }
+
+// torStuck is the state a TOR is in when it is unresponsive to commands, but
+// is still powered on.  By implication, the connection state for each cable is
+// also stuck.
+type torStuck struct {
+	sm.NullState
+}
+
+// Receive processes incoming requests for this state.
+func (s *torStuck) Receive(ctx context.Context, sm *sm.SimpleSM, msg interface{}, ch chan interface{}) {
+	t := sm.Parent.(*tor)
+
+	switch msg := msg.(type) {
+	case *services.InventoryRepairMsg:
+		// the TOR is not responding to commands, so no repairs can be
+		// processed.
+		ch <- droppedResponse(msg.Target, common.TickFromContext(ctx))
+		return
+
+	case *services.InventoryStatusMsg:
+		ch <- t.newStatusReport(ctx, msg.Target)
+		return
+
+	default:
+		return
+	}
+}
+
+// Name returns the friendly name for this state.
+func (s *torStuck) Name() string { return "stuck" }

--- a/internal/services/inventory/tor.go
+++ b/internal/services/inventory/tor.go
@@ -1,21 +1,40 @@
 package inventory
 
 import (
+	"context"
+
+	"github.com/Jim3Things/CloudChamber/internal/common"
 	"github.com/Jim3Things/CloudChamber/internal/sm"
 	pb "github.com/Jim3Things/CloudChamber/pkg/protos/inventory"
 )
 
 type tor struct {
-	cables map[int64]bool
+	cables map[int64]*cable
 	holder *rack
 
 	sm *sm.SimpleSM
 }
 
-func newTor(t *pb.ExternalTor) *tor {
-	return nil
+func newTor(ext *pb.ExternalTor, r *rack) *tor {
+	t := &tor {
+		cables: make(map[int64]*cable),
+		holder: r,
+		sm: nil,
+	}
+
+	t.sm = sm.NewSimpleSM(t)
+
+	return t
 }
 
-func (t *tor) fixConnection(id int64) {
+func (t *tor) fixConnection(ctx context.Context, id int64) {
+	at := common.TickFromContext(ctx)
 
+	t.sm.AdvanceGuard(at)
+
+	t.cables[id] = newCable(false, false, at)
+}
+
+type torWorking struct {
+	sm.NullState
 }

--- a/internal/services/inventory/tor.go
+++ b/internal/services/inventory/tor.go
@@ -11,18 +11,36 @@ import (
 	"github.com/Jim3Things/CloudChamber/pkg/protos/services"
 )
 
+// tor defines the state required to simulate a top-of-rack network
+// switch.  The simulation is relatively shallow - it is a controller
+// with cables that connect to a blade.  Because of this, it is similar to
+// the simulation of a PDU, at this time.
 type tor struct {
+	// cables are the network connections to the rack's blades.  They are
+	// either programmed and working, or un-programmed (black-holed).  They
+	// can also be in a faulted state.
 	cables map[int64]*cable
+
+	// rack holds the pointer to the rack that contains this TOR.
 	holder *rack
 
+	// sm is the state machine fro this TOR's simulation
 	sm *sm.SimpleSM
 }
 
 const (
+	// torWorkingState is the ID for when the TOR is fully operational.
 	torWorkingState int = iota
+
+	// torStuckState is the ID for when the TOR is faulted and unresponsive.
+	// Note that programmed cables may or may not continue to be programmed.
 	torStuckState
 )
 
+// newTor creates a new simulated TOR instance from the definition structure
+// and the containing rack.  Note that it currently does not fill in the cable
+// information, as that is missing from the inventory definition.  That is
+// done is the fixConnection function below.
 func newTor(_ *pb.ExternalTor, r *rack) *tor {
 	t := &tor {
 		cables: make(map[int64]*cable),
@@ -37,6 +55,9 @@ func newTor(_ *pb.ExternalTor, r *rack) *tor {
 	return t
 }
 
+// fixConnection updates the TOR with presumed cable definitions to match up
+// with the blades defined for the rack.  This is a temporary workaround until
+// the inventory definition structures include the cable definitions.
 func (t *tor) fixConnection(ctx context.Context, id int64) {
 	at := common.TickFromContext(ctx)
 
@@ -45,18 +66,25 @@ func (t *tor) fixConnection(ctx context.Context, id int64) {
 	t.cables[id] = newCable(false, false, at)
 }
 
+// Receive handles incoming messages for the TOR.
+func (t *tor) Receive(ctx context.Context, msg interface{}, ch chan interface{}) {
+	t.sm.Receive(ctx, msg, ch)
+}
+
 // newStatusReport is a helper function to construct a status response for this
-// PDU.
+// TOR.
 func (t *tor) newStatusReport(
 	ctx context.Context,
 	target *services.InventoryAddress) *services.InventoryStatusResp {
 	return nil
 }
 
+// torWorking is the state a TOR is in when it is functioning correctly.
 type torWorking struct {
 	sm.NullState
 }
 
+// Receive processes incoming requests for this state.
 func (s *torWorking) Receive(ctx context.Context, sm *sm.SimpleSM, msg interface{}, ch chan interface{}) {
 	t := sm.Parent.(*tor)
 
@@ -83,6 +111,11 @@ func (s *torWorking) Receive(ctx context.Context, sm *sm.SimpleSM, msg interface
 	}
 }
 
+// Name returns the friendly name for this state.
+func (s *torWorking) Name() string { return "working" }
+
+// changeConnection implements the repair operation to program or deprogram a
+// network cable in the TOR.
 func (s *torWorking) changeConnection(
 	ctx context.Context,
 	sm *sm.SimpleSM,
@@ -122,8 +155,6 @@ func (s *torWorking) changeConnection(
 			target, occursAt, "invalid target specified, request ignored")
 	}
 }
-
-func (s *torWorking) Name() string { return "working" }
 
 // torStuck is the state a TOR is in when it is unresponsive to commands, but
 // is still powered on.  By implication, the connection state for each cable is

--- a/internal/services/inventory/tor_test.go
+++ b/internal/services/inventory/tor_test.go
@@ -1,0 +1,271 @@
+package inventory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/Jim3Things/CloudChamber/internal/common"
+	"github.com/Jim3Things/CloudChamber/internal/tracing/exporters"
+	ct "github.com/Jim3Things/CloudChamber/pkg/protos/common"
+	"github.com/Jim3Things/CloudChamber/pkg/protos/services"
+)
+
+type TorTestSuite struct {
+	suite.Suite
+
+	utf *exporters.Exporter
+}
+
+func (ts *TorTestSuite) SetupSuite() {
+	ts.utf = exporters.NewExporter(exporters.NewUTForwarder())
+	exporters.ConnectToProvider(ts.utf)
+}
+
+func (ts *TorTestSuite) SetupTest() {
+	_ = ts.utf.Open(ts.T())
+}
+
+func (ts *TorTestSuite) TearDownTest() {
+	ts.utf.Close()
+}
+
+func (ts *TorTestSuite) TestCreateTor() {
+	require := ts.Require()
+	assert := ts.Assert()
+
+	rackDef := createDummyRack(2)
+
+	r := newRack(context.Background(), rackDef)
+	require.NotNil(r)
+
+	t := r.tor
+	require.NotNil(t)
+
+	assert.Equal(2, len(t.cables))
+
+	assert.Equal("working", t.sm.Current.Name())
+
+	for _, c := range t.cables {
+		assert.False(c.on)
+		assert.False(c.faulted)
+	}
+}
+
+func (ts *TorTestSuite) TestBadConnectionTarget() {
+	require := ts.Require()
+	assert := ts.Assert()
+
+	ctx := common.ContextWithTick(context.Background(), 1)
+
+	rackDef := createDummyRack(2)
+
+	r := newRack(ctx, rackDef)
+	ctx = common.ContextWithTick(ctx, 2)
+
+	t := r.tor
+	require.NotNil(t)
+
+	for i := range t.cables {
+		t.cables[i] = newCable(true, false, 0)
+	}
+
+	rsp := make(chan interface{})
+
+	badMsg := &services.InventoryRepairMsg{
+		Target: &services.InventoryAddress{
+			Rack:    "",
+			Element: &services.InventoryAddress_Tor{},
+		},
+		After:  &ct.Timestamp{Ticks: common.TickFromContext(ctx)},
+		Action: &services.InventoryRepairMsg_Connect{
+			Connect: false,
+		},
+	}
+
+	go func() {
+		t.Receive(ctx, badMsg, rsp)
+	}()
+
+	res := common.CompleteWithinInterface(rsp, time.Duration(1) * time.Second)
+	assert.NotNil(res)
+
+	repairResp, ok := res.(*services.InventoryRepairResp)
+	require.True(ok)
+
+	reason, ok := repairResp.Rsp.(*services.InventoryRepairResp_Failed)
+	require.True(ok)
+
+	assert.Equal(badMsg.Target, repairResp.Source)
+	assert.Equal(common.TickFromContext(ctx), repairResp.At.Ticks)
+
+	assert.Equal("working", t.sm.Current.Name())
+
+	for _, c := range t.cables {
+		assert.True(c.on)
+	}
+
+	assert.Equal("invalid target specified, request ignored", reason.Failed)
+}
+
+func (ts *TorTestSuite) TestConnectBlade() {
+	require := ts.Require()
+	assert := ts.Assert()
+
+	ctx := common.ContextWithTick(context.Background(), 1)
+
+	rackDef := createDummyRack(2)
+
+	r := newRack(ctx, rackDef)
+	require.NotNil(r)
+	t := r.tor
+
+	ctx = common.ContextWithTick(ctx, 2)
+
+	rsp := make(chan interface{})
+
+	msg := &services.InventoryRepairMsg{
+		Target: &services.InventoryAddress{
+			Rack:    "",
+			Element: &services.InventoryAddress_BladeId{
+				BladeId: 0,
+			},
+		},
+		After:  &ct.Timestamp{Ticks: common.TickFromContext(ctx)},
+		Action: &services.InventoryRepairMsg_Connect{
+			Connect: true,
+		},
+	}
+
+	go func() {
+		t.Receive(ctx, msg, rsp)
+	}()
+
+	res := common.CompleteWithinInterface(rsp, time.Duration(1) * time.Second)
+	assert.NotNil(res)
+
+	repairResp, ok := res.(*services.InventoryRepairResp)
+	require.True(ok)
+
+	_, ok = repairResp.Rsp.(*services.InventoryRepairResp_Success)
+	require.True(ok)
+
+	assert.Equal(msg.Target, repairResp.Source)
+	assert.Equal(common.TickFromContext(ctx), repairResp.At.Ticks)
+	assert.Equal(common.TickFromContext(ctx), t.sm.Guard)
+	assert.Equal(common.TickFromContext(ctx), t.cables[0].Guard)
+	assert.True(t.cables[0].on)
+	assert.False(t.cables[0].faulted)
+
+	assert.Equal("working", t.sm.Current.Name())
+}
+
+func (ts *TorTestSuite) TestConnectTooLate() {
+	require := ts.Require()
+	assert := ts.Assert()
+
+	startTime := int64(1)
+	ctx := common.ContextWithTick(context.Background(), startTime)
+
+	rackDef := createDummyRack(2)
+
+	r := newRack(ctx, rackDef)
+	t := r.tor
+	ctx = common.ContextWithTick(ctx, 2)
+
+	rsp := make(chan interface{})
+
+	msg := &services.InventoryRepairMsg{
+		Target: &services.InventoryAddress{
+			Rack:    "",
+			Element: &services.InventoryAddress_BladeId{
+				BladeId: 0,
+			},
+		},
+		After:  &ct.Timestamp{Ticks: startTime - 1},
+		Action: &services.InventoryRepairMsg_Power{
+			Power: true,
+		},
+	}
+
+	go func() {
+		t.Receive(ctx, msg, rsp)
+	}()
+
+	res := common.CompleteWithinInterface(rsp, time.Duration(1) * time.Second)
+	assert.NotNil(res)
+
+	repairResp, ok := res.(*services.InventoryRepairResp)
+	require.True(ok)
+
+	_, ok = repairResp.Rsp.(*services.InventoryRepairResp_Dropped)
+	require.True(ok)
+
+	assert.Equal(msg.Target, repairResp.Source)
+	assert.Equal(common.TickFromContext(ctx), repairResp.At.Ticks)
+	assert.Equal(startTime, t.sm.Guard)
+	assert.Equal(startTime, t.cables[0].Guard)
+	assert.False(t.cables[0].on)
+
+	assert.Equal("working", t.sm.Current.Name())
+}
+
+func (ts *TorTestSuite) TestStuckCable() {
+	require := ts.Require()
+	assert := ts.Assert()
+
+	ctx := common.ContextWithTick(context.Background(), 1)
+
+	rackDef := createDummyRack(2)
+
+	r := newRack(ctx, rackDef)
+	t := r.tor
+
+	startTime := common.TickFromContext(ctx)
+	require.Nil(t.cables[0].fault(false, startTime, startTime))
+	ctx = common.ContextWithTick(ctx, 2)
+
+	rsp := make(chan interface{})
+
+	msg := &services.InventoryRepairMsg{
+		Target: &services.InventoryAddress{
+			Rack:    "",
+			Element: &services.InventoryAddress_BladeId{
+				BladeId: 0,
+			},
+		},
+		After:  &ct.Timestamp{Ticks: common.TickFromContext(ctx)},
+		Action: &services.InventoryRepairMsg_Connect{
+			Connect: true,
+		},
+	}
+
+	go func() {
+		t.Receive(ctx, msg, rsp)
+	}()
+
+	res := common.CompleteWithinInterface(rsp, time.Duration(1) * time.Second)
+	assert.NotNil(res)
+
+	repairResp, ok := res.(*services.InventoryRepairResp)
+	require.True(ok)
+
+	resp, ok := repairResp.Rsp.(*services.InventoryRepairResp_Failed)
+	require.True(ok)
+	assert.Equal(resp.Failed, "cable is faulted")
+
+	assert.Equal(msg.Target, repairResp.Source)
+	assert.Equal(common.TickFromContext(ctx), repairResp.At.Ticks)
+	assert.Equal(startTime, t.sm.Guard)
+	assert.Equal(startTime, t.cables[0].Guard)
+	assert.False(t.cables[0].on)
+	assert.Equal(true, t.cables[0].faulted)
+
+	assert.Equal("working", t.sm.Current.Name())
+}
+
+func TestTorTestSuite(t *testing.T) {
+	suite.Run(t, new(TorTestSuite))
+}

--- a/internal/sm/simpleSm.go
+++ b/internal/sm/simpleSm.go
@@ -43,6 +43,7 @@ func (x *NullState) Name() string { return "NullState" }
 // issues of concurrency and lifecycle management are handled by some external
 // logic.
 type SimpleSM struct {
+	common.Guarded
 
 	// CurrentIndex holds the index to the current state
 	CurrentIndex int
@@ -59,9 +60,6 @@ type SimpleSM struct {
 	// Parent points to the structure that holds this state machine, and likely
 	// holds global context that the state actions need.
 	Parent interface{}
-
-	// At is the simulated time tick when the current state was entered.
-	At int64
 }
 
 // StateDecl defines the type expected for a state declaration decorator when
@@ -120,7 +118,7 @@ func (sm *SimpleSM) ChangeState(ctx context.Context, newState int) error {
 
 	sm.CurrentIndex = newState
 	sm.Current = cur
-	sm.At = common.TickFromContext(ctx)
+	sm.AdvanceGuard(common.TickFromContext(ctx))
 	return nil
 }
 

--- a/pkg/protos/services/inventory.proto
+++ b/pkg/protos/services/inventory.proto
@@ -65,6 +65,11 @@ message InventoryRepairMsg {
 
         // boot defines the (re-)booting action.
         BootStyle boot = 4;
+
+        // connect defines whether the target network cable is connected or
+        // not.  The value is true if it is connected, otherwise it is false.
+        // This repair must target a blade.
+        bool connect = 5;
     }
 }
 


### PR DESCRIPTION
This contains the initial TOR simulation.  It is currently similar to the PDU, but that is likely to change as we go forward.  Again, like with the PDU change, this only accounts for the repair operations.  The status calls are currently not implemented.