### PR TITLE
Further improvements to test structure and startup

### DIFF
--- a/internal/clients/trace_sink/trace_sink.go
+++ b/internal/clients/trace_sink/trace_sink.go
@@ -24,7 +24,7 @@ type TraceData struct {
 func InitSinkClient(name string, opts ...grpc.DialOption) {
 	dialName = name
 
-	dialOpts = append(dialOpts, opts...)
+	dialOpts = append([]grpc.DialOption{}, opts...)
 }
 
 // Reset forcibly resets the trace sink to its initial state.  This is intended


### PR DESCRIPTION
Initialize the clients only once, fix tracking of listener and buffer connection in test startup, restructure timestamp client.

Note I'd like feedback on the timestamp client.  If this looks useful I'll convert the sink client as well.