### PR TITLE
Add start of C# support in protos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode
 /deployments/
 /pkg/protos/**/*pb.go
+/pkg/protos/**/*pb.cs
 /.idea/
 *~
 /**/#*#

--- a/clients/observer/src/proxies/Session.tsx
+++ b/clients/observer/src/proxies/Session.tsx
@@ -109,7 +109,8 @@ export function getETag(resp: Response): number {
         return -1
     }
 
-    return parseInt(tag, 10)
+    const value = tag.replace("\"", "")
+    return parseInt(value, 10)
 }
 
 // Set the ETag into a header as a match condition

--- a/clients/powershell/Cmdlets/script_tests/Simulation.Tests.ps1
+++ b/clients/powershell/Cmdlets/script_tests/Simulation.Tests.ps1
@@ -16,8 +16,8 @@
         $span = New-TimeSpan -Hours 1
         $status.InactivityTimeout | Should Be $span
 
-        $now = Get-Date
-        ($status.FrontEndStartedAt -lt $now) | Should Be $true
+        $now = (Get-Date).ToUniversalTime()
+        $status.FrontEndStartedAt | Should BeLessThan $now
     }
 
     It "Gets the summary list of current active sessions" {

--- a/internal/services/frontend/simulation.go
+++ b/internal/services/frontend/simulation.go
@@ -89,13 +89,13 @@ func handlerSimSessionList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	list := &pb.SessionSummary{
-		Sessions: []*pb.SessionSummarySession{},
+		Sessions: []*pb.SessionSummary_Session{},
 	}
 
 	b := common.URLPrefix(r)
 
 	for _, key := range getSessionSummaryList() {
-		list.Sessions = append(list.Sessions, &pb.SessionSummarySession{
+		list.Sessions = append(list.Sessions, &pb.SessionSummary_Session{
 			Id:  key,
 			Uri: fmt.Sprintf("%s%d", b, key),
 		})

--- a/internal/services/frontend/users.go
+++ b/internal/services/frontend/users.go
@@ -106,7 +106,7 @@ func handlerUsersList(w http.ResponseWriter, r *http.Request) {
 			tracing.WithImpactRead("/users"),
 			"   Listing user %q: %q%s", entry.Name, target, protected)
 
-		users.Users = append(users.Users, &pb.UserListEntry{
+		users.Users = append(users.Users, &pb.UserList_Entry{
 			Name:      entry.Name,
 			Uri:       target,
 			Protected: entry.NeverDelete,

--- a/pkg/protos/admin/simulation.proto
+++ b/pkg/protos/admin/simulation.proto
@@ -6,15 +6,16 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/admin";
+option csharp_namespace = "CloudChamber.Protos.Admin";
 
 // SessionSummary contains the key and address information for all active
 // logged-in sessions.
 message SessionSummary {
-    message session {
+    message Session {
         int64 id = 1;
         string uri = 2;
     }
-    repeated session sessions = 1;
+    repeated Session sessions = 1;
 }
 
 // SimulationStatus contains overview information about the status of the

--- a/pkg/protos/admin/users.proto
+++ b/pkg/protos/admin/users.proto
@@ -3,13 +3,14 @@ syntax = "proto3";
 package admin;
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/admin";
+option csharp_namespace = "CloudChamber.Protos.Admin";
 
 // User is a representation of an individual user
 //
 // TODO This is just a placeholder until we have proper user records held
 //     in a persisted store (Etcd)
 //
-message user {
+message User {
     // The username, held so as to preserve the original case
     string name = 1;
 
@@ -26,7 +27,7 @@ message user {
 
 // Limited exposure of user attributes for use when returning information
 // to a remote client.
-message user_public {
+message UserPublic {
     bool enabled = 1;
 
     // The rights this user has
@@ -38,7 +39,7 @@ message user_public {
 
 // Public definition for a user, sent by a remote client to the Cloud Chamber
 // controller when the user is created.
-message user_definition {
+message UserDefinition {
     string password = 1;
     bool enabled = 2;
 
@@ -48,7 +49,7 @@ message user_definition {
 
 // Public definition for the fields for a user that can be mutated in an
 // update operation
-message user_update {
+message UserUpdate {
     bool enabled = 2;
 
     // The rights this user has
@@ -56,7 +57,7 @@ message user_update {
 }
 
 // Public definition for a request to set a new password for a user
-message user_password {
+message UserPassword {
     // The existing password, used to check that this is a legit request
     string old_password = 1;
 
@@ -68,10 +69,10 @@ message user_password {
 }
 
 // User list response.
-message user_list {
+message UserList {
 
     // A single user entry
-    message entry {
+    message Entry {
         // Name of the user
         string name = 1;
 
@@ -83,5 +84,5 @@ message user_list {
     }
 
     // List of known users
-    repeated entry users = 1;
+    repeated Entry users = 1;
 }

--- a/pkg/protos/common/completion.proto
+++ b/pkg/protos/common/completion.proto
@@ -5,6 +5,7 @@ syntax = "proto3";
 package common;
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/common";
+option csharp_namespace = "CloudChamber.Protos.Common";
 
 message Completion {
     string error = 1;   // Completion error message

--- a/pkg/protos/common/timestamp.proto
+++ b/pkg/protos/common/timestamp.proto
@@ -5,6 +5,7 @@ syntax = "proto3";
 package common;
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/common";
+option csharp_namespace = "CloudChamber.Protos.Common";
 
 // Define the structure for a simulated time
 //

--- a/pkg/protos/log/entry.proto
+++ b/pkg/protos/log/entry.proto
@@ -19,9 +19,10 @@ syntax = "proto3";
 package log;
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/log";
+option csharp_namespace = "CloudChamber.Protos.Log";
 
 // Describe the type of impact that this event has on a module.
-enum impact {
+enum Impact {
     Invalid = 0;
     Read = 1;
     Create = 2;
@@ -31,7 +32,7 @@ enum impact {
 }
 
 // Describe the actions to take when reading an event entry.
-enum action {
+enum Action {
     // Trace is the most common type of event.  The contents are added to a serial
     // list in the span, and the formatters will display the entry's data as a
     // child trace event.
@@ -67,7 +68,7 @@ enum action {
     AddLink = 4;
 }
 
-enum severity {
+enum Severity {
     Debug = 0;
 
     // This is the severity use to denote a purely explanatory entry
@@ -80,18 +81,18 @@ enum severity {
 }
 
 // Describe an impacted module
-message module {
-    impact impact = 1;
+message Module {
+    Impact impact = 1;
     string name = 2;
 }
 
 // Define an individual trace event
-message event {
+message Event {
     // Simulated time when it was logged.
     int64 tick = 1;
 
     // Event severity
-    severity severity = 2;
+    Severity severity = 2;
 
     // Label to quickly mark the event
     string name = 3;
@@ -103,10 +104,10 @@ message event {
     string stack_trace = 5;
 
     // The set of modules impacted, and the type of impact.
-    repeated module impacted = 6;
+    repeated Module impacted = 6;
 
     // Action to take when this trace is encountered.
-    action event_action = 7;
+    Action event_action = 7;
 
     // Child's span ID.  Ignored if the action is not SpanStart.
     string span_id = 8;
@@ -116,7 +117,7 @@ message event {
 }
 
 // Describe a full correlated span, consisting of zero or more events.
-message entry {
+message Entry {
     // Name of the span
     string name = 1;
 
@@ -132,7 +133,7 @@ message entry {
     string stack_trace = 6;
 
     // The set of events emitted by this span
-    repeated event event = 7;
+    repeated Event event = 7;
 
     // True, if this span represents internal-only operations.
     bool infrastructure = 8;

--- a/pkg/protos/services/requests.proto
+++ b/pkg/protos/services/requests.proto
@@ -8,6 +8,7 @@ import "github.com/Jim3Things/CloudChamber/pkg/protos/log/entry.proto";
 import "google/protobuf/duration.proto";
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/services";
+option csharp_namespace = "CloudChamber.Protos.Services";
 
 // +++ Shared messages
 
@@ -108,7 +109,7 @@ message StatusResponse {
 // Specify the trace entry to append to the trace sink's store
 message AppendRequest {
     // The trace entry
-    log.entry entry = 1;
+    log.Entry entry = 1;
 }
 
 // Specify what trace entries to receive
@@ -141,7 +142,7 @@ message GetAfterResponse {
         int64 id = 1;
 
         // Contents of the trace entry
-        log.entry entry = 2;
+        log.Entry entry = 2;
     }
 
     // Set of trace entries we're returning


### PR DESCRIPTION
Also fixed two failures: one in the powershell unit tests, and one in ETag handling in the web UI.  Both found while validating that the new protos were json consistent with the old ones.