### PR TITLE
repair manager rules engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,7 @@ run_tests: $(PROTO_GEN_FILES) $(VERSION_MARKER)
 	go test -count=1 $(PROJECT)/internal/clients/timestamp
 	go test -count=1 $(PROJECT)/internal/services/frontend
 	go test -count=1 $(PROJECT)/internal/services/inventory
+	go test -count=1 $(PROJECT)/internal/services/repair_manager/ruler
 	go test -count=1 $(PROJECT)/internal/services/stepper
 	go test -count=1 $(PROJECT)/internal/services/tracing_sink
 	go test -count=1 $(PROJECT)/internal/tracing/exporters

--- a/internal/services/repair_manager/ruler/leaf.go
+++ b/internal/services/repair_manager/ruler/leaf.go
@@ -104,7 +104,7 @@ func (v *Leaf) AsInt64() (int64, error) {
 	}
 }
 
-// AsInt32 returns the int632 value, if it is a numeric value.  int32 and int64
+// AsInt32 returns the int32 value, if it is a numeric value.  int32 and int64
 // values are returned as expected (including truncation), boolean returns 1
 // for true, 0 for false, while string values return an error.
 func (v *Leaf) AsInt32() (int32, error) {

--- a/internal/services/repair_manager/ruler/leaf.go
+++ b/internal/services/repair_manager/ruler/leaf.go
@@ -1,0 +1,184 @@
+package ruler
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ValueType int
+
+const (
+	ValueInvalid ValueType = iota
+	ValueInt64
+	ValueInt32
+	ValueBool
+	ValueString
+)
+
+// Leaf holds a data value and its associated data type.  Note that the types
+// break down into numeric or string families, thus reducing the number of
+// fields needed to store the data.
+type Leaf struct {
+	vtype  ValueType
+	numVal uint64
+	strVal string
+}
+
+// +++ Constructor functions
+
+// NewLeafString creates a new Leaf entry containing the supplied string value.
+func NewLeafString(val string) *Leaf {
+	return &Leaf{
+		vtype:  ValueString,
+		numVal: 0,
+		strVal: val,
+	}
+}
+
+// NewLeafBool creates a new Leaf entry containing the supplied boolean value.
+func NewLeafBool(val bool) *Leaf {
+	// true is a nonzero value, false is zero
+	num := 0
+	if val {
+		num = 1
+	}
+
+	return &Leaf{
+		vtype:  ValueBool,
+		numVal: uint64(num),
+		strVal: "",
+	}
+}
+
+// NewLeafInt32 creates a new Leaf entry containing the supplied integer value.
+func NewLeafInt32(val int32) *Leaf {
+	return &Leaf{
+		vtype:  ValueInt32,
+		numVal: uint64(val),
+		strVal: "",
+	}
+}
+
+// NewLeafInt64 creates a new Leaf entry containing the supplied integer value.
+func NewLeafInt64(val int64) *Leaf {
+	return &Leaf{
+		vtype:  ValueInt64,
+		numVal: uint64(val),
+		strVal: "",
+	}
+}
+
+// --- Constructor functions
+
+// Evaluate returns this Leaf element.
+func (v *Leaf) Evaluate(*EvalContext) (*Leaf, error) { return v, nil }
+
+// Format returns a descriptive string for this instance.
+func (v *Leaf) Format(indent string) string {
+	return fmt.Sprintf("%s[Leaf: %s] %q", indent, v.typeName(), v.valueString())
+}
+
+// AsName returns a string where the replacement tokens are applied.  In order
+// to do so, this function accepts an array of strings that are alternating
+// strings of tokens and replacement values.
+func (v *Leaf) AsName(replacements []string) (string, error) {
+	if v.vtype != ValueString {
+		return v.AsString()
+	}
+
+	r := strings.NewReplacer(replacements...)
+
+	return r.Replace(v.strVal), nil
+}
+
+// AsInt64 returns the int64 value, if it is a numeric value.  int32 and int64
+// values are returned as expected, boolean returns 1 for true, 0 for false,
+// while string values return an error.
+func (v *Leaf) AsInt64() (int64, error) {
+	switch v.vtype {
+	case ValueBool, ValueInt64, ValueInt32:
+		return int64(v.numVal), nil
+
+	default:
+		return 0, ErrInvalidType
+	}
+}
+
+// AsInt32 returns the int632 value, if it is a numeric value.  int32 and int64
+// values are returned as expected (including truncation), boolean returns 1
+// for true, 0 for false, while string values return an error.
+func (v *Leaf) AsInt32() (int32, error) {
+	switch v.vtype {
+	case ValueBool, ValueInt64, ValueInt32:
+		return int32(v.numVal), nil
+
+	default:
+		return 0, ErrInvalidType
+	}
+}
+
+// AsBool returns true if the numeric value is non-zero, false if it is zero,
+// and an error if it is a string value.
+func (v *Leaf) AsBool() (bool, error) {
+	switch v.vtype {
+	case ValueBool, ValueInt64, ValueInt32:
+		return v.numVal != 0, nil
+
+	default:
+		return false, ErrInvalidType
+	}
+}
+
+// AsString returns either the string value, or the numeric value as a
+// formatted string.
+func (v *Leaf) AsString() (string, error) {
+	switch v.vtype {
+	case ValueBool:
+		if v.numVal != 0 {
+			return "true", nil
+		}
+		return "false", nil
+
+	case ValueInt32:
+		return fmt.Sprintf("%d", int32(v.numVal)), nil
+
+	case ValueInt64:
+		return fmt.Sprintf("%d", int64(v.numVal)), nil
+
+	case ValueString:
+		return v.strVal, nil
+
+	default:
+		return "", ErrInvalidType
+	}
+}
+
+func (v *Leaf) typeName() string {
+	switch v.vtype {
+	case ValueBool:
+		return "bool"
+	case ValueInt32:
+		return "int32"
+	case ValueInt64:
+		return "int64"
+	case ValueString:
+		return "string"
+	default:
+		return "Invalid"
+	}
+}
+
+func (v *Leaf) valueString() string {
+	switch v.vtype {
+	case ValueBool:
+		return fmt.Sprintf("%v", v.numVal != 0)
+	case ValueInt32:
+		return fmt.Sprintf("%v", int32(v.numVal))
+	case ValueInt64:
+		return fmt.Sprintf("%v", int64(v.numVal))
+	case ValueString:
+		return v.strVal
+	default:
+		return "<<unknown>>"
+	}
+}

--- a/internal/services/repair_manager/ruler/leaf_test.go
+++ b/internal/services/repair_manager/ruler/leaf_test.go
@@ -124,6 +124,8 @@ func (ts *LeafTestSuite) TestAsInt32() {
 	ts.testInt32Val(NewLeafInt64(1), 1, nil)
 	ts.testInt32Val(NewLeafInt64(-1), -1, nil)
 	ts.testInt32Val(NewLeafInt64(2), 2, nil)
+	ts.testInt32Val(NewLeafInt64(1<<33+2), 2, nil)
+	ts.testInt32Val(NewLeafInt64(1<<34-2), -2, nil)
 
 	ts.testInt32Val(NewLeafString("test"), 0, ErrInvalidType)
 }

--- a/internal/services/repair_manager/ruler/leaf_test.go
+++ b/internal/services/repair_manager/ruler/leaf_test.go
@@ -1,0 +1,203 @@
+package ruler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type LeafTestSuite struct {
+	suite.Suite
+}
+
+func (ts *LeafTestSuite) TestEvaluate() {
+	require := ts.Require()
+
+	val := NewLeafBool(true)
+	v, err := val.Evaluate(nil)
+	require.NoError(err)
+	require.Same(val, v)
+
+	val = NewLeafInt32(1)
+	v, err = val.Evaluate(nil)
+	require.NoError(err)
+	require.Same(val, v)
+
+	val = NewLeafInt64(2)
+	v, err = val.Evaluate(nil)
+	require.NoError(err)
+	require.Same(val, v)
+
+	val = NewLeafString("test")
+	v, err = val.Evaluate(nil)
+	require.NoError(err)
+	require.Same(val, v)
+}
+
+func (ts *LeafTestSuite) TestFormat() {
+	assert := ts.Assert()
+
+	indent := "    "
+
+	boolVal := NewLeafBool(true)
+	assert.Equal("    [Leaf: bool] \"true\"", boolVal.Format(indent))
+
+	int32Val := NewLeafInt32(23)
+	assert.Equal("    [Leaf: int32] \"23\"", int32Val.Format(indent))
+
+	int64Val := NewLeafInt64(230000000)
+	assert.Equal("    [Leaf: int64] \"230000000\"", int64Val.Format(indent))
+
+	stringVal := NewLeafString("this is a test")
+	assert.Equal("    [Leaf: string] \"this is a test\"", stringVal.Format(indent))
+}
+
+func (ts *LeafTestSuite) TestAsName() {
+	assert := ts.Assert()
+	require := ts.Require()
+
+	replacements := []string{
+		"%id%", "2",
+		"%rack%", "rack1",
+		"%workload%", "fred",
+	}
+
+	pattern := "/racks/%rack%/blades/%id%"
+
+	stringVal := NewLeafString(pattern)
+
+	s, err := stringVal.AsString()
+	require.NoError(err)
+	assert.Equal(pattern, s)
+
+	path, err := stringVal.AsName(replacements)
+	require.NoError(err)
+	assert.Equal("/racks/rack1/blades/2", path)
+
+	stringVal = NewLeafString("/workload/rack1")
+	path, err = stringVal.AsName(replacements)
+	require.NoError(err)
+	assert.Equal("/workload/rack1", path)
+}
+
+func (ts *LeafTestSuite) testBoolVal(l *Leaf, expected bool, expErr error) {
+	assert := ts.Assert()
+	require := ts.Require()
+
+	b, err := l.AsBool()
+	require.Equal(expErr, err)
+	assert.Equal(expected, b)
+}
+
+func (ts *LeafTestSuite) TestAsBool() {
+	ts.testBoolVal(NewLeafBool(true), true, nil)
+	ts.testBoolVal(NewLeafBool(false), false, nil)
+
+	ts.testBoolVal(NewLeafInt32(1), true, nil)
+	ts.testBoolVal(NewLeafInt32(2), true, nil)
+	ts.testBoolVal(NewLeafInt32(0), false, nil)
+
+	ts.testBoolVal(NewLeafInt64(1), true, nil)
+	ts.testBoolVal(NewLeafInt64(2), true, nil)
+	ts.testBoolVal(NewLeafInt64(0), false, nil)
+
+	ts.testBoolVal(NewLeafString("test"), false, ErrInvalidType)
+}
+
+func (ts *LeafTestSuite) testInt32Val(l *Leaf, expected int32, expErr error) {
+	assert := ts.Assert()
+	require := ts.Require()
+
+	b, err := l.AsInt32()
+	require.Equal(expErr, err)
+	assert.Equal(expected, b)
+}
+
+func (ts *LeafTestSuite) TestAsInt32() {
+	ts.testInt32Val(NewLeafBool(true), 1, nil)
+	ts.testInt32Val(NewLeafBool(false), 0, nil)
+
+	ts.testInt32Val(NewLeafInt32(1), 1, nil)
+	ts.testInt32Val(NewLeafInt32(-1), -1, nil)
+	ts.testInt32Val(NewLeafInt32(2), 2, nil)
+
+	ts.testInt32Val(NewLeafInt64(1), 1, nil)
+	ts.testInt32Val(NewLeafInt64(-1), -1, nil)
+	ts.testInt32Val(NewLeafInt64(2), 2, nil)
+
+	ts.testInt32Val(NewLeafString("test"), 0, ErrInvalidType)
+}
+
+func (ts *LeafTestSuite) testInt64Val(l *Leaf, expected int64, expErr error) {
+	assert := ts.Assert()
+	require := ts.Require()
+
+	b, err := l.AsInt64()
+	require.Equal(expErr, err)
+	assert.Equal(expected, b)
+}
+
+func (ts *LeafTestSuite) TestAsInt64() {
+	ts.testInt64Val(NewLeafBool(true), 1, nil)
+	ts.testInt64Val(NewLeafBool(false), 0, nil)
+
+	ts.testInt64Val(NewLeafInt32(1), 1, nil)
+	ts.testInt64Val(NewLeafInt32(-1), -1, nil)
+	ts.testInt64Val(NewLeafInt32(2), 2, nil)
+
+	ts.testInt64Val(NewLeafInt64(1), 1, nil)
+	ts.testInt64Val(NewLeafInt64(-1), -1, nil)
+	ts.testInt64Val(NewLeafInt64(2), 2, nil)
+
+	ts.testInt64Val(NewLeafString("test"), 0, ErrInvalidType)
+}
+
+func (ts *LeafTestSuite) testStringVal(l *Leaf, expected string, expErr error) {
+	assert := ts.Assert()
+	require := ts.Require()
+
+	b, err := l.AsString()
+	require.Equal(expErr, err)
+	assert.Equal(expected, b)
+}
+
+func (ts *LeafTestSuite) TestAsString() {
+	ts.testStringVal(NewLeafBool(true), "true", nil)
+	ts.testStringVal(NewLeafBool(false), "false", nil)
+
+	ts.testStringVal(NewLeafInt32(3), "3", nil)
+	ts.testStringVal(NewLeafInt32(-3), "-3", nil)
+
+	ts.testStringVal(NewLeafInt64(3), "3", nil)
+	ts.testStringVal(NewLeafInt64(-3), "-3", nil)
+
+	ts.testStringVal(NewLeafString("test"), "test", nil)
+	ts.testStringVal(NewLeafString("%test%"), "%test%", nil)
+}
+
+func (ts *LeafTestSuite) testNameVal(l *Leaf, expected string, expErr error) {
+	assert := ts.Assert()
+	require := ts.Require()
+
+	b, err := l.AsName([]string{"%test%", "fred", "%true%", "bogus"})
+	require.Equal(expErr, err)
+	assert.Equal(expected, b)
+}
+
+func (ts *LeafTestSuite) TestAsName2() {
+	ts.testNameVal(NewLeafBool(true), "true", nil)
+	ts.testNameVal(NewLeafBool(false), "false", nil)
+
+	ts.testNameVal(NewLeafInt32(3), "3", nil)
+	ts.testNameVal(NewLeafInt32(-3), "-3", nil)
+
+	ts.testNameVal(NewLeafInt64(3), "3", nil)
+	ts.testNameVal(NewLeafInt64(-3), "-3", nil)
+
+	ts.testNameVal(NewLeafString("test"), "test", nil)
+	ts.testNameVal(NewLeafString("%test%"), "fred", nil)
+}
+
+func TestLeafTestSuite(t *testing.T) {
+	suite.Run(t, new(LeafTestSuite))
+}

--- a/internal/services/repair_manager/ruler/node.go
+++ b/internal/services/repair_manager/ruler/node.go
@@ -1,0 +1,298 @@
+package ruler
+
+import (
+	"fmt"
+)
+
+type OpType int
+
+const (
+	OpInvalid OpType = iota
+	OpFetch
+	OpMatch
+	OpNotMatch
+	OpAll
+	OpAny
+)
+
+const (
+	bump = "    "
+)
+
+// Node holds a computation directive, which requires at least one child term
+// to complete.  That child term may be another Node, or a Leaf.
+type Node struct {
+	Op   OpType
+	Args []Term
+}
+
+// Two key Node functions are table driven, based on the operation type.  The
+// table structure and contents are defined here.
+
+// evalFunc is the signature for a function that implements the Evaluate logic
+// for a particular operation type.
+type evalFunc func(args []Term, ec *EvalContext) (*Leaf, error)
+
+// opEntry defines the structure of an entry in the per-operation table.  This
+// consists of the text string for the operation, used in Format, and a pointer
+// to the specific Evaluate worker function.
+type opEntry struct {
+	name string
+	eval evalFunc
+}
+
+var opToEntry = map[OpType]*opEntry{
+	OpFetch: {
+		name: "Fetch",
+		eval: doOpFetch,
+	},
+	OpMatch: {
+		name: "Match",
+		eval: doOpMatch,
+	},
+	OpNotMatch: {
+		name: "Not Match",
+		eval: doOpNotMatch,
+	},
+	OpAll: {
+		name: "All Match",
+		eval: doOpAll,
+	},
+	OpAny: {
+		name: "At Least One Matches",
+		eval: doOpAny,
+	},
+}
+
+// Evaluate executes the calculation defined by this Node.  It returns the
+// final result as a Leaf item, or an error, if the calculation fails.
+func (n *Node) Evaluate(ec *EvalContext) (*Leaf, error) {
+	item, ok := opToEntry[n.Op]
+	if !ok {
+		return nil, ErrInvalidOp
+	}
+
+	return item.eval(n.Args, ec)
+}
+
+// Format returns a structured string representation of the Node and its
+// children.
+func (n *Node) Format(indent string) string {
+	res := fmt.Sprintf("%s%s", indent, n.opString())
+	for _, arg := range n.Args {
+		res = fmt.Sprintf("%s\n%s", res, arg.Format(indent+bump))
+	}
+
+	return res
+}
+
+// +++ Constructor functions
+
+// NewNodeFetch creates a new Node instance with that fetches data from a
+// supplied table using the specified key (after variable expansion).
+func NewNodeFetch(name Term) *Node {
+	return &Node{
+		Op:   OpFetch,
+		Args: []Term{name},
+	}
+}
+
+// NewNodeMatch creates a new Node instance that tests whether the two child
+// Term instances are equivalent.  It returns that in a boolean Leaf instance,
+// or an error if the test failed.
+func NewNodeMatch(left Term, right Term) *Node {
+	return &Node{
+		Op:   OpMatch,
+		Args: []Term{left, right},
+	}
+}
+
+// NewNodeNotMatch creates a new Node instance that tests whether the two
+// child Term instances differ.  It returns that in a boolean Leaf instance,
+// or an error if the test failed.
+func NewNodeNotMatch(left Term, right Term) *Node {
+	return &Node{
+		Op:   OpNotMatch,
+		Args: []Term{left, right},
+	}
+}
+
+// NewNodeAll creates a Node instance that tests whether all the child
+// instances are logically true.  It returns that in a boolean Leaf instance,
+// // or an error if the test failed.
+func NewNodeAll(terms ...Term) *Node {
+	return &Node{
+		Op:   OpAll,
+		Args: terms,
+	}
+}
+
+// NewNodeAny creates a Node instance that tests whether any of the child
+// instances are logically true.  It returns that in a boolean Leaf instance,
+// or an error if the test failed.
+func NewNodeAny(terms ...Term) *Node {
+	return &Node{
+		Op:   OpAny,
+		Args: terms,
+	}
+}
+
+// --- Constructor functions
+
+// +++ Evaluate helper functions
+
+func doOpFetch(args []Term, ec *EvalContext) (*Leaf, error) {
+	if len(args) != 1 {
+		return nil, ErrInvalidArgLen
+	}
+
+	leaf, err := args[0].Evaluate(ec)
+	if err != nil {
+		return nil, err
+	}
+
+	// need to fill in what to do with the key.
+	_, err = leaf.AsName(ec.Replacements)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, ErrInvalidOp
+}
+
+func doOpMatch(args []Term, ec *EvalContext) (*Leaf, error) {
+	if len(args) != 2 {
+		return nil, ErrInvalidArgLen
+	}
+
+	lTerm := args[0]
+	rTerm := args[1]
+
+	lLeaf, err := lTerm.Evaluate(ec)
+	if err != nil {
+		return nil, err
+	}
+
+	rLeaf, err := rTerm.Evaluate(ec)
+	if err != nil {
+		return nil, err
+	}
+
+	return equals(lLeaf, rLeaf)
+}
+
+func doOpNotMatch(args []Term, ec *EvalContext) (*Leaf, error) {
+	if len(args) != 2 {
+		return nil, ErrInvalidArgLen
+	}
+
+	lTerm := args[0]
+	rTerm := args[1]
+
+	lLeaf, err := lTerm.Evaluate(ec)
+	if err != nil {
+		return nil, err
+	}
+
+	rLeaf, err := rTerm.Evaluate(ec)
+	if err != nil {
+		return nil, err
+	}
+
+	return notEquals(lLeaf, rLeaf)
+}
+
+func doOpAll(args []Term, ec *EvalContext) (*Leaf, error) {
+	if len(args) <= 0 {
+		return nil, ErrInvalidArgLen
+	}
+
+	for _, arg := range args {
+		leaf, err := arg.Evaluate(ec)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := leaf.AsBool()
+		if err != nil {
+			return nil, err
+		}
+
+		if !v {
+			return NewLeafBool(false), nil
+		}
+	}
+
+	return NewLeafBool(true), nil
+}
+
+func doOpAny(args []Term, ec *EvalContext) (*Leaf, error) {
+	if len(args) <= 0 {
+		return nil, ErrInvalidArgLen
+	}
+
+	for _, arg := range args {
+		leaf, err := arg.Evaluate(ec)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := leaf.AsBool()
+		if err != nil {
+			return nil, err
+		}
+
+		if v {
+			return NewLeafBool(true), nil
+		}
+	}
+
+	return NewLeafBool(false), nil
+}
+
+// --- Evaluate helper functions
+
+func equals(l *Leaf, r *Leaf) (*Leaf, error) {
+	if l.vtype == r.vtype {
+		return NewLeafBool(l.numVal == r.numVal && l.strVal == r.strVal), nil
+	}
+
+	lv, err := l.AsString()
+	if err != nil {
+		return nil, err
+	}
+
+	rv, err := r.AsString()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewLeafBool(lv == rv), nil
+}
+
+func notEquals(l *Leaf, r *Leaf) (*Leaf, error) {
+	if l.vtype == r.vtype {
+		return NewLeafBool(l.numVal != r.numVal || l.strVal != r.strVal), nil
+	}
+
+	lv, err := l.AsString()
+	if err != nil {
+		return nil, err
+	}
+
+	rv, err := r.AsString()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewLeafBool(lv != rv), nil
+}
+
+func (n *Node) opString() string {
+	s, ok := opToEntry[n.Op]
+	if !ok {
+		return "Invalid"
+	}
+
+	return s.name
+}

--- a/internal/services/repair_manager/ruler/node_test.go
+++ b/internal/services/repair_manager/ruler/node_test.go
@@ -1,0 +1,278 @@
+package ruler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type NodeTestSuite struct {
+	suite.Suite
+}
+
+func (ts *NodeTestSuite) TestOpType() {
+	require := ts.Require()
+
+	n := NewNodeFetch(NewLeafString("test"))
+	require.Equal(OpFetch, n.Op)
+
+	n = NewNodeMatch(NewLeafInt64(1), NewLeafInt64(2))
+	require.Equal(OpMatch, n.Op)
+
+	n = NewNodeNotMatch(NewLeafInt64(1), NewLeafInt64(2))
+	require.Equal(OpNotMatch, n.Op)
+
+	n = NewNodeAll(NewLeafInt32(1), NewLeafInt32(1))
+	require.Equal(OpAll, n.Op)
+
+	n = NewNodeAny(NewLeafInt32(1), NewLeafInt32(1))
+	require.Equal(OpAny, n.Op)
+}
+
+func (ts *NodeTestSuite) TestFetchFormat() {
+	assert := ts.Assert()
+
+	n := NewNodeFetch(NewLeafString("test"))
+	s := n.Format("")
+	assert.Equal(
+		"Fetch\n"+
+			"    [Leaf: string] \"test\"",
+		s)
+}
+
+func (ts *NodeTestSuite) TestMatchFormat() {
+	assert := ts.Assert()
+
+	n := NewNodeMatch(NewLeafInt32(1), NewLeafInt32(2))
+	s := n.Format("")
+	assert.Equal(
+		"Match\n"+
+			"    [Leaf: int32] \"1\"\n"+
+			"    [Leaf: int32] \"2\"",
+		s)
+}
+
+func (ts *NodeTestSuite) TestNotMatchFormat() {
+	assert := ts.Assert()
+
+	n := NewNodeNotMatch(NewLeafInt32(1), NewLeafInt32(2))
+	s := n.Format("")
+	assert.Equal(
+		"Not Match\n"+
+			"    [Leaf: int32] \"1\"\n"+
+			"    [Leaf: int32] \"2\"",
+		s)
+}
+
+func (ts *NodeTestSuite) TestComplexMatchFormat() {
+	assert := ts.Assert()
+
+	n := NewNodeMatch(
+		NewNodeFetch(NewLeafString("%test%")),
+		NewNodeMatch(
+			NewNodeFetch(NewLeafString("%testing%")),
+			NewLeafInt32(1)))
+	s := n.Format("")
+	assert.Equal(
+		"Match\n"+
+			"    Fetch\n"+
+			"        [Leaf: string] \"%test%\"\n"+
+			"    Match\n"+
+			"        Fetch\n"+
+			"            [Leaf: string] \"%testing%\"\n"+
+			"        [Leaf: int32] \"1\"",
+		s)
+}
+
+func (ts *NodeTestSuite) TestAllFormat() {
+	assert := ts.Assert()
+
+	n := NewNodeAll(
+		NewLeafInt32(1),
+		NewLeafBool(true),
+		NewLeafInt64(100))
+	s := n.Format("")
+	assert.Equal(
+		"All Match\n"+
+			"    [Leaf: int32] \"1\"\n"+
+			"    [Leaf: bool] \"true\"\n"+
+			"    [Leaf: int64] \"100\"",
+		s)
+}
+
+func (ts *NodeTestSuite) TestAnyFormat() {
+	assert := ts.Assert()
+
+	n := NewNodeAny(
+		NewLeafInt32(1),
+		NewLeafBool(true),
+		NewLeafInt64(100))
+	s := n.Format("")
+	assert.Equal(
+		"At Least One Matches\n"+
+			"    [Leaf: int32] \"1\"\n"+
+			"    [Leaf: bool] \"true\"\n"+
+			"    [Leaf: int64] \"100\"",
+		s)
+}
+
+func (ts *NodeTestSuite) TestInvalidFormat() {
+	assert := ts.Assert()
+
+	n := &Node{
+		Op: OpInvalid,
+		Args: []Term{
+			NewLeafString("test"),
+		},
+	}
+
+	s := n.Format("")
+	assert.Equal(
+		"Invalid\n"+
+			"    [Leaf: string] \"test\"",
+		s)
+}
+
+func (ts *NodeTestSuite) TestMatchEvaluate() {
+	assert := ts.Assert()
+	require := ts.Require()
+
+	ec := &EvalContext{Replacements: []string{}}
+
+	n := NewNodeMatch(NewLeafInt32(1), NewLeafInt32(2))
+
+	l, err := n.Evaluate(ec)
+	require.NoError(err)
+	v, err := l.AsBool()
+	require.NoError(err)
+	assert.False(v)
+
+	n = NewNodeMatch(NewLeafInt32(1), NewLeafInt64(1))
+
+	l, err = n.Evaluate(ec)
+	require.NoError(err)
+	v, err = l.AsBool()
+	require.NoError(err)
+	assert.True(v)
+}
+
+func (ts *NodeTestSuite) TestNotMatchEvaluate() {
+	assert := ts.Assert()
+	require := ts.Require()
+
+	ec := &EvalContext{Replacements: []string{}}
+
+	n := NewNodeNotMatch(NewLeafInt32(1), NewLeafInt32(2))
+
+	l, err := n.Evaluate(ec)
+	require.NoError(err)
+	v, err := l.AsBool()
+	require.NoError(err)
+	assert.True(v)
+
+	n = NewNodeNotMatch(NewLeafInt32(1), NewLeafInt32(1))
+
+	l, err = n.Evaluate(ec)
+	require.NoError(err)
+	v, err = l.AsBool()
+	require.NoError(err)
+	assert.False(v)
+}
+
+func (ts *NodeTestSuite) TestAllEvaluate() {
+	assert := ts.Assert()
+	require := ts.Require()
+
+	ec := &EvalContext{Replacements: []string{}}
+
+	n := NewNodeAll(
+		NewLeafInt64(1),
+		NewLeafBool(true),
+		NewLeafInt32(100))
+
+	l, err := n.Evaluate(ec)
+	require.NoError(err)
+	v, err := l.AsBool()
+	require.NoError(err)
+	assert.True(v)
+
+	n = NewNodeAll(
+		NewLeafInt64(1),
+		NewLeafBool(true),
+		NewLeafInt32(0))
+
+	l, err = n.Evaluate(ec)
+	require.NoError(err)
+	v, err = l.AsBool()
+	require.NoError(err)
+	assert.False(v)
+
+	n = NewNodeAll(
+		NewLeafInt64(1),
+		NewLeafBool(true),
+		NewLeafString("test"))
+
+	l, err = n.Evaluate(ec)
+	require.Error(err)
+	assert.Equal(ErrInvalidType, err)
+}
+
+func (ts *NodeTestSuite) TestAnyEvaluate() {
+	assert := ts.Assert()
+	require := ts.Require()
+
+	ec := &EvalContext{Replacements: []string{}}
+
+	n := NewNodeAny(
+		NewLeafInt64(0),
+		NewLeafBool(false),
+		NewLeafInt32(100))
+
+	l, err := n.Evaluate(ec)
+	require.NoError(err)
+	v, err := l.AsBool()
+	require.NoError(err)
+	assert.True(v)
+
+	n = NewNodeAny(
+		NewLeafInt64(0),
+		NewLeafBool(false),
+		NewLeafInt32(0))
+
+	l, err = n.Evaluate(ec)
+	require.NoError(err)
+	v, err = l.AsBool()
+	require.NoError(err)
+	assert.False(v)
+
+	n = NewNodeAny(
+		NewLeafInt64(0),
+		NewLeafBool(false),
+		NewLeafString("test"))
+
+	l, err = n.Evaluate(ec)
+	require.Error(err)
+	assert.Equal(ErrInvalidType, err)
+}
+
+func (ts *NodeTestSuite) TestInvalidEvaluate() {
+	assert := ts.Assert()
+	require := ts.Require()
+
+	n := &Node{
+		Op: OpInvalid,
+		Args: []Term{
+			NewLeafString("test"),
+		},
+	}
+
+	ec := &EvalContext{Replacements: []string{}}
+
+	_, err := n.Evaluate(ec)
+	require.Error(err)
+	assert.Equal(ErrInvalidOp, err)
+}
+
+func TestNodeTestSuite(t *testing.T) {
+	suite.Run(t, new(NodeTestSuite))
+}

--- a/internal/services/repair_manager/ruler/rules.go
+++ b/internal/services/repair_manager/ruler/rules.go
@@ -1,0 +1,125 @@
+package ruler
+
+import (
+	"errors"
+)
+
+// Error definitions.  Placeholder for now.
+
+var ErrInvalidType = errors.New("invalid type")
+var ErrInvalidOp = errors.New("invalid operation")
+var ErrInvalidArgLen = errors.New("invalid number of arguments")
+
+// Define the rules definition layout
+
+// Proposal is the placeholder structure for the result from calling the
+// output function
+type Proposal struct {
+}
+
+// Arg contains a context item to use when preparing the final output
+type Arg struct {
+	Name string
+	From *Term
+}
+
+// OutputFunc is the signature for a function that generates the result of a
+// ruleset matching.
+type OutputFunc func(args []Arg) (*Proposal, error)
+
+// Rule defines a matching rule to evaluate and, if matched, execute.
+type Rule struct {
+	// Where is the initial trigger test. If this evaluates to true, then the
+	// various choices are evaluated until one matches.
+	Where Term
+
+	// Choices are the set of conditional subtests, which are listed in order
+	// of decreasing priority.  This enables contextual operation, such as
+	// repair action escalation.
+	Choices []RuleChoice
+}
+
+// RuleChoice defines a single subtest for a Rule.
+type RuleChoice struct {
+	// Assuming contains the enabling test.  If this evaluates to true, then
+	// this choice is taken, and this choice's output function is called.
+	Assuming Term
+
+	// With contains the set of argument and context state to provide to the
+	// output function
+	With []Arg
+
+	// Call is the function to call when this choice is taken.  The resulting
+	// Proposal is then returned as the evaluation output for the Rule.
+	Call OutputFunc
+}
+
+// [ { Where: NotMatch(N("first/%blade%/state"), N("second/%blade%/state")),
+//	   Choices: []RuleChoice {
+//			{ Assuming: All(
+//     			Match(N("second/%pdu%/power"), V(true)),
+//				Match(N("second/%pdu%/cables/%blade%/power"), V(true)),
+//				Match(N("second/%tor%/state"), V(torWorking)),
+//				Match(N("second/%tor%/cables/%blade%/connected"), V(true)),
+//				Match(N("second/%blade%/booting"), V(false)),
+//	   		),
+//	   		With: []Arg {
+//	  			{Name:"blade", From: N(%blade%)},
+//	  			{Name:"boot", From:V(true)},
+//	   		},
+//     		Call: createBootBladeRepair },
+//		},
+// ]
+
+// +++ Rule API functions
+// This section contains functions that simplify creating a rule set
+
+// N creates the Terms required to specify that the data associated with the
+// supplied key is to be used.
+func N(key string) Term {
+	return NewNodeFetch(NewLeafString(key))
+}
+
+// V creates a Term holding the specified value.
+func V(value interface{}) Term {
+	switch v := value.(type) {
+	case bool:
+		return NewLeafBool(v)
+
+	case int32:
+		return NewLeafInt32(v)
+
+	case int:
+		return NewLeafInt32(int32(v))
+
+	case int64:
+		return NewLeafInt64(v)
+
+	case string:
+		return NewLeafString(v)
+	}
+
+	return nil
+}
+
+// Match creates the Terms to hold a Match test
+func Match(l Term, r Term) Term {
+	return NewNodeMatch(l, r)
+}
+
+// NotMatch creates the Terms to hold a NotMatch test
+func NotMatch(l Term, r Term) Term {
+	return NewNodeNotMatch(l, r)
+}
+
+// All creates the Terms to hold a All test
+func All(terms ...Term) Term {
+	return NewNodeAll(terms...)
+}
+
+// Any creates the Terms to hold a Any test
+func Any(terms ...Term) Term {
+	return NewNodeAny(terms...)
+}
+
+// --- Rule API functions

--- a/internal/services/repair_manager/ruler/rules_api_test.go
+++ b/internal/services/repair_manager/ruler/rules_api_test.go
@@ -1,0 +1,32 @@
+package ruler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type RulesApiTestSuite struct {
+	suite.Suite
+}
+
+func (ts *RulesApiTestSuite) testLeaf(l Term, vt ValueType) {
+	require := ts.Require()
+
+	s, ok := l.(*Leaf)
+	require.True(ok)
+	require.Equal(vt, s.vtype)
+}
+
+func (ts *RulesApiTestSuite) TestV() {
+	ts.testLeaf(V("test"), ValueString)
+	ts.testLeaf(V(3), ValueInt32)
+	ts.testLeaf(V(true), ValueBool)
+	ts.testLeaf(V("foo/bar/%baz%"), ValueString)
+	ts.testLeaf(V(int32(1)), ValueInt32)
+	ts.testLeaf(V(int64(1)), ValueInt64)
+}
+
+func TestRulesApiTest(t *testing.T) {
+	suite.Run(t, new(RulesApiTestSuite))
+}

--- a/internal/services/repair_manager/ruler/term.go
+++ b/internal/services/repair_manager/ruler/term.go
@@ -1,0 +1,23 @@
+package ruler
+
+// EvalContext defines the context to supply to an Evaluate call on a Term.
+type EvalContext struct {
+	// Replacements hold sequences of variable/replacement strings to use when
+	// expanding a name string.
+	Replacements []string
+
+	// -- data access values are TBD
+}
+
+// Term is the general definition for an entry in the ruleset - either an
+// intermediate Node that must be executed to get a value, or a Leaf that
+// already holds a final value.
+type Term interface {
+	// Evaluate performs whatever operations are necessary for the Term to
+	// produce the final value.
+	Evaluate(ec *EvalContext) (*Leaf, error)
+
+	// Format produces a structured string of the (sub-)tree rooted in this
+	// Term instance.
+	Format(indent string) string
+}


### PR DESCRIPTION
This contains the initial implementation of the rules engine that the repair manager will use.  It is mostly complete, with three significant exceptions.

First, the interface to the data tables that drive the rules is missing, which impacts the EvaluationContext and Fetch.

Second, the Proposal struct is currently a placeholder.  It is also partly waiting on the datastore, but it also needs the definition of what a repair order will look like.

Third, the error definitions are currently placeholder values.