### PR TITLE
Clean up trace and timestamp client initialization

### DIFF
--- a/internal/clients/timestamp/StepperTestClientSuite.go
+++ b/internal/clients/timestamp/StepperTestClientSuite.go
@@ -20,7 +20,7 @@ import (
 const bufSize = 1024 * 1024
 
 var (
-	s *grpc.Server = nil
+	s   *grpc.Server = nil
 	lis *bufconn.Listener
 )
 
@@ -30,7 +30,7 @@ type stepperTestClientSuite struct {
 	lis *bufconn.Listener
 	utf *exporters.Exporter
 
-	ep string
+	ep       string
 	dialOpts []grpc.DialOption
 
 	s *grpc.Server
@@ -48,19 +48,19 @@ func (ts *stepperTestClientSuite) SetupSuite() {
 	}
 
 	ts.ensureStepperStarted()
+	_ = InitTimestamp(ts.ep, ts.dialOpts...)
 }
 
 func (ts *stepperTestClientSuite) SetupTest() {
+	require := ts.Require()
+
 	_ = ts.utf.Open(ts.T())
 
-	InitTimestamp(ts.ep, ts.dialOpts...)
-
-	err := Reset(context.Background())
-	ts.Require().Nilf(err, "Reset failed")
+	require.NoError(Reset(context.Background()))
 
 	ctx := context.Background()
 
-	ts.Require().Nil(SetPolicy(ctx, pb.StepperPolicy_Manual, &duration.Duration{Seconds: 0}, -1))
+	require.NoError(SetPolicy(ctx, pb.StepperPolicy_Manual, &duration.Duration{Seconds: 0}, -1))
 }
 
 func (ts *stepperTestClientSuite) TearDownTest() {

--- a/internal/clients/trace_sink/trace_sink.go
+++ b/internal/clients/trace_sink/trace_sink.go
@@ -2,6 +2,8 @@ package trace_sink
 
 import (
 	"context"
+	"errors"
+	"sync"
 
 	"google.golang.org/grpc"
 
@@ -9,91 +11,123 @@ import (
 	pb "github.com/Jim3Things/CloudChamber/pkg/protos/services"
 )
 
+type traceClient interface {
+	initialize(name string, opts ...grpc.DialOption) error
+	reset(ctx context.Context) error
+	append(ctx context.Context, entry *log.Entry) error
+	getPolicy(ctx context.Context) (*pb.GetPolicyResponse, error)
+	getTraces(ctx context.Context, start int64, maxCount int64) <-chan traceData
+}
+
 var (
-	dialName string
-	dialOpts []grpc.DialOption
+	errAlreadyInitialized = errors.New("trace sink client has already been initialized")
+	errNotReady           = errors.New("client is not ready")
+
+	tsc traceClient = &notReady{}
 )
 
-// TraceData contains the 'GetAfter' response, or an error.
-type TraceData struct {
+// traceData contains the 'GetAfter' response, or an error.
+type traceData struct {
 	Traces *pb.GetAfterResponse
 	Err    error
 }
 
-// InitSinkClient stores the information needed to be able to connect to the Stepper service.
-func InitSinkClient(name string, opts ...grpc.DialOption) {
-	dialName = name
+type notReady struct{}
 
-	dialOpts = append([]grpc.DialOption{}, opts...)
+func (nrc notReady) initialize(name string, opts ...grpc.DialOption) error {
+	tsc = newTraceClient(name, opts...)
+	return nil
 }
 
-// Reset forcibly resets the trace sink to its initial state.  This is intended
-// to support unit tests
-func Reset(ctx context.Context) error {
-	conn, err := grpc.Dial(dialName, dialOpts...)
+func (nrc notReady) reset(_ context.Context) error {
+	return errNotReady
+}
+
+func (nrc notReady) append(_ context.Context, _ *log.Entry) error {
+	return errNotReady
+}
+
+func (nrc notReady) getPolicy(_ context.Context) (*pb.GetPolicyResponse, error) {
+	return nil, errNotReady
+}
+
+func (nrc notReady) getTraces(_ context.Context, _ int64, _ int64) <-chan traceData {
+	ch := make(chan traceData)
+	ch <- traceData{
+		Traces: nil,
+		Err:    errNotReady,
+	}
+
+	return ch
+}
+
+type activeClient struct {
+	dialName string
+	dialOpts []grpc.DialOption
+
+	conn   *grpc.ClientConn
+	client pb.TraceSinkClient
+	m      *sync.Mutex
+}
+
+func newTraceClient(dialName string, opts ...grpc.DialOption) traceClient {
+	return &activeClient{
+		dialName: dialName,
+		dialOpts: append([]grpc.DialOption{}, opts...),
+		conn:     nil,
+		client:   nil,
+		m:        &sync.Mutex{},
+	}
+}
+
+func (acl *activeClient) initialize(_ string, _ ...grpc.DialOption) error {
+	return errAlreadyInitialized
+}
+
+func (acl *activeClient) reset(ctx context.Context) error {
+	client, err := acl.dial()
 	if err != nil {
 		return err
 	}
-
-	defer func() { _ = conn.Close() }()
-
-	client := pb.NewTraceSinkClient(conn)
 
 	_, err = client.Reset(ctx, &pb.ResetRequest{})
 
-	return err
+	return acl.cleanup(client, err)
 }
 
-// Append adds a log entry to the trace sink
-func Append(ctx context.Context, entry *log.Entry) error {
-	conn, err := grpc.Dial(dialName, dialOpts...)
+func (acl *activeClient) append(ctx context.Context, entry *log.Entry) error {
+	client, err := acl.dial()
 	if err != nil {
 		return err
 	}
 
-	defer func() { _ = conn.Close() }()
-
-	client := pb.NewTraceSinkClient(conn)
-
 	_, err = client.Append(ctx, &pb.AppendRequest{Entry: entry})
-	return err
+	return acl.cleanup(client, err)
 }
 
-// GetPolicy obtains the current trace sink policy and returns it
-func GetPolicy(ctx context.Context) (*pb.GetPolicyResponse, error) {
-	conn, err := grpc.Dial(dialName, dialOpts...)
+func (acl *activeClient) getPolicy(ctx context.Context) (*pb.GetPolicyResponse, error) {
+	client, err := acl.dial()
 	if err != nil {
 		return nil, err
 	}
 
-	defer func() { _ = conn.Close() }()
-
-	client := pb.NewTraceSinkClient(conn)
-
 	policy, err := client.GetPolicy(ctx, &pb.GetPolicyRequest{})
 
-	return policy, err
+	return policy, acl.cleanup(client, err)
 }
 
-// GetTraces retrieves up to the specified limit of trace entries, from the
-// specified starting point.  It will always wait for at least one
-// non-internal entry before returning.
-func GetTraces(ctx context.Context, start int64, maxCount int64) <-chan TraceData {
-	ch := make(chan TraceData)
+func (acl *activeClient) getTraces(ctx context.Context, start int64, maxCount int64) <-chan traceData {
+	ch := make(chan traceData)
 
-	go func(res chan<- TraceData) {
-		conn, err := grpc.Dial(dialName, dialOpts...)
+	go func(res chan<- traceData) {
+		client, err := acl.dial()
 		if err != nil {
-			res <- TraceData{
+			res <- traceData{
 				Traces: nil,
 				Err:    err,
 			}
 			return
 		}
-
-		defer func() { _ = conn.Close() }()
-
-		client := pb.NewTraceSinkClient(conn)
 
 		rsp, err := client.GetAfter(ctx, &pb.GetAfterRequest{
 			Id:         start,
@@ -101,8 +135,74 @@ func GetTraces(ctx context.Context, start int64, maxCount int64) <-chan TraceDat
 			Wait:       true,
 		})
 
-		res <- TraceData{Traces: rsp, Err: nil}
+		res <- traceData{Traces: rsp, Err: acl.cleanup(client, err)}
 	}(ch)
 
 	return ch
+}
+
+// dial abstracts the connection logic to the trace sink service.  It caches
+// the connection for use in later calls in order to avoid excess transport and
+// grpc connection operations.
+func (acl *activeClient) dial() (pb.TraceSinkClient, error) {
+	acl.m.Lock()
+	defer acl.m.Unlock()
+
+	if acl.conn == nil {
+		conn, err := grpc.Dial(acl.dialName, acl.dialOpts...)
+		if err != nil {
+			return nil, err
+		}
+
+		acl.conn = conn
+		acl.client = pb.NewTraceSinkClient(conn)
+	}
+
+	return acl.client, nil
+}
+
+// cleanup ensures that if an error has occurred the cached connection is
+// cleared.
+func (acl *activeClient) cleanup(client pb.TraceSinkClient, err error) error {
+	acl.m.Lock()
+	defer acl.m.Unlock()
+
+	// Clear the connection iff we had an error, the connection has not been
+	// cleaned up already, and we had an error against the current client.
+	if err != nil && acl.conn != nil && client == acl.client {
+		_ = acl.conn.Close()
+
+		acl.conn = nil
+		acl.client = nil
+	}
+
+	return err
+}
+
+// InitSinkClient stores the information needed to be able to connect to the Stepper service.
+func InitSinkClient(name string, opts ...grpc.DialOption) error {
+	return tsc.initialize(name, opts...)
+}
+
+// Reset forcibly resets the trace sink to its initial state.  This is intended
+// to support unit tests
+func Reset(ctx context.Context) error {
+	return tsc.reset(ctx)
+}
+
+// Append adds a log entry to the trace sink
+func Append(ctx context.Context, entry *log.Entry) error {
+	return tsc.append(ctx, entry)
+}
+
+// GetPolicy obtains the current trace sink policy and returns it
+func GetPolicy(ctx context.Context) (*pb.GetPolicyResponse, error) {
+	return tsc.getPolicy(ctx)
+}
+
+// GetTraces retrieves up to the specified limit of trace entries, from the
+// specified starting point.  It will always wait for at least one
+// non-internal entry before returning.
+func GetTraces(ctx context.Context, start int64, maxCount int64) <-chan traceData {
+	return tsc.getTraces(ctx, start, maxCount)
 }

--- a/internal/services/frontend/frontend.go
+++ b/internal/services/frontend/frontend.go
@@ -136,17 +136,21 @@ func initHandlers() error {
 // initClients sets up the internal service clients used by the frontend
 // handlers themselves.
 func initClients(cfg *config.GlobalConfig) error {
-	ts.InitTimestamp(
+	err := ts.InitTimestamp(
 		cfg.SimSupport.EP.String(),
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(ct.Interceptor))
 
-	tsc.InitSinkClient(
+	if err != nil {
+		return err
+	}
+
+	err = tsc.InitSinkClient(
 		cfg.SimSupport.EP.String(),
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(ct.Interceptor))
 
-	return nil
+	return err
 }
 
 func initService(cfg *config.GlobalConfig) error {

--- a/internal/services/inventory/inventory.go
+++ b/internal/services/inventory/inventory.go
@@ -24,15 +24,19 @@ type server struct {
 }
 
 func Register(svc *grpc.Server, cfg *config.GlobalConfig) error {
-	ts.InitTimestamp(
+	if err := ts.InitTimestamp(
 		cfg.SimSupport.EP.String(),
 		grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(ct.Interceptor))
+		grpc.WithUnaryInterceptor(ct.Interceptor)); err != nil {
+		return err
+	}
 
-	tsc.InitSinkClient(
+	if err := tsc.InitSinkClient(
 		cfg.SimSupport.EP.String(),
 		grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(ct.Interceptor))
+		grpc.WithUnaryInterceptor(ct.Interceptor)); err != nil {
+		return err
+	}
 
 	timers := ts.NewTimers(
 		cfg.SimSupport.EP.String(),

--- a/test/utilities/simSupportTestInfra.go
+++ b/test/utilities/simSupportTestInfra.go
@@ -63,8 +63,8 @@ func StartSimSupportServices() (*config.GlobalConfig, error) {
 
 		cfg = c
 
-		timestamp.InitTimestamp(ep, dialOpts...)
-		trace_sink.InitSinkClient(ep, dialOpts...)
+		_ = timestamp.InitTimestamp(ep, dialOpts...)
+		_ = trace_sink.InitSinkClient(ep, dialOpts...)
 
 		lis = bufconn.Listen(bufSize)
 		s = grpc.NewServer(grpc.UnaryInterceptor(st.Interceptor))


### PR DESCRIPTION
This is a follow-on from an earlier partial change to handle proper initialization code for these two clients.

They now return an 'already initialized' error that is used in production to indicate an internal error.  Test suites expect to get this, and that it is harmless, so the error is ignored in those cases.

They both cache the grpc connection and clients, replacing them after a failure.  There is a unit test for the timestamp client that verifies this handling.

There is a common pattern and almost perfectly common code between these initializations.  I may factor that out in the future, even though it is a small amount of code.