### PR TITLE
Reduce test key set size to aid test runtime for disk based stores

### DIFF
--- a/internal/clients/store/common_test.go
+++ b/internal/clients/store/common_test.go
@@ -22,7 +22,7 @@ import (
 // Limited by etcd configuration option --max-txn-ops which (currently)
 // defaults to 128
 //
-const keySetSize = 100
+const keySetSize = 10
 
 var (
 	initialized bool


### PR DESCRIPTION
Currently, a number of the store tests use a set size of 100 to test the function of the stores multi-key read/write/update/delete  calls. There is no real need for this to be so large and reducing this to a more reasonable 10 will significantly ease test runtime for hard disk based stores for no cost in test coverage.