### PR TITLE
Rules engine, part 2

### DIFF
--- a/internal/services/repair_manager/ruler/leaf.go
+++ b/internal/services/repair_manager/ruler/leaf.go
@@ -68,6 +68,29 @@ func NewLeafInt64(val int64) *Leaf {
 	}
 }
 
+// NewLeaf creates a new Leaf entry of the correct ValueType based on the Go
+// type of the value supplied.
+func NewLeaf(val interface{}) *Leaf {
+	switch v := val.(type) {
+	case bool:
+		return NewLeafBool(v)
+
+	case int32:
+		return NewLeafInt32(v)
+
+	case int:
+		return NewLeafInt32(int32(v))
+
+	case int64:
+		return NewLeafInt64(v)
+
+	case string:
+		return NewLeafString(v)
+	}
+
+	return nil
+}
+
 // --- Constructor functions
 
 // Evaluate returns this Leaf element.
@@ -100,7 +123,7 @@ func (v *Leaf) AsInt64() (int64, error) {
 		return int64(v.numVal), nil
 
 	default:
-		return 0, ErrInvalidType
+		return 0, ErrInvalidType(v.vtype)
 	}
 }
 
@@ -113,7 +136,7 @@ func (v *Leaf) AsInt32() (int32, error) {
 		return int32(v.numVal), nil
 
 	default:
-		return 0, ErrInvalidType
+		return 0, ErrInvalidType(v.vtype)
 	}
 }
 
@@ -125,7 +148,7 @@ func (v *Leaf) AsBool() (bool, error) {
 		return v.numVal != 0, nil
 
 	default:
-		return false, ErrInvalidType
+		return false, ErrInvalidType(v.vtype)
 	}
 }
 
@@ -149,7 +172,7 @@ func (v *Leaf) AsString() (string, error) {
 		return v.strVal, nil
 
 	default:
-		return "", ErrInvalidType
+		return "", ErrInvalidType(v.vtype)
 	}
 }
 

--- a/internal/services/repair_manager/ruler/leaf_test.go
+++ b/internal/services/repair_manager/ruler/leaf_test.go
@@ -101,7 +101,7 @@ func (ts *LeafTestSuite) TestAsBool() {
 	ts.testBoolVal(NewLeafInt64(2), true, nil)
 	ts.testBoolVal(NewLeafInt64(0), false, nil)
 
-	ts.testBoolVal(NewLeafString("test"), false, ErrInvalidType)
+	ts.testBoolVal(NewLeafString("test"), false, ErrInvalidType(ValueString))
 }
 
 func (ts *LeafTestSuite) testInt32Val(l *Leaf, expected int32, expErr error) {
@@ -127,7 +127,7 @@ func (ts *LeafTestSuite) TestAsInt32() {
 	ts.testInt32Val(NewLeafInt64(1<<33+2), 2, nil)
 	ts.testInt32Val(NewLeafInt64(1<<34-2), -2, nil)
 
-	ts.testInt32Val(NewLeafString("test"), 0, ErrInvalidType)
+	ts.testInt32Val(NewLeafString("test"), 0, ErrInvalidType(ValueString))
 }
 
 func (ts *LeafTestSuite) testInt64Val(l *Leaf, expected int64, expErr error) {
@@ -151,7 +151,7 @@ func (ts *LeafTestSuite) TestAsInt64() {
 	ts.testInt64Val(NewLeafInt64(-1), -1, nil)
 	ts.testInt64Val(NewLeafInt64(2), 2, nil)
 
-	ts.testInt64Val(NewLeafString("test"), 0, ErrInvalidType)
+	ts.testInt64Val(NewLeafString("test"), 0, ErrInvalidType(ValueString))
 }
 
 func (ts *LeafTestSuite) testStringVal(l *Leaf, expected string, expErr error) {

--- a/internal/services/repair_manager/ruler/node_test.go
+++ b/internal/services/repair_manager/ruler/node_test.go
@@ -214,7 +214,7 @@ func (ts *NodeTestSuite) TestAllEvaluate() {
 
 	l, err = n.Evaluate(ec)
 	require.Error(err)
-	assert.Equal(ErrInvalidType, err)
+	assert.Equal(ErrInvalidType(ValueString), err)
 }
 
 func (ts *NodeTestSuite) TestAnyEvaluate() {
@@ -252,7 +252,7 @@ func (ts *NodeTestSuite) TestAnyEvaluate() {
 
 	l, err = n.Evaluate(ec)
 	require.Error(err)
-	assert.Equal(ErrInvalidType, err)
+	assert.Equal(ErrInvalidType(ValueString), err)
 }
 
 func (ts *NodeTestSuite) TestInvalidEvaluate() {
@@ -270,7 +270,7 @@ func (ts *NodeTestSuite) TestInvalidEvaluate() {
 
 	_, err := n.Evaluate(ec)
 	require.Error(err)
-	assert.Equal(ErrInvalidOp, err)
+	assert.Equal(ErrInvalidOp(OpInvalid), err)
 }
 
 func TestNodeTestSuite(t *testing.T) {

--- a/internal/services/repair_manager/ruler/rules.go
+++ b/internal/services/repair_manager/ruler/rules.go
@@ -1,24 +1,57 @@
 package ruler
 
 import (
-	"errors"
+	"context"
+	"fmt"
+
+	"github.com/Jim3Things/CloudChamber/internal/tracing"
 )
 
 // Error definitions.  Placeholder for now.
 
-var ErrInvalidType = errors.New("invalid type")
-var ErrInvalidOp = errors.New("invalid operation")
-var ErrInvalidArgLen = errors.New("invalid number of arguments")
+type ErrInvalidType ValueType
+func (e ErrInvalidType) Error() string {
+	return fmt.Sprintf("unexpected value type %d encountered", int(e))
+}
+
+type ErrInvalidOp OpType
+func (e ErrInvalidOp) Error() string {
+	return fmt.Sprintf("unexpected operation %d encountered", int(e))
+}
+
+type ErrInvalidArgLen struct {
+	op string
+	required string
+	actual int
+}
+func (e ErrInvalidArgLen) Error() string {
+	return fmt.Sprintf("operation %s expects %s but received %d", e.op, e.required, e.actual)
+}
+
+type ErrMissingFieldName string
+func (e ErrMissingFieldName) Error() string {
+	return fmt.Sprintf(
+		"key must have a table name, one or more path elements, and one field name.  " +
+			"no field name was found in %q.", string(e))
+}
+
+type ErrExtraFieldNames string
+func (e ErrExtraFieldNames) Error() string {
+	return fmt.Sprintf(
+		"key must have a table name, one or more path elements, and one field name.  " +
+			"multiple possible field were names found in %q.",
+			string(e))
+}
+
+type ErrMissingPath string
+func (e ErrMissingPath) Error() string {
+	return fmt.Sprintf(
+		"key must have a table name, one or more path elements, and one field name.  " +
+			"No path elements were found in %q.",
+			string(e))
+}
 
 // Define the rules definition layout
-
-type Tables interface {
-	GetTable(name string) (*Table, error)
-}
-
-type Table interface {
-	GetValue(key string) (interface{}, error)
-}
 
 // Proposal is the placeholder structure for the result from calling the
 // output function
@@ -107,24 +140,7 @@ func N(key string) Term {
 
 // V creates a Term holding the specified value.
 func V(value interface{}) Term {
-	switch v := value.(type) {
-	case bool:
-		return NewLeafBool(v)
-
-	case int32:
-		return NewLeafInt32(v)
-
-	case int:
-		return NewLeafInt32(int32(v))
-
-	case int64:
-		return NewLeafInt64(v)
-
-	case string:
-		return NewLeafString(v)
-	}
-
-	return nil
+	return NewLeaf(value)
 }
 
 // Match creates the Terms to hold a Match test
@@ -148,3 +164,78 @@ func Any(terms ...Term) Term {
 }
 
 // --- Rule API functions
+
+// Process is the main entry into the rules processing.  It processes each
+// rule, looking for a match.  When it finds one, it adds it to the set of
+// proposals.  When it gets an error processing, it stops and immediately
+// returns.
+//
+// -- Should it return on the first proposal match?  If it gets an error
+//    should it return the previously completed proposals?
+func Process(rules []Rule, tables Tables, vars map[string]string) ([]*Proposal, error) {
+	ec := &EvalContext{
+		Replacements: varsToReplacements(vars),
+		Tables:       tables,
+	}
+
+	var proposals []*Proposal
+
+	for _, rule := range rules {
+		reason := ""
+
+		v, err := processTerm(rule.Where, ec)
+		if err != nil {
+			return nil, err
+		}
+
+		but := " but"
+		if v {
+			reason = rule.Reason
+			for _, choice := range rule.Choices {
+				v, err := processTerm(choice.Assuming, ec)
+				if err != nil {
+					return nil, err
+				}
+
+				if v {
+					reason = fmt.Sprintf("%s and %s", reason, choice.Chosen)
+					_, span := tracing.StartSpan(context.Background(),
+						tracing.WithReason(reason))
+
+					p, err := choice.Call(choice.With)
+					if err != nil {
+						return nil, err
+					}
+					proposals = append(proposals, p)
+
+					span.End()
+					break
+				} else {
+
+					reason = fmt.Sprintf("%s%s %s", reason, but, choice.Rejected)
+					but = ", "
+				}
+			}
+		}
+	}
+
+	return proposals, nil
+}
+
+func varsToReplacements(vars map[string]string) []string {
+	var r []string
+	for k, v := range vars {
+		r = append(r, k, v)
+	}
+
+	return r
+}
+
+func processTerm(where Term, ec *EvalContext) (bool, error) {
+	res, err := where.Evaluate(ec)
+	if err != nil {
+		return false, err
+	}
+
+	return res.AsBool()
+}

--- a/internal/services/repair_manager/ruler/rules_api_test.go
+++ b/internal/services/repair_manager/ruler/rules_api_test.go
@@ -1,10 +1,52 @@
 package ruler
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/Jim3Things/CloudChamber/pkg/errors"
 )
+
+type MockTable struct {
+	rows map[string]map[string]interface{}
+}
+
+func (m *MockTable) GetValue(key *Key) (interface{}, error) {
+	if len(key.Nodes) != 1 {
+		return nil, ErrInvalidArgLen{
+			op:       fmt.Sprintf("GetValue from table %s", key.Table),
+			required: "exactly 1 node in the path",
+			actual:   len(key.Nodes),
+		}
+	}
+
+	row, ok := m.rows[key.Nodes[0]]
+	if !ok {
+		return nil, errors.ErrStoreKeyNotFound(key.Nodes[0])
+	}
+
+	v, ok := row[key.Field]
+	if !ok {
+		return nil, errors.ErrStoreKeyNotFound(key.Field)
+	}
+
+	return v, nil
+}
+
+type MockTables struct {
+	tables map[string]*MockTable
+}
+
+func (mt *MockTables) GetTable(key *Key) (Table, error) {
+	r, ok := mt.tables[key.Table]
+	if !ok {
+		return nil, errors.ErrStoreKeyNotFound(key.Table)
+	}
+
+	return r, nil
+}
 
 type RulesApiTestSuite struct {
 	suite.Suite
@@ -16,6 +58,70 @@ func (ts *RulesApiTestSuite) testLeaf(l Term, vt ValueType) {
 	s, ok := l.(*Leaf)
 	require.True(ok)
 	require.Equal(vt, s.vtype)
+}
+
+func (ts *RulesApiTestSuite) buildMockTable(rowCount int) *MockTable {
+	rows := make(map[string]map[string]interface{})
+
+	for i := 0; i < rowCount; i++ {
+		kv := make(map[string]interface{})
+		kv["f1"] = i
+		kv["s2"] = fmt.Sprintf("test%d", i)
+		kv["b3"] = i/2 * 2 == i
+		rows[fmt.Sprintf("row%d", i)] = kv
+	}
+
+	return &MockTable{rows: rows}
+}
+
+func (ts *RulesApiTestSuite) buildMockTables(tableCount int, rowCount int) *MockTables {
+	t := make(map[string]*MockTable)
+	for i := 0; i < tableCount; i++ {
+		t[fmt.Sprintf("table%d", i)] = ts.buildMockTable(rowCount)
+	}
+
+	return &MockTables{tables: t}
+}
+
+func (ts *RulesApiTestSuite) TestSimple() {
+	require := ts.Require()
+
+	tables := ts.buildMockTables(2, 2)
+
+	vars := make(map[string]string)
+	vars["%table%"] = "table1"
+
+	r := []Rule{
+		{
+			Where:  Match(N("%table%/row1.f1"), V(1)),
+			Reason: "f1 matched expectations",
+			Choices: []RuleChoice{
+				{
+					Assuming: V(true),
+					Chosen:   "always chosen",
+					Rejected: "never fails",
+					With:     nil,
+					Call: func(args []Arg) (*Proposal, error) {
+						return &Proposal{}, nil
+					},
+				},
+				{
+					Assuming: V(true),
+					Chosen:   "should not be chosen",
+					Rejected: "should not get here",
+					With:     nil,
+					Call: func(args []Arg) (*Proposal, error) {
+						require.Fail("should not get here")
+						return &Proposal{}, nil
+					},
+				},
+			},
+		},
+	}
+
+	props, err := Process(r, tables, vars)
+	require.NoError(err)
+	require.NotNil(props)
 }
 
 func (ts *RulesApiTestSuite) TestV() {

--- a/internal/services/repair_manager/ruler/tables.go
+++ b/internal/services/repair_manager/ruler/tables.go
@@ -1,0 +1,54 @@
+package ruler
+
+import (
+	"strings"
+)
+
+// Key defines the path to a designated field.
+type Key struct {
+	Table string
+	Nodes []string
+	Field string
+}
+
+// MakeKey produces a key from a path string which uses '/' between table and
+// path node elements, and '.' to designate a field.  For instance, the string
+// 'table1/path1/path2.field1' would designate table 'table1', a path made up
+// of two nodes: 'path1' with 'path2' as its child, and a field called
+// 'field1'.
+func MakeKey(path string) (*Key, error) {
+	pathAndField := strings.Split(path, ".")
+	if len(pathAndField) == 1 {
+		return nil, ErrMissingFieldName(path)
+	}
+
+	if len(pathAndField) > 2 {
+		return nil, ErrExtraFieldNames(path)
+	}
+
+	tableAndPath := strings.Split(pathAndField[0], "/")
+
+	if len(tableAndPath) == 1 {
+		return nil, ErrMissingPath(path)
+	}
+
+	return &Key{
+		Table: tableAndPath[0],
+		Nodes: tableAndPath[1:],
+		Field: pathAndField[1],
+	}, nil
+}
+
+// Tables defines the core interface for a collection of tables.
+type Tables interface {
+	// GetTable returns the table that matches the Table field in the key
+	GetTable(key *Key) (Table, error)
+}
+
+// Table defines the core interface for a named table of values
+type Table interface {
+	// GetValue returns a field value that matches the path and field names
+	// in the key
+	GetValue(key *Key) (interface{}, error)
+}
+

--- a/internal/services/repair_manager/ruler/term.go
+++ b/internal/services/repair_manager/ruler/term.go
@@ -6,7 +6,8 @@ type EvalContext struct {
 	// expanding a name string.
 	Replacements []string
 
-	// -- data access values are TBD
+	// Tables holds the access to the data tables used by these rules
+	Tables Tables
 }
 
 // Term is the general definition for an entry in the ruleset - either an


### PR DESCRIPTION
This mostly adds interfaces to the table stores, implements fetch via that, and has a unit test to verify the basic simple case.

Aside form the normal, looking for confirmation that the table interface is acceptable.

Purposefully not in part 2:

output function and proposal structure still outstanding.
Reason text started, but tracing in general needs to be added.
Need to extend unit tests and add unit test tracing exporter support.