### PR TITLE
Fix how ETag values are constructed and parsed

### DIFF
--- a/internal/services/frontend/doc.go
+++ b/internal/services/frontend/doc.go
@@ -117,7 +117,7 @@
 // This includes the blade ID number and associated URI.
 //
 // GET /api/racks/{rackid}/blades/{bladeid}
-// Returns the detail information for the blade numbed by bladeid in the rack
+// Returns the detail information for the blade number by bladeid in the rack
 // identified by rackid.
 //
 //
@@ -162,6 +162,9 @@
 // supplied document is invalid in some way, or if the supplied username is not
 // known.
 //
+// This operation is normally gated by an If-Match on a previously returned
+// revision ETag.
+//
 // POST /api/users/{username}
 // Creates a record for the user matching username, or an error if the supplied
 // document is invalid in some way. If the user record is successfully created,
@@ -174,9 +177,6 @@
 // If the username already exists and the supplied document differs from the
 // existing user record in any significant way, the response will be an HTTP
 // 409 (Conflict) status.
-//
-// This operation is normally gated by an If-Match on a previously returned
-// revision ETag.
 //
 // DELETE /api/users/{username}
 // Deletes the record for the user matching username, or an error is the

--- a/internal/services/frontend/doc.go
+++ b/internal/services/frontend/doc.go
@@ -10,6 +10,10 @@
 // specific source file associated with it.  These, and their associated
 // URL subtrees, are:
 //
+// frontend.go : all URIs
+// This is the starting point for the http processing.  It initializes the http
+// service attributes, including the initialization of the modules above.
+//
 // faults.go : /api/faults subtree
 // Implements the service handler to retrieve information on faults, to inject
 // faults into the simulated structure, to create and view devops actions.
@@ -40,131 +44,211 @@
 //
 // There are also a number of supporting files:
 //
-// frontend.go
-// Base file containing the global definition for the package and the main() entry point
+// etag.go
+// This module implements functions to convert between a revision number and a
+// legal ETag string.
 //
-// Service Syntax
-// ==============
+// httpErrors.go
+// This module implements custom errors designed to be returned in an HTTP
+// response, and validation functions used on incoming HTTP requests.
 //
-// In the below definitions, the "{" and "}" characters surround an object name/key and are not included
-// in the URI. For example, to read the record of the user with the name "Bob", the URI would be
+// session_manager.go
+// Implements the handling and lifecycle management for logged in user sessions.
 //
-// First, note that /api is a reserved subtree for all REST operations.  Any URI that is outside
-// of that subtree is assumed to be a static file that needs to be served.
 //
+// Finally, there are several files that provide access to the underlying data
+// stores.  Each is responsible for mediating access to a single table.  These
+// are:
+//
+// DBInventory.go: access to the inventory defined state table.
+// DBInventoryActual.go: access to the inventory current state table.
+// DBUsers.go: access to the known users state table.
+//
+//
+// REST Service Syntax
+// ===================
+//
+// In the below definitions, the "{" and "}" characters surround an object
+// name/key and are not included in the URI. For example, to read the record
+// of the user with the name "Bob", the URI would be "/api/users/Bob".
+//
+// First, note that /api is a reserved subtree for all REST operations.  Any
+// URI that is outside of that subtree is assumed to be a static file that
+// needs to be served.
+//
+// Second, note that most calls do not require ETag validation.  Those that do
+// are called out in their description.
+//
+//
+// /api/logs
+// ----------
+//
+// GET /api/logs?from={startingID}&for={limit}
+// Returns log entries, starting with the startingID value, up to the limit
+// number of entries.  If the last log entry is not yet at the startingID, the
+// call will wait for new log entries to be created before returning.
+//
+// GET /api/logs/policy
+// Returns the current log stream policy, including the earliest known log ID
+// and the maximum number of log entries that may be returned in a single call.
+//
+// /api/ping
+//
+// GET /api/ping
+// This is a simple operation that resets the inactivity timeout on a logged in
+// session.
+//
+// /api/racks
+// -----------
+//
+// GET /api/racks
+// Returns a summary list of all racks. This includes, for each rack, its name,
+// the URI to use to get detailed information, and the maximum capacity and
+// population limits for the blades in that rack.  This is sufficient to block
+// in a graphical display of all racks.
+//
+// GET /api/racks/{rackid}
+// Returns the detail information about the rack identified by rackid.  This
+// includes information about the blades and rack-level support components,
+// such as the TOR and PDU.
+//
+// GET /api/racks/{rackid}/blades
+// Returns the summary list of the blades in the rack identified by rackid.
+// This includes the blade ID number and associated URI.
+//
+// GET /api/racks/{rackid}/blades/{bladeid}
+// Returns the detail information for the blade numbed by bladeid in the rack
+// identified by rackid.
+//
+//
+// /api/stepper
+// ------------
+//
+// GET /api/stepper
+// Returns the current simulated time service status, including policy revision,
+// policy mode and advance rate
+//
+// GET /api/stepper/now
+// Returns the current simulated time
+//
+// GET /api/stepper/now?after={duetime}
+// Waits until the simulated time is equal or greater than the duetime.  It then
+// returns the current simulated time.
+//
+// PUT - /api/stepper?advance[={ticks}]
+// Moves simulated time forward, so long as the mode is manual.  The number of
+// ticks to advance can be specified, with a default value of 1.
+//
+// PUT - /api/stepper?mode=(manual|automatic[={rate])
+// Sets the new mode to either manual advance, or automatic.  If automatic, a
+// rate in terms of ticks per second can be provided, with 1 tick per second as
+// the default.
+//
+// This operation is normally gated by an If-Match on a previously returned
+// revision ETag.
 //
 // /api/users/
 // -----------
 //
 // GET /api/users
-// list all the user records. At some point we may need to add a filter to restrict
-// the set being returned.
+// list all the user records.
 //
 // GET /api/users/{username}
-// Returns a single user record for the user matching username or an error if the
-// supplied username is not known.
+// Returns a single user record for the user matching username or an error if
+// the supplied username is not known.
 //
 // PUT /api/users/{username}
-// Updates the record for the user matching username, or an error if the supplied
-// document is invalid in some way, or if the supplied username is not known.
+// Updates the record for the user matching username, or an error if the
+// supplied document is invalid in some way, or if the supplied username is not
+// known.
 //
-// POST - /api/users/{username}
+// POST /api/users/{username}
 // Creates a record for the user matching username, or an error if the supplied
 // document is invalid in some way. If the user record is successfully created,
 // the response will be an HTTP 201 (Created) status.
 //
 // If the supplied username is already known, and the supplied document exactly
 // matches the existing record, this will be interpreted as a duplicate request
-// and will result in an HTTP 200 (OK) status code. If the username already exists
-// and the supplied document differs from the existing user record in any significant
-// way, the response will be an HTTP 409 (Conflict) status.
+// and will result in an HTTP 200 (OK) status code.
 //
-// DELETE - /api/users/{username}
-// Deletes the record for the user matching username, or an error is the supplied
-// username is not known.
+// If the username already exists and the supplied document differs from the
+// existing user record in any significant way, the response will be an HTTP
+// 409 (Conflict) status.
+//
+// This operation is normally gated by an If-Match on a previously returned
+// revision ETag.
+//
+// DELETE /api/users/{username}
+// Deletes the record for the user matching username, or an error is the
+// supplied username is not known or is protected against deletion.
 //
 // PUT /api/users/{username}?op=[login|logout]
-// Updates the user record the for user matching username according to the supplied
-// operation, or returns and error if the supplied username is not known, or the
-// operation code is invalid in some way.
+// Updates the user record the for user matching username according to the
+// supplied operation, or returns and error if the supplied username is not
+// known, or the operation code is invalid in some way.
+//
+// PUT /api/users/{username}?password
+// Updates the password for the user with value specified in the request body.
+//
+// This operation is normally gated by an If-Match on a previously returned
+// revision ETag.
+//
+// Outstanding or Future items
+// ===========================
+//
+// All REST calls that return collections of items need to support filtering at
+// the service, and paging (the ability to incrementally return the response).
+//
+// Operations that wait need to support cancellation.
+//
+// Ping, and the various waiting operations, need to be merged into a single
+// change notification call with a timeout.
+//
+// Update operations that do not require ETag validation need to be reviewed as
+// to whether or not they should.
+//
+// Some REST subtrees are not currently implemented:
+// /api/faults
+// -----------
+// (This is to be filled in as the design progresses)
+//
+// /api/racks
+// ----------
+// This subtree needs to add support for retrieval of the different viewpoints
+// on the inventory: its defined state, its target state, the last observed
+// state in the controller, and the current simulated state.
+//
+// This subtree needs to add support for modifying the target and defined states
+// of the inventory.
 //
 // /api/workloads
 // --------------
+// (This is still a to be done subtree, and the list below is therefore likely
+// incomplete and subject to change.)
+//
+// Much like /api/racks, this subtree needs to add support for retrieval of the
+// different viewpoints: its defined state, its target state, the last observed
+// state in the controller, and the current simulated state.
 //
 // GET - /api/workloads
-// list all the workload records. At some point we may need to add a filter to restrict
-// the set being returned.
+// list all the workload records.
 //
 // GET - /api/workloads/{workloadname}
-// Returns a single workload record for the workload matching workloadname or an error if the
-// supplied workloadname is not known.
+// Returns a single workload record for the workload matching workloadname or
+// an error if the supplied workloadname is not known.
 //
 // PUT - /api/workloads/{workloadname}
-// Updates the record for the workload matching workloadname, or an error if the supplied
-// document is invalid in some way, or if the supplied workloadname is not known.
+// Updates the record for the workload matching workloadname, or an error if the
+// supplied document is invalid in some way, or if the supplied workloadname is
+// not known.
 //
 // POST - /api/workloads/{workloadname}
-// Creates a record for the workload matching workloadname, or an error if the supplied
-// document is invalid in some way, or if the supplied workloadname is already known.
+// Creates a record for the workload matching workloadname, or an error if the
+// supplied document is invalid in some way, or if the supplied workloadname is
+// already known.
 //
 // DELETE - /api/workloads/{workloadname}
-// Deletes the record for the workload matching workloadname, or an error is the supplied
-// workloadname is not known.
+// Deletes the record for the workload matching workloadname, or an error is the
+// supplied workloadname is not known.
 //
-// PUT /api/workloads/{workloadname}?op=[login|logout|enable|disable]
-// Updates the workload record the for workload matching workloadname according to the supplied
-// operation, or returns and error if the supplied workloadname is not known, or the
-// operation code is invalid in some way.
-//
-// /api/racks/
-// -----------
-//
-// GET - /api/racks  //Get the list of all known racks.
-//
-// GET - /api/racks/{rackid}  //Returns a single rack ID record.
-//
-// GET - /api/racks/{rack-id}/blades //Get list of known blades in a rack.
-//
-// GET - /api/racks/{rack-id}/TOR  //Get Top of Racks details .
-//
-// GET - /api/racks/{rack-id}/PDU //Gets Power distribution Unit details.
-//
-// GET - /api/racks/{rack-id}/blades/{blade-id} //Returns a record details of a single blade.
-//
-// GET - /api/racks/{rack-id}/TOR //To get details about a specific blade in a specific rack
-//
-// GET - /api/racks/rack-id/PDU //Gets Power distribution Unit details.
-//
-//
-// /api/stepper
-// ------------
-//
-// GET - /api/stepper
-// Returns the current simulated time, mode and advance rate
-//
-// GET - /api/stepper/now
-// Returns the current simulated time
-//
-// PUT - /api/stepper?advance
-// Moves simulated time forward, so long as the mode is manual
-// This relies on an ETag returned by either of the two preceding GET operations
-//
-// PUT - /api/stepper?mode={manual|automatic[=rate]}
-// Sets the new mode and advance rate
-// This relies on an ETag returned by the first GET operation above
-//
-// /api/faults
-// -----------
-//
-// GET - /api/faults
-//
-// TODO
-//
-// /api/logs
-//
-// /api/faults
-// /api/inventory
-// will be a configuration file. you will be
-// /point to cmd. Few of them per server.
-// */
 package frontend

--- a/internal/services/frontend/doc.go
+++ b/internal/services/frontend/doc.go
@@ -1,145 +1,170 @@
-// This directory holds the primary frontend for the CloudChamber web service. It calls
-// out to, or invokes the component libraries and microservices as nessesary that provide
-// the actual implementation of the CloudChamber project.
 
-/*
-Package frontend implements the primary service front end to receive the
-user HTTP requests, route the request to the appropriate libraries
-and/or micro-services and then format the response.
-
-File Layout
-===========
-
-frontend.go
-Base file containing the global definition for the package and the main() entry point
-
-users.go
-Implements the service handler to provide the API to manage user records. Generally
-invoked by the UI files and scripts executing on the client browser.
-
-workloads.go
-Implements the service handler to provide the API to manage workload records. Generally
-invoked by the UI files and scripts executing on the client browser.
-
-stepper.go
-Implements the service handler to provide the API to query and change the simulated
-time.
-
-Service Syntax
-==============
-
-In the below definitions, the "{" and "}" characters surround an object name/key and are not included
-in the URI. For example, to read the record of the user with the name "Bob", the URI would be
-
-First, note that /api is a reserved subtree for all REST operations.  Any URI that is outside
-of that subtree is assumed to be a static file that needs to be served.
-
-
-GET - /api/users/Bob
-
-
-The syntax of the commands to the web servers are
-
-GET - /api/users
-list all the user records. At some point we may need to add a filter to restrict
-the set being returned.
-
-GET - /api/users/{username}
-Returns a single user record for the user matching username or an error if the
-supplied username is not known.
-
-PUT - /api/users/{username}
-Updates the record for the user matching username, or an error if the supplied
-document is invalid in some way, or if the supplied username is not known.
-
-POST - /api/users/{username}
-Creates a record for the user matching username, or an error if the supplied
-document is invalid in some way. If the user record is successfully created,
-the response will be an HTTP 201 (Created) status.
-
-If the supplied username is already known, and the supplied document excatly
-matches the existing record, this will be interpreted as a duplicate request
-and will result in an HTTP 200 (OK) status code. If the username already exists
-and the supplied document differs from the existing user record in any significant
-way, the response will be an HTTP 409 (Conflict) status.
-
-DELETE - /api/users/{username}
-Deletes the record for the user matching username, or an error is the supplied
-username is not known.
-
-PUT /api/users/{username}?op=[login|logout]
-Updates the user record the for user matching username according to the supplied
-operation, or returns and error if the supplied username is not known, or the
-operation code is invalid in some way.
-
-/api/workloads
-
-GET - /api/workloads
-list all the workload records. At some point we may need to add a filter to restrict
-the set being returned.
-
-GET - /api/workloads/{workloadname}
-Returns a single workload record for the workload matching workloadname or an error if the
-supplied workloadname is not known.
-
-PUT - /api/workloads/{workloadname}
-Updates the record for the workload matching workloadname, or an error if the supplied
-document is invalid in some way, or if the supplied workloadname is not known.
-
-POST - /api/workloads/{workloadname}
-Creates a record for the workload matching workloadname, or an error if the supplied
-document is invalid in some way, or if the supplied workloadname is already known.
-
-DELETE - /api/workloads/{workloadname}
-Deletes the record for the workload matching workloadname, or an error is the supplied
-workloadname is not known.
-
-PUT /api/workloads/{workloadname}?op=[login|logout|enable|disable]
-Updates the workload record the for workload matching workloadname according to the supplied
-operation, or returns and error if the supplied workloadname is not known, or the
-operation code is invalid in some way.
-
-GET - /api/racks  //Get the list of all known racks.
-
-GET - /api/racks/{rackid}  //Returns a single rack ID record.
-
-GET - /api/racks/{rack-id}/blades //Get list of known blades in a rack.
-
-GET - /api/racks/{rack-id}/TOR  //Get Top of Racks details .
-
-GET - /api/racks/{rack-id}/PDU //Gets Power distribution Unit details.
-
-GET - /api/racks/{rack-id}/blades/{blade-id} //Returns a record details of a single blade.
-
-GET - /api/racks/{rack-id}/TOR //To get details about a specific blade in a specific rack
-
-GET - /api/racks/rack-id/PDU //Gets Power distribution Unit details.
-
-
-/api/stepper
-
-GET - /api/stepper
-Returns the current simulated time, mode and advance rate
-
-GET - /api/stepper/now
-Returns the current simulated time
-
-PUT - /api/stepper?advance
-Moves simulated time forward, so long as the mode is manual
-This relies on an ETag returned by either of the two preceding GET operations
-
-PUT - /api/stepper?mode={manual|automatic[=rate]}
-Sets the new mode and advance rate
-This relies on an ETag returned by the first GET operation above
-
-TODO
-
-/api/logs
-
-/api/stepper
-/api/injector
-/api/inventory
-will be a configuration file. you will be
-/point to cmd. Few of them per server.
-*/
+// Package frontend implements the primary service front end to receive the
+// user HTTP requests, route the request to the appropriate libraries and/or
+// micro-services and then format the response.
+//
+// File Layout
+// ===========
+//
+// Each major object type is represented by a subtree root in the URL, and a
+// specific source file associated with it.  These, and their associated
+// URL subtrees, are:
+//
+// faults.go : /api/faults subtree
+// Implements the service handler to retrieve information on faults, to inject
+// faults into the simulated structure, to create and view devops actions.
+//
+// inventory.go : /api/racks subtree
+// Implements the service handler to retrieve information about the simulated
+// inventory.  This spans declared content, as well as target, observed, and
+// current status.
+//
+// logs.go : /api/logs subtree
+// Implements the service handler to retrieve log entries, or to wait for new
+// ones.
+//
+// ping.go : /api/ping subtree
+// Implements a simple service handler used to reset the inactivity timer for
+// the logged in session.
+//
+// stepper.go : /api/stepper subtree
+// Implements the service handler to provide the API to query and change the
+// simulated time.
+//
+// users.go : /api/users subtree
+// Implements the service handler to provide the API to manage user records, as
+// well as logging into or out of a simulation.
+//
+// workloads.go : /api/workloads subtree
+// Implements the service handler to provide the API to manage workload records.
+//
+// There are also a number of supporting files:
+//
+// frontend.go
+// Base file containing the global definition for the package and the main() entry point
+//
+// Service Syntax
+// ==============
+//
+// In the below definitions, the "{" and "}" characters surround an object name/key and are not included
+// in the URI. For example, to read the record of the user with the name "Bob", the URI would be
+//
+// First, note that /api is a reserved subtree for all REST operations.  Any URI that is outside
+// of that subtree is assumed to be a static file that needs to be served.
+//
+//
+// /api/users/
+// -----------
+//
+// GET /api/users
+// list all the user records. At some point we may need to add a filter to restrict
+// the set being returned.
+//
+// GET /api/users/{username}
+// Returns a single user record for the user matching username or an error if the
+// supplied username is not known.
+//
+// PUT /api/users/{username}
+// Updates the record for the user matching username, or an error if the supplied
+// document is invalid in some way, or if the supplied username is not known.
+//
+// POST - /api/users/{username}
+// Creates a record for the user matching username, or an error if the supplied
+// document is invalid in some way. If the user record is successfully created,
+// the response will be an HTTP 201 (Created) status.
+//
+// If the supplied username is already known, and the supplied document exactly
+// matches the existing record, this will be interpreted as a duplicate request
+// and will result in an HTTP 200 (OK) status code. If the username already exists
+// and the supplied document differs from the existing user record in any significant
+// way, the response will be an HTTP 409 (Conflict) status.
+//
+// DELETE - /api/users/{username}
+// Deletes the record for the user matching username, or an error is the supplied
+// username is not known.
+//
+// PUT /api/users/{username}?op=[login|logout]
+// Updates the user record the for user matching username according to the supplied
+// operation, or returns and error if the supplied username is not known, or the
+// operation code is invalid in some way.
+//
+// /api/workloads
+// --------------
+//
+// GET - /api/workloads
+// list all the workload records. At some point we may need to add a filter to restrict
+// the set being returned.
+//
+// GET - /api/workloads/{workloadname}
+// Returns a single workload record for the workload matching workloadname or an error if the
+// supplied workloadname is not known.
+//
+// PUT - /api/workloads/{workloadname}
+// Updates the record for the workload matching workloadname, or an error if the supplied
+// document is invalid in some way, or if the supplied workloadname is not known.
+//
+// POST - /api/workloads/{workloadname}
+// Creates a record for the workload matching workloadname, or an error if the supplied
+// document is invalid in some way, or if the supplied workloadname is already known.
+//
+// DELETE - /api/workloads/{workloadname}
+// Deletes the record for the workload matching workloadname, or an error is the supplied
+// workloadname is not known.
+//
+// PUT /api/workloads/{workloadname}?op=[login|logout|enable|disable]
+// Updates the workload record the for workload matching workloadname according to the supplied
+// operation, or returns and error if the supplied workloadname is not known, or the
+// operation code is invalid in some way.
+//
+// /api/racks/
+// -----------
+//
+// GET - /api/racks  //Get the list of all known racks.
+//
+// GET - /api/racks/{rackid}  //Returns a single rack ID record.
+//
+// GET - /api/racks/{rack-id}/blades //Get list of known blades in a rack.
+//
+// GET - /api/racks/{rack-id}/TOR  //Get Top of Racks details .
+//
+// GET - /api/racks/{rack-id}/PDU //Gets Power distribution Unit details.
+//
+// GET - /api/racks/{rack-id}/blades/{blade-id} //Returns a record details of a single blade.
+//
+// GET - /api/racks/{rack-id}/TOR //To get details about a specific blade in a specific rack
+//
+// GET - /api/racks/rack-id/PDU //Gets Power distribution Unit details.
+//
+//
+// /api/stepper
+// ------------
+//
+// GET - /api/stepper
+// Returns the current simulated time, mode and advance rate
+//
+// GET - /api/stepper/now
+// Returns the current simulated time
+//
+// PUT - /api/stepper?advance
+// Moves simulated time forward, so long as the mode is manual
+// This relies on an ETag returned by either of the two preceding GET operations
+//
+// PUT - /api/stepper?mode={manual|automatic[=rate]}
+// Sets the new mode and advance rate
+// This relies on an ETag returned by the first GET operation above
+//
+// /api/faults
+// -----------
+//
+// GET - /api/faults
+//
+// TODO
+//
+// /api/logs
+//
+// /api/faults
+// /api/inventory
+// will be a configuration file. you will be
+// /point to cmd. Few of them per server.
+// */
 package frontend

--- a/internal/services/frontend/etag.go
+++ b/internal/services/frontend/etag.go
@@ -12,9 +12,9 @@ func formatAsEtag(rev int64) string {
 	return fmt.Sprintf("\"%d\"", rev)
 }
 
-// parseAsMatchTag converts a string into the revision number that would have
+// parseETag converts a string into the revision number that would have
 // been provided as a previous ETag, or an error if it is unable to parse it.
-func parseAsMatchTag(match string) (int64, error) {
+func parseETag(match string) (int64, error) {
 	test := strings.Trim(match, "\"")
 	return strconv.ParseInt(test, 10, 64)
 }

--- a/internal/services/frontend/etag.go
+++ b/internal/services/frontend/etag.go
@@ -1,0 +1,20 @@
+package frontend
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// formatAsEtag converts a number into a string formatted to meet the ETag
+// specification.
+func formatAsEtag(rev int64) string {
+	return fmt.Sprintf("\"%d\"", rev)
+}
+
+// parseAsMatchTag converts a string into the revision number that would have
+// been provided as a previous ETag, or an error if it is unable to parse it.
+func parseAsMatchTag(match string) (int64, error) {
+	test := strings.Trim(match, "\"")
+	return strconv.ParseInt(test, 10, 64)
+}

--- a/internal/services/frontend/faults.go
+++ b/internal/services/frontend/faults.go
@@ -8,7 +8,7 @@ import (
 )
 
 func injectionAddRoutes(routeBase *mux.Router) {
-	router := routeBase.PathPrefix("/inject").Subrouter()
+	router := routeBase.PathPrefix("/faults").Subrouter()
 
 	router.HandleFunc("", handlerInjectionRoot).Methods("GET")
 	router.HandleFunc("/", handlerInjectionRoot).Methods("GET")

--- a/internal/services/frontend/inventory.go
+++ b/internal/services/frontend/inventory.go
@@ -90,7 +90,7 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 
 		return nil
 	})
-
+If
 	if err != nil {
 		postHTTPError(ctx, w, err)
 		return

--- a/internal/services/frontend/inventory.go
+++ b/internal/services/frontend/inventory.go
@@ -90,7 +90,7 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 
 		return nil
 	})
-If
+
 	if err != nil {
 		postHTTPError(ctx, w, err)
 		return

--- a/internal/services/frontend/stepper.go
+++ b/internal/services/frontend/stepper.go
@@ -2,7 +2,6 @@ package frontend
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -61,7 +60,7 @@ func handleGetStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("ETag", fmt.Sprintf("%v", stat.Epoch))
+	w.Header().Set("ETag", formatAsEtag(stat.Epoch))
 
 	p := jsonpb.Marshaler{}
 	err = p.Marshal(w, stat)
@@ -148,8 +147,7 @@ func handleSetMode(w http.ResponseWriter, r *http.Request) {
 	}
 
 	matchString := r.Header.Get("If-Match")
-	match, err := strconv.ParseInt(matchString, 10, 64)
-
+	match, err := parseAsMatchTag(matchString)
 	if err != nil {
 		postHTTPError(ctx, w, NewErrBadMatchType(matchString))
 		return
@@ -196,7 +194,7 @@ func handleSetMode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("ETag", fmt.Sprintf("%v", match+1))
+	w.Header().Set("ETag", formatAsEtag(match+1))
 
 	httpErrorIf(ctx, w, err)
 }

--- a/internal/services/frontend/stepper.go
+++ b/internal/services/frontend/stepper.go
@@ -147,7 +147,7 @@ func handleSetMode(w http.ResponseWriter, r *http.Request) {
 	}
 
 	matchString := r.Header.Get("If-Match")
-	match, err := parseAsMatchTag(matchString)
+	match, err := parseETag(matchString)
 	if err != nil {
 		postHTTPError(ctx, w, NewErrBadMatchType(matchString))
 		return

--- a/internal/services/frontend/stepper_test.go
+++ b/internal/services/frontend/stepper_test.go
@@ -33,12 +33,12 @@ func (ts *StepperTestSuite) setManual(match int64, cookies []*http.Cookie) []*ht
 	assert := ts.Assert()
 
 	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", ts.stepperPath(), "?mode=manual"), nil)
-	request.Header.Set("If-Match", fmt.Sprintf("%v", match))
+	request.Header.Set("If-Match", formatAsEtag(match))
 
 	response := ts.doHTTP(request, cookies)
 
 	assert.Equal(http.StatusOK, response.StatusCode)
-	assert.Equal(fmt.Sprintf("%v", match+1), response.Header.Get("ETag"))
+	assert.Equal(formatAsEtag(match+1), response.Header.Get("ETag"))
 
 	return response.Cookies()
 }
@@ -147,7 +147,7 @@ func (ts *StepperTestSuite) TestSetModeInvalid() {
 	cookies = ts.setManual(res.Epoch, cookies)
 
 	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", ts.stepperPath(), "?mode=badChoice"), nil)
-	request.Header.Set("If-Match", "-1")
+	request.Header.Set("If-Match", formatAsEtag(-1))
 
 	response = ts.doHTTP(request, cookies)
 
@@ -179,7 +179,7 @@ func (ts *StepperTestSuite) TestSetModeBadEpoch() {
 	cookies = ts.setManual(stat.Epoch, cookies)
 
 	request := httptest.NewRequest("PUT", fmt.Sprintf("%s%s", ts.stepperPath(), "?mode=manual"), nil)
-	request.Header.Set("If-Match", fmt.Sprintf("%v", stat.Epoch))
+	request.Header.Set("If-Match", formatAsEtag(stat.Epoch))
 
 	response = ts.doHTTP(request, cookies)
 

--- a/internal/services/frontend/users.go
+++ b/internal/services/frontend/users.go
@@ -267,7 +267,7 @@ func handlerUserUpdate(w http.ResponseWriter, r *http.Request) {
 	var match int64
 
 	matchString := r.Header.Get("If-Match")
-	match, err = parseAsMatchTag(matchString)
+	match, err = parseETag(matchString)
 	if err != nil {
 		postHTTPError(ctx, w, NewErrBadMatchType(matchString))
 		return
@@ -428,7 +428,7 @@ func handlerUserSetPassword(w http.ResponseWriter, r *http.Request) {
 	var match int64
 
 	matchString := r.Header.Get("If-Match")
-	match, err = parseAsMatchTag(matchString)
+	match, err = parseETag(matchString)
 	if err != nil {
 		postHTTPError(ctx, w, NewErrBadMatchType(matchString))
 		return

--- a/internal/services/frontend/users.go
+++ b/internal/services/frontend/users.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/golang/protobuf/jsonpb"
@@ -20,8 +19,8 @@ import (
 	"github.com/Jim3Things/CloudChamber/internal/clients/timestamp"
 	"github.com/Jim3Things/CloudChamber/internal/common"
 	"github.com/Jim3Things/CloudChamber/internal/tracing"
-    "github.com/Jim3Things/CloudChamber/pkg/errors"
-    pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
+	"github.com/Jim3Things/CloudChamber/pkg/errors"
+	pb "github.com/Jim3Things/CloudChamber/pkg/protos/admin"
 )
 
 const (
@@ -163,7 +162,7 @@ func handlerUserCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("ETag", fmt.Sprintf("%v", rev))
+	w.Header().Set("ETag", formatAsEtag(rev))
 
 	tracing.Info(
 		ctx,
@@ -209,7 +208,7 @@ func handlerUserRead(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("ETag", fmt.Sprintf("%v", rev))
+	w.Header().Set("ETag", formatAsEtag(rev))
 
 	ext := &pb.UserPublic{
 		Enabled:           u.Enabled,
@@ -268,7 +267,7 @@ func handlerUserUpdate(w http.ResponseWriter, r *http.Request) {
 	var match int64
 
 	matchString := r.Header.Get("If-Match")
-	match, err = strconv.ParseInt(matchString, 10, 64)
+	match, err = parseAsMatchTag(matchString)
 	if err != nil {
 		postHTTPError(ctx, w, NewErrBadMatchType(matchString))
 		return
@@ -301,7 +300,7 @@ func handlerUserUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("ETag", fmt.Sprintf("%v", rev))
+	w.Header().Set("ETag", formatAsEtag(rev))
 
 	ext := &pb.UserPublic{
 		Enabled:           newVer.Enabled,
@@ -429,7 +428,7 @@ func handlerUserSetPassword(w http.ResponseWriter, r *http.Request) {
 	var match int64
 
 	matchString := r.Header.Get("If-Match")
-	match, err = strconv.ParseInt(matchString, 10, 64)
+	match, err = parseAsMatchTag(matchString)
 	if err != nil {
 		postHTTPError(ctx, w, NewErrBadMatchType(matchString))
 		return
@@ -452,7 +451,7 @@ func handlerUserSetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("ETag", fmt.Sprintf("%v", rev))
+	w.Header().Set("ETag", formatAsEtag(rev))
 
 	tracing.Info(
 		ctx,

--- a/internal/services/frontend/users_test.go
+++ b/internal/services/frontend/users_test.go
@@ -83,7 +83,7 @@ func (ts *UserTestSuite) ensureAccount(
 
 		var rev int64
 		tagString := response.Header.Get("ETag")
-		rev, err := parseAsMatchTag(tagString)
+		rev, err := parseETag(tagString)
 		assert.NoError(err, "Error parsing ETag. tag = %q, err = %v", tagString, err)
 
 		return rev, response.Cookies()
@@ -110,7 +110,7 @@ func (ts *UserTestSuite) ensureAccount(
 	ts.knownNames[path] = path
 
 	tagString := response.Header.Get("ETag")
-	tag, err := parseAsMatchTag(tagString)
+	tag, err := parseETag(tagString)
 	assert.NoError(err, "Error parsing ETag. tag = %q, err = %v", tagString, err)
 
 	return tag, response.Cookies()
@@ -153,7 +153,7 @@ func (ts *UserTestSuite) setPassword(
 
 	response := ts.doHTTP(request, cookies)
 
-	match, err := parseAsMatchTag(response.Header.Get("ETag"))
+	match, err := parseETag(response.Header.Get("ETag"))
 	assert.NoError(err)
 
 	return response, match
@@ -176,7 +176,7 @@ func (ts *UserTestSuite) userUpdate(
 	response := ts.doHTTP(request, cookies)
 	assert.Equal(http.StatusOK, response.StatusCode)
 
-	tag, err := parseAsMatchTag(response.Header.Get("ETag"))
+	tag, err := parseETag(response.Header.Get("ETag"))
 	assert.NoError(err)
 
 	return response, tag
@@ -667,7 +667,7 @@ func (ts *UserTestSuite) TestRead() {
 
 	assert.Equal("application/json", strings.ToLower(response.Header.Get("Content-Type")))
 
-	match, err := parseAsMatchTag(response.Header.Get("ETag"))
+	match, err := parseETag(response.Header.Get("ETag"))
 	assert.NoError(err, "failed to convert the ETag to valid int64")
 	assert.Less(int64(1), match)
 
@@ -801,7 +801,7 @@ func (ts *UserTestSuite) TestUpdateSuccess() {
 	err = ts.getJSONBody(response, user)
 	assert.NoError(err, "Failed to convert body to valid json.  err: %v", err)
 
-	match, err := parseAsMatchTag(response.Header.Get("ETag"))
+	match, err := parseETag(response.Header.Get("ETag"))
 	assert.NoError(err, "failed to convert the ETag to valid int64")
 
 	// Note: since ensureAccount() will attempt to re-use an existing account, all we know is


### PR DESCRIPTION
ETag values are quoted strings, so we need to add the extra quotes when sending, and strip them off when matching.

.. This also pulls in a partial update to doc.go.