### PR TITLE
Add simulation status and trace retrieval cmdlets

### DIFF
--- a/clients/powershell/Cmdlets/Cmdlets.csproj
+++ b/clients/powershell/Cmdlets/Cmdlets.csproj
@@ -13,6 +13,7 @@
           <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
           <Visible>False</Visible>
         </Content>
+        <PackageReference Include="Google.Protobuf" Version="3.14.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.0-preview-06">
             <PrivateAssets>All</PrivateAssets>

--- a/clients/powershell/Cmdlets/Names.cs
+++ b/clients/powershell/Cmdlets/Names.cs
@@ -13,5 +13,22 @@
 
         internal const string Time = "CcTime";
         internal const string TimePolicy = "CcTimePolicy";
+
+        internal const string Simulation = "CcCluster";
+        internal const string Sessions = "CcSessions";
+        internal const string Session = "CcSession";
+
+        internal const string Traces = "CcTraces";
+        internal const string TracePolicy = "CcTracePolicy";
+
+        internal const string Zones = "CcZones";
+        internal const string Zone = "CcZone";
+
+        internal const string Racks = "CcRacks";
+        internal const string Rack = "CcRack";
+
+        internal const string Blade = "CcBlade";
+        internal const string Tor = "CcTor";
+        internal const string Pdu = "CcPdu";
     }
 }

--- a/clients/powershell/Cmdlets/Session.cs
+++ b/clients/powershell/Cmdlets/Session.cs
@@ -54,7 +54,7 @@ namespace CloudChamber.Cmdlets
     /// Connect to a specified account on the target cluster.
     /// </summary>
     [Cmdlet(VerbsCommunications.Connect, Names.Account)]
-    public class LoginCmdlet : Cmdlet
+    public class LoginCmdlet : PSCmdlet
     {
         /// <summary>
         /// ClusterUri is the address of the target cluster.
@@ -93,7 +93,7 @@ namespace CloudChamber.Cmdlets
     /// Disconnect an active session.
     /// </summary>
     [Cmdlet(VerbsCommunications.Disconnect, Names.Account)]
-    public class LogoutCmdlet : Cmdlet
+    public class LogoutCmdlet : PSCmdlet
     {
         /// <summary>
         /// Session is the active session to disconnect.

--- a/clients/powershell/Cmdlets/Simulation.cs
+++ b/clients/powershell/Cmdlets/Simulation.cs
@@ -5,19 +5,18 @@ using Newtonsoft.Json;
 
 namespace CloudChamber.Cmdlets
 {
-    public class SimulationCmdlets : CmdletBase
+    /// <summary>
+    ///     SimulationCmdlets provides the common specialization used by all
+    ///     simulation object cmdlets.
+    /// </summary>
+    public class SimulationCmdlets : LoggedInCmdlet
     {
-        protected SimulationCmdlets() : base("/api/simulation")
-        {
-        }
-
-        /// <summary>
-        ///     Session is the logged-in session to use for the operation.
-        /// </summary>
-        [Parameter(Mandatory = true)]
-        public Session Session { get; set; }
+        protected SimulationCmdlets() : base("/api/simulation") { }
     }
 
+    /// <summary>
+    ///     Get the current status of the simulation.
+    /// </summary>
     [Cmdlet(VerbsCommon.Get, Names.Simulation)]
     [OutputType(typeof(SimulationStatus))]
     public class GetSimulationCmdlet : SimulationCmdlets
@@ -34,6 +33,9 @@ namespace CloudChamber.Cmdlets
         }
     }
 
+    /// <summary>
+    ///     Get the summary list of active logged-in sessions.
+    /// </summary>
     [Cmdlet(VerbsCommon.Get, Names.Sessions)]
     [OutputType(typeof(List<SessionEntry>))]
     public class SessionsCmdlet : SimulationCmdlets
@@ -51,15 +53,22 @@ namespace CloudChamber.Cmdlets
         }
     }
 
