### PR TITLE
Add linked-to support to tracing subsystem

### DIFF
--- a/internal/services/inventory/pdu_test.go
+++ b/internal/services/inventory/pdu_test.go
@@ -67,7 +67,6 @@ func execute(ctx context.Context, msg *sm.Envelope, action func(ctx2 context.Con
 
 		c2 = common.ContextWithTick(c2, tick)
 
-
 		action(c2, msg)
 
 		s.End()

--- a/internal/services/inventory/rack_test.go
+++ b/internal/services/inventory/rack_test.go
@@ -52,7 +52,11 @@ func (ts *RackTestSuite) TestStartStopRack() {
 	ctx := common.ContextWithTick(context.Background(), 1)
 
 	rackDef := createDummyRack(2)
-	ctx, span := tracing.StartSpan(ctx, tracing.WithName("test rack start and stop"))
+
+	ctx, span := tracing.StartSpan(
+		ctx,
+		tracing.WithName("test rack start and stop"))
+
 	r := newRack(ctx, rackDef)
 	require.NotNil(r)
 	assert.Equal(len(rackDef.Blades), len(r.blades))

--- a/internal/services/inventory/tor.go
+++ b/internal/services/inventory/tor.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"go.opentelemetry.io/otel/api/trace"
-
 	"github.com/Jim3Things/CloudChamber/internal/common"
 	"github.com/Jim3Things/CloudChamber/internal/sm"
 	ct "github.com/Jim3Things/CloudChamber/pkg/protos/common"
@@ -137,15 +135,14 @@ func (s *torWorking) changeConnection(
 				machine.AdvanceGuard(occursAt)
 
 				if changed {
-					fwd := &sm.Envelope{
-						Ch:   ch,
-						Span: trace.SpanFromContext(ctx).SpanContext(),
-						Msg:  &services.InventoryRepairMsg{
+					fwd := sm.NewEnvelope(
+						ctx,
+						&services.InventoryRepairMsg{
 							Target: target,
 							After:  after,
 							Action: connect,
 						},
-					}
+						ch)
 
 					t.holder.forwardToBlade(ctx, id, fwd)
 				}

--- a/internal/tracing/constants.go
+++ b/internal/tracing/constants.go
@@ -14,6 +14,9 @@ const (
 	SourceSpanID    = "cc-starting-span-span-id"
 	SourceTraceFlgs = "cc-starting-span-trace-flags"
 
+	// link tracking keys
+	LinkTagKey      = "cc-link-tag"
+
 	// rpc injection keys
 	InfraSourceKey  = "cc-infra"
 

--- a/internal/tracing/server/actor_interceptor.go
+++ b/internal/tracing/server/actor_interceptor.go
@@ -24,7 +24,7 @@ func ReceiveLogger(next actor.ReceiverFunc) actor.ReceiverFunc {
 		ctx, span := tracing.StartSpan(
 			annotatedContext(context.Background(), envelope),
 			tracing.WithName(fmt.Sprintf("Actor %q/Receive", c.Self())),
-			tracing.WithLink(spanContextFromEnvelope(envelope)),
+			tracing.WithLink(spanContextFromEnvelope(envelope), tagFromEnvelope(envelope)),
 			tracing.WithNewRoot())
 
 		defer func() {
@@ -178,6 +178,10 @@ func spanContextFromEnvelope(envelope *actor.MessageEnvelope) trc.SpanContext {
 	}
 
 	return noop
+}
+
+func tagFromEnvelope(envelope *actor.MessageEnvelope) string {
+	return envelope.Header.Get(tracing.LinkTagKey)
 }
 
 func annotatedContext(ctx context.Context, envelope *actor.MessageEnvelope) context.Context {

--- a/pkg/protos/log/entry.proto
+++ b/pkg/protos/log/entry.proto
@@ -30,17 +30,47 @@ enum impact {
     Execute = 5;
 }
 
+// Describe the actions to take when reading an event entry.
 enum action {
+    // Trace is the most common type of event.  The contents are added to a serial
+    // list in the span, and the formatters will display the entry's data as a
+    // child trace event.
     Trace = 0;
+
+    // UpdateSpanName and UpdateReason are directives to edit the containing span
+    // information.  The first replaces the span's name field, and the second
+    // replaces the span's reason text. This allows for better descriptions for a
+    // span once the details have been better understood - e.g. 'logging in a user'
+    // vs. 'logging in user "admin"'.
     UpdateSpanName = 1;
     UpdateReason = 2;
+
+    // SpanStart is used to place the child span in the correct spot in the
+    // sequence of events in the containing span.  It identifies the child span's
+    // ID.  Structured formatters will expand the child span at this point in the
+    // sequence in order to keep a time order.  Note that parent/child span
+    // relationships are strong - they can safely assume that both spans will
+    // complete, they will execute in the same process, and that completion of the
+    // overall trace ID is not complete until both are complete.
     SpanStart = 3;
+
+    // AddLink is used to place a the request point that may result in a linked
+    // span.  It has an associated ID that is assigned by the active span at the
+    // point of the request, as the future linked span id cannot yet be known.
+    // Note that linked spans have a much looser relationship than parent/child
+    // spans.  The linked span may not be required to complete a logical trace
+    // sequence.  It may not execute in the same process as the initiator.  It
+    // may not even execute.  Consequently, structured formatters consider the
+    // linked information as soft (optional) parent/child relationships.  If they
+    // can put them into a logical execution tree, they do so.  If they cannot,
+    // then they do not.
+    AddLink = 4;
 }
 
 enum severity {
     Debug = 0;
 
-    // This is the severity use to denote an explanatory entry
+    // This is the severity use to denote a purely explanatory entry
     Reason = 1;
 
     Info = 2;
@@ -80,6 +110,9 @@ message event {
 
     // Child's span ID.  Ignored if the action is not SpanStart.
     string span_id = 8;
+
+    // Outgoing link ID.  Ignored if the action is not AddLink.
+    string link_id = 9;
 }
 
 // Describe a full correlated span, consisting of zero or more events.
@@ -107,4 +140,13 @@ message entry {
     // Friendly string describing the purpose of the logic covered by this
     // entry.
     string reason = 9;
+
+    // The link tag associated with an AddLink event at the source span,
+    // if present.
+    string starting_link = 10;
+
+    // The link span ID and trace ID identify the active span at the point
+    // where the request to start a new related span was made.
+    string link_spanID = 11;
+    string link_traceID = 12;
 }


### PR DESCRIPTION
This adds tracking of linked spans with enough context to stitch the caller sequence back together.  Linked spans are more loosely coupled than parent/child spans.  Formatting of events and spans now includes link information, but there is no attempt to restructure the io-span tree in the iow forwarder.  The expectation is that the UI log display will stitch these together in real time.