+    /// <summary>
+    ///     Get the details for a given logged-in session.
+    /// </summary>
     [Cmdlet(VerbsCommon.Get, Names.Session)]
     [OutputType(typeof(ClusterSession))]
     public class ClusterSessionCmdlet : SimulationCmdlets
     {
-        [Parameter(Mandatory = true)] public long ActiveSessionId { get; set; }
+        /// <summary>
+        ///     Identifier for the session, such as supplied in the summary
+        ///     list.
+        /// </summary>
+        [Parameter(Mandatory = true)] public long Id { get; set; }
 
         protected override void ProcessRecord()
         {
-            var uri = $"{Prefix}/sessions/{ActiveSessionId}";
+            var uri = $"{Prefix}/sessions/{Id}";
             var resp = Session.Client.GetAsync(uri).Result;
             ThrowOnHttpFailure(resp, "GetSimulationSessionDetails", null);
 

--- a/clients/powershell/Cmdlets/Simulation.cs
+++ b/clients/powershell/Cmdlets/Simulation.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Management.Automation;
+using CloudChamber.Cmdlets.Protos;
+using Newtonsoft.Json;
+
+namespace CloudChamber.Cmdlets
+{
+    public class SimulationCmdlets : CmdletBase
+    {
+        protected SimulationCmdlets() : base("/api/simulation")
+        {
+        }
+
+        /// <summary>
+        ///     Session is the logged-in session to use for the operation.
+        /// </summary>
+        [Parameter(Mandatory = true)]
+        public Session Session { get; set; }
+    }
+
+    [Cmdlet(VerbsCommon.Get, Names.Simulation)]
+    [OutputType(typeof(SimulationStatus))]
+    public class GetSimulationCmdlet : SimulationCmdlets
+    {
+        protected override void ProcessRecord()
+        {
+            var resp = Session.Client.GetAsync(Prefix).Result;
+            ThrowOnHttpFailure(resp, "GetSimulationStatus", null);
+
+            var msg = resp.Content.ReadAsStringAsync().Result;
+            var status = JsonConvert.DeserializeObject<SimulationStatus>(msg);
+
+            WriteObject(status);
+        }
+    }
+
+    [Cmdlet(VerbsCommon.Get, Names.Sessions)]
+    [OutputType(typeof(List<SessionEntry>))]
+    public class SessionsCmdlet : SimulationCmdlets
+    {
+        protected override void ProcessRecord()
+        {
+            var uri = $"{Prefix}/sessions";
+            var resp = Session.Client.GetAsync(uri).Result;
+            ThrowOnHttpFailure(resp, "GetSimulationSessionList", null);
+
+            var msg = resp.Content.ReadAsStringAsync().Result;
+            var details = JsonConvert.DeserializeObject<SessionList>(msg);
+
+            WriteObject(details.Sessions, true);
+        }
+    }
+
+    [Cmdlet(VerbsCommon.Get, Names.Session)]
+    [OutputType(typeof(ClusterSession))]
+    public class ClusterSessionCmdlet : SimulationCmdlets
+    {
+        [Parameter(Mandatory = true)] public long ActiveSessionId { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            var uri = $"{Prefix}/sessions/{ActiveSessionId}";
+            var resp = Session.Client.GetAsync(uri).Result;
+            ThrowOnHttpFailure(resp, "GetSimulationSessionDetails", null);
+
+            var msg = resp.Content.ReadAsStringAsync().Result;
+            var details = JsonConvert.DeserializeObject<ClusterSession>(msg);
+
+            WriteObject(details);
+        }
+    }
+}

--- a/clients/powershell/Cmdlets/Stepper.cs
+++ b/clients/powershell/Cmdlets/Stepper.cs
@@ -10,17 +10,9 @@ namespace CloudChamber.Cmdlets
     ///     StepperCmdlets is the base class providing common prefix and command
     ///     parameter values.
     /// </summary>
-    public class StepperCmdlets : CmdletBase
+    public class StepperCmdlets : LoggedInCmdlet
     {
-        protected StepperCmdlets() : base("/api/stepper")
-        {
-        }
-
-        /// <summary>
-        ///     Session is the logged-in session to use for the operation.
-        /// </summary>
-        [Parameter(Mandatory = true)]
-        public Session Session { get; set; }
+        protected StepperCmdlets() : base("/api/stepper") { }
     }
 
     /// <summary>

--- a/clients/powershell/Cmdlets/Traces.cs
+++ b/clients/powershell/Cmdlets/Traces.cs
@@ -1,0 +1,65 @@
+﻿using System.Management.Automation;
+using CloudChamber.Cmdlets.Protos;
+using Newtonsoft.Json;
+
+namespace CloudChamber.Cmdlets
+{
+    /// <summary>
+    ///     Common trace-related cmdlet properties.
+    /// </summary>
+    public class TraceCmdlets : LoggedInCmdlet
+    {
+        protected TraceCmdlets() : base("/api/logs") { }
+    }
+
+    /// <summary>
+    ///     Get the current tracing policy.
+    /// </summary>
+    [Cmdlet(VerbsCommon.Get, Names.TracePolicy)]
+    [OutputType(typeof(TracePolicy))]
+    public class GetTracePolicyCmdlet : TraceCmdlets
+    {
+        protected override void ProcessRecord()
+        {
+            var uri = $"{Prefix}/policy";
+            var resp = Session.Client.GetAsync(uri).Result;
+            ThrowOnHttpFailure(resp, "GetTracePolicyError", null);
+
+            var msg = resp.Content.ReadAsStringAsync().Result;
+            var policy = JsonConvert.DeserializeObject<TracePolicy>(msg);
+
+            WriteObject(policy);
+        }
+    }
+
+    /// <summary>
+    ///     Get an extract of the traces.  Waits for new traces if it the From
+    ///     parameter is set to later than the last known trace.
+    /// </summary>
+    [Cmdlet(VerbsCommon.Get, Names.Traces)]
+    [OutputType(typeof(Traces))]
+    public class GetTracesCmdlet : TraceCmdlets
+    {
+        /// <summary>
+        ///     From is the starting trace ID.
+        /// </summary>
+        [Parameter] public long From { get; set; } = 0;
+
+        /// <summary>
+        ///     For is the maximum number of traces to return in this call
+        /// </summary>
+        [Parameter] public long For { get; set; } = 100;
+
+        protected override void ProcessRecord()
+        {
+            var uri = $"{Prefix}?from={From}&for={For}";
+            var resp = Session.Client.GetAsync(uri).Result;
+            ThrowOnHttpFailure(resp, "GetTracePolicyError", null);
+
+            var msg = resp.Content.ReadAsStringAsync().Result;
+            var traces = JsonConvert.DeserializeObject<Traces>(msg);
+
+            WriteObject(traces);
+        }
+    }
+}

--- a/clients/powershell/Cmdlets/Users.cs
+++ b/clients/powershell/Cmdlets/Users.cs
@@ -5,14 +5,15 @@ using Newtonsoft.Json;
 
 namespace CloudChamber.Cmdlets
 {
-
     /// <summary>
     ///     NamedUserCmdlets further specializes UserCmdlets by including the most
     ///     common parameters.
     /// </summary>
     public class NamedUserCmdlets : CmdletBase
     {
-        public NamedUserCmdlets() : base("/api/users") { }
+        public NamedUserCmdlets() : base("/api/users")
+        {
+        }
 
         /// <summary>
         ///     Name is the name of the user to operate on.
@@ -33,7 +34,9 @@ namespace CloudChamber.Cmdlets
     [Cmdlet(VerbsCommon.Get, Names.Users)]
     public class GetUsersCmdlet : CmdletBase
     {
-        public GetUsersCmdlet()  : base("/api/users/") { }
+        public GetUsersCmdlet() : base("/api/users/")
+        {
+        }
 
         /// <summary>
         ///     Session contains the currently logged-in http client to use when

--- a/clients/powershell/Cmdlets/Users.cs
+++ b/clients/powershell/Cmdlets/Users.cs
@@ -9,41 +9,24 @@ namespace CloudChamber.Cmdlets
     ///     NamedUserCmdlets further specializes UserCmdlets by including the most
     ///     common parameters.
     /// </summary>
-    public class NamedUserCmdlets : CmdletBase
+    public class NamedUserCmdlets : LoggedInCmdlet
     {
-        public NamedUserCmdlets() : base("/api/users")
-        {
-        }
+        public NamedUserCmdlets() : base("/api/users") { }
 
         /// <summary>
         ///     Name is the name of the user to operate on.
         /// </summary>
         [Parameter(Position = 0, Mandatory = true)]
         public string Name { get; set; }
-
-        /// <summary>
-        ///     Session is the logged-in session to use for the operation.
-        /// </summary>
-        [Parameter(Mandatory = true)]
-        public Session Session { get; set; }
     }
 
     /// <summary>
     ///     GetUsersCmdlet gets the list of users known to the cluster.
     /// </summary>
     [Cmdlet(VerbsCommon.Get, Names.Users)]
-    public class GetUsersCmdlet : CmdletBase
+    public class GetUsersCmdlet : LoggedInCmdlet
     {
-        public GetUsersCmdlet() : base("/api/users/")
-        {
-        }
-
-        /// <summary>
-        ///     Session contains the currently logged-in http client to use when
-        ///     contacting the cluster.
-        /// </summary>
-        [Parameter(Mandatory = true)]
-        public Session Session { get; set; }
+        public GetUsersCmdlet() : base("/api/users/") { }
 
         /// <summary>
         ///     ProcessRecord retrieves the user list and writes it to the output

--- a/clients/powershell/Cmdlets/cmdletBase.cs
+++ b/clients/powershell/Cmdlets/cmdletBase.cs
@@ -29,4 +29,19 @@ namespace CloudChamber.Cmdlets
                 ThrowTerminatingError(resp.ToErrorRecord(errorName, target));
         }
     }
+
+    /// <summary>
+    ///     Extend the CmdletBase with the common Session parameter to handle the
+    ///     normal logged-in operations.
+    /// </summary>
+    public class LoggedInCmdlet : CmdletBase
+    {
+        protected LoggedInCmdlet(string prefix) : base(prefix) { }
+
+        /// <summary>
+        ///     Session is the logged-in session to use for the operation.
+        /// </summary>
+        [Parameter(Mandatory = true)]
+        public Session Session { get; set; }
+    }
 }

--- a/clients/powershell/Cmdlets/protos/SimulationProtos.cs
+++ b/clients/powershell/Cmdlets/protos/SimulationProtos.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CloudChamber.Cmdlets.Protos
+{
+    public class SimulationStatus
+    {
+        [JsonProperty("frontEndStartedAt")]
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTime FrontEndStartedAt { get; set; }
+
+        [JsonProperty("inactivityTimeout")]
+        [JsonConverter(typeof(DurationConverter))]
+        public TimeSpan InactivityTimeout { get; set; }
+    }
+
+    public class SessionList
+    {
+        [JsonProperty("sessions")] public List<SessionEntry> Sessions { get; set; }
+    }
+
+    public class SessionEntry
+    {
+        [JsonProperty("id")] public long Id { get; set; }
+
+        [JsonProperty("uri")] public Uri Uri { get; set; }
+    }
+
+    public class ClusterSession
+    {
+        [JsonProperty("userName")] public string Name { get; set; }
+
+        [JsonProperty("timeout")]
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTime Expiry { get; set; }
+    }
+}

--- a/clients/powershell/Cmdlets/protos/TraceProtos.cs
+++ b/clients/powershell/Cmdlets/protos/TraceProtos.cs
@@ -1,0 +1,117 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CloudChamber.Cmdlets.Protos
+{
+    public class LogEventModule
+    {
+        public enum ImpactEnum
+        {
+            Invalid,
+            Read,
+            Create,
+            Modify,
+            Delete,
+            Execute,
+        }
+
+        [JsonProperty("impact")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ImpactEnum Impact { get; set; }
+
+        [JsonProperty("name")] public string Name { get; set; }
+    }
+
+    public class LogEvent
+    {
+        public enum ActionEnum
+        {
+            Trace,
+            UpdateSpanName,
+            UpdateReason,
+            SpanStart,
+            AddLink
+        }
+
+        public enum SeverityEnum
+        {
+            Debug,
+            Reason,
+            Info,
+            Warning,
+            Error,
+            Fatal,
+        }
+
+        [JsonProperty("tick")] public long Tick { get; set; }
+
+        [JsonProperty("severity")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public SeverityEnum Severity { get; set; }
+
+        [JsonProperty("name")] public string Name { get; set; }
+
+        [JsonProperty("text")] public string Text { get; set; }
+
+        [JsonProperty("stackTrace")] public string StackTrace { get; set; }
+
+        [JsonProperty("impacted")] public List<LogEventModule> Impacted { get; set; }
+
+        [JsonProperty("eventAction")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ActionEnum Action { get; set; }
+
+        [JsonProperty("spanId")] public string ChildSpanID { get; set; }
+
+        [JsonProperty("linkId")] public string LinkID { get; set; }
+    }
+
+    public class LogEntry
+    {
+        [JsonProperty("name")] public string Name { get; set; }
+
+        [JsonProperty("spanID")] public string SpanID { get; set; }
+
+        [JsonProperty("parentID")] public string ParentID { get; set; }
+
+        [JsonProperty("traceID")] public string TraceID { get; set; }
+
+        [JsonProperty("status")] public string Status { get; set; }
+
+        [JsonProperty("stackTrace")] public string StackTrace { get; set; }
+
+        [JsonProperty("infrastructure")] public bool Infrastructure { get; set; }
+
+        [JsonProperty("reason")] public string Reason { get; set; }
+
+        [JsonProperty("startingLink")] public string StartingLink { get; set; }
+
+        [JsonProperty("linkSpanID")] public string LinkSpanID { get; set; }
+
+        [JsonProperty("linkTraceID")] public string LinkTraceId { get; set; }
+
+        [JsonProperty("event")] public List<LogEvent> Event { get; set; }
+    }
+
+    public class TraceEntry
+    {
+        [JsonProperty("id")] public long Id { get; set; }
+
+        [JsonProperty("entry")] public LogEntry Entry { get; set; }
+    }
+
+    public class Traces
+    {
+        [JsonProperty("lastId")] public long LastId { get; set; }
+
+        [JsonProperty("entries")] public List<TraceEntry> Entries { get; set; }
+    }
+
+    public class TracePolicy
+    {
+        [JsonProperty("maxEntriesHeld")] public long MaxEntriesHeld { get; set; }
+
+        [JsonProperty("firstId")] public long FirstID { get; set; }
+    }
+}

--- a/clients/powershell/Cmdlets/protos/TraceProtos.cs
+++ b/clients/powershell/Cmdlets/protos/TraceProtos.cs
@@ -62,20 +62,20 @@ namespace CloudChamber.Cmdlets.Protos
         [JsonConverter(typeof(StringEnumConverter))]
         public ActionEnum Action { get; set; }
 
-        [JsonProperty("spanId")] public string ChildSpanID { get; set; }
+        [JsonProperty("spanId")] public string ChildSpanId { get; set; }
 
-        [JsonProperty("linkId")] public string LinkID { get; set; }
+        [JsonProperty("linkId")] public string LinkId { get; set; }
     }
 
     public class LogEntry
     {
         [JsonProperty("name")] public string Name { get; set; }
 
-        [JsonProperty("spanID")] public string SpanID { get; set; }
+        [JsonProperty("spanID")] public string SpanId { get; set; }
 
-        [JsonProperty("parentID")] public string ParentID { get; set; }
+        [JsonProperty("parentID")] public string ParentId { get; set; }
 
-        [JsonProperty("traceID")] public string TraceID { get; set; }
+        [JsonProperty("traceID")] public string TraceId { get; set; }
 
         [JsonProperty("status")] public string Status { get; set; }
 
@@ -87,7 +87,7 @@ namespace CloudChamber.Cmdlets.Protos
 
         [JsonProperty("startingLink")] public string StartingLink { get; set; }
 
-        [JsonProperty("linkSpanID")] public string LinkSpanID { get; set; }
+        [JsonProperty("linkSpanID")] public string LinkSpanId { get; set; }
 
         [JsonProperty("linkTraceID")] public string LinkTraceId { get; set; }
 
@@ -112,6 +112,6 @@ namespace CloudChamber.Cmdlets.Protos
     {
         [JsonProperty("maxEntriesHeld")] public long MaxEntriesHeld { get; set; }
 
-        [JsonProperty("firstId")] public long FirstID { get; set; }
+        [JsonProperty("firstId")] public long FirstId { get; set; }
     }
 }

--- a/clients/powershell/Cmdlets/script_tests/Simulation.Tests.ps1
+++ b/clients/powershell/Cmdlets/script_tests/Simulation.Tests.ps1
@@ -1,0 +1,36 @@
+﻿Describe "Status checks against the simulation" {
+    BeforeAll {
+        Import-Module ..\bin\Debug\netstandard2.0\CloudChamber.Cmdlets.dll
+    }
+
+    BeforeEach {
+        $sess = Connect-CcAccount -ClusterUri http://localhost:8080 -Name admin -Password adminPassword
+    }
+
+    AfterEach {
+        Disconnect-CcAccount -Session $sess
+    }
+
+    It "Gets the simulation status" {
+        $status = Get-CcCluster -Session $sess
+        $span = New-TimeSpan -Hours 1
+        $status.InactivityTimeout | Should Be $span
+
+        $now = Get-Date
+        ($status.FrontEndStartedAt -lt $now) | Should Be $true
+    }
+
+    It "Gets the summary list of current active sessions" {
+        $list = Get-CcSessions -Session $sess
+        $list.Count | Should BeGreaterThan 0
+
+        $found = $false
+        for ($i = 0; $i -lt $list.Count; $i++) {
+            $entry = $list[$i]
+            $item = Get-CcSession -Session $sess -Id $entry.Id
+            $found = $found -or ($item.Name -eq "admin")
+        }
+
+        $found | Should Be $true
+    }
+}

--- a/clients/powershell/Cmdlets/script_tests/Traces.Tests.ps1
+++ b/clients/powershell/Cmdlets/script_tests/Traces.Tests.ps1
@@ -1,0 +1,37 @@
+﻿Describe "Trace File Tests" {
+    BeforeAll {
+        Import-Module ..\bin\Debug\netstandard2.0\CloudChamber.Cmdlets.dll
+    }
+
+    BeforeEach {
+        $sess = Connect-CcAccount -ClusterUri http://localhost:8080 -Name admin -Password adminPassword
+    }
+
+    AfterEach {
+        Disconnect-CcAccount -Session $sess
+    }
+
+    It "Gets the current trace policy" {
+        $policy = Get-CcTracePolicy -Session $sess
+        $policy.MaxEntriesHeld | Should Be 1000
+        $policy.FirstId | Should BeGreaterThan -2
+    }
+
+    It "Gets a set of traces from the start" {
+        $traces = Get-CcTraces -Session $sess
+        $traces.LastId | Should BeGreaterThan 0
+        $traces.Entries.Count | Should Be 100
+    }
+
+    It "Gets a set of traces from a given point" {
+        $traces = Get-CcTraces -Session $sess -From 10
+        $traces.LastId | Should BeGreaterThan 0
+        $traces.Entries.Count | Should Be 100
+    }
+
+    It "Gets a set of traces with a given length" {
+        $traces = Get-CcTraces -Session $sess -From 10 -For 10
+        $traces.LastId | Should BeGreaterThan 0
+        $traces.Entries.Count | Should Be 10
+    }
+}


### PR DESCRIPTION
This adds cmdlets to retrieve the current simulation status, and to forcibly clear out logged in sessions.  It also adds cmdlets to retrieve the trace policy and extracts of the current traces.

Note that the protos definitions are uncommented as they are extracts from the protos and will soon be replaced by generated code.