### PR TITLE
Add store.DeleteMultiple() to allow for atomic delete of record with index

### DIFF
--- a/internal/clients/inventory/definition_test.go
+++ b/internal/clients/inventory/definition_test.go
@@ -1262,15 +1262,19 @@ func (ts *testSuiteCore) TestNewRegionWithCreate() {
 
 	ctx := context.Background()
 
-	r, err := NewRegion(ctx, ts.store, DefinitionTable, ts.regionName(stdSuffix))
+	region, err := NewRegion(ctx, ts.store, DefinitionTable, ts.regionName(stdSuffix))
 	require.NoError(err)
 
-	r.SetDetails(ctx, stdDetails)
+	region.SetDetails(ctx, stdDetails)
 
-	rev, err := r.Create(ctx)
+	rev, err := region.Create(ctx)
 
 	require.NoError(err)
 	assert.NotEqual(store.RevisionInvalid, rev)
+
+	revDel, err := region.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(rev, revDel)
 }
 
 func (ts *testSuiteCore) TestNewZoneWithCreate() {
@@ -1291,6 +1295,10 @@ func (ts *testSuiteCore) TestNewZoneWithCreate() {
 
 	require.NoError(err)
 	assert.NotEqual(store.RevisionInvalid, rev)
+
+	revDel, err := zone.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(rev, revDel)
 }
 
 func (ts *testSuiteCore) TestNewRackWithCreate() {
@@ -1318,6 +1326,10 @@ func (ts *testSuiteCore) TestNewRackWithCreate() {
 
 	require.NoError(err)
 	assert.NotEqual(store.RevisionInvalid, rev)
+
+	revDel, err := rack.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(rev, revDel)
 }
 
 func (ts *testSuiteCore) TestNewPduWithCreate() {
@@ -1348,6 +1360,10 @@ func (ts *testSuiteCore) TestNewPduWithCreate() {
 
 	require.NoError(err)
 	assert.NotEqual(store.RevisionInvalid, rev)
+
+	revDel, err := pdu.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(rev, revDel)
 }
 
 func (ts *testSuiteCore) TestNewTorWithCreate() {
@@ -1378,6 +1394,10 @@ func (ts *testSuiteCore) TestNewTorWithCreate() {
 
 	require.NoError(err)
 	assert.NotEqual(store.RevisionInvalid, rev)
+
+	revDel, err := tor.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(rev, revDel)
 }
 
 func (ts *testSuiteCore) TestNewBladeWithCreate() {
@@ -1411,6 +1431,10 @@ func (ts *testSuiteCore) TestNewBladeWithCreate() {
 
 	require.NoError(err)
 	assert.NotEqual(store.RevisionInvalid, rev)
+
+	revDel, err := blade.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(rev, revDel)
 }
 
 func (ts *testSuiteCore) TestRootNewChild() {
@@ -1436,6 +1460,10 @@ func (ts *testSuiteCore) TestRootNewChild() {
 	rev, err := region.Create(ctx)
 	require.NoError(err)
 	assert.NotEqual(store.RevisionInvalid, rev)
+
+	revDel, err := region.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(rev, revDel)
 }
 
 func (ts *testSuiteCore) TestNewChildZone() {
@@ -1463,6 +1491,10 @@ func (ts *testSuiteCore) TestNewChildZone() {
 	rev, err := zone.Create(ctx)
 	require.NoError(err)
 	assert.NotEqual(store.RevisionInvalid, rev)
+
+	revDel, err := zone.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(rev, revDel)
 }
 
 func (ts *testSuiteCore) TestNewChildRack() {
@@ -1494,6 +1526,10 @@ func (ts *testSuiteCore) TestNewChildRack() {
 	rev, err := rack.Create(ctx)
 	require.NoError(err)
 	assert.NotEqual(store.RevisionInvalid, rev)
+
+	revDel, err := rack.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(rev, revDel)
 }
 
 func (ts *testSuiteCore) TestNewChildPdu() {
@@ -1530,6 +1566,10 @@ func (ts *testSuiteCore) TestNewChildPdu() {
 	rev, err := pdu.Create(ctx)
 	require.NoError(err)
 	assert.NotEqual(store.RevisionInvalid, rev)
+
+	revDel, err := pdu.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(rev, revDel)
 }
 
 func (ts *testSuiteCore) TestNewChildTor() {
@@ -1566,6 +1606,10 @@ func (ts *testSuiteCore) TestNewChildTor() {
 	rev, err := tor.Create(ctx)
 	require.NoError(err)
 	assert.NotEqual(store.RevisionInvalid, rev)
+
+	revDel, err := tor.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(rev, revDel)
 }
 
 func (ts *testSuiteCore) TestNewChildBlade() {
@@ -1610,6 +1654,10 @@ func (ts *testSuiteCore) TestNewChildBlade() {
 	rev, err := blade.Create(ctx)
 	require.NoError(err)
 	assert.NotEqual(store.RevisionInvalid, rev)
+
+	revDel, err := blade.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(rev, revDel)
 }
 
 func (ts *testSuiteCore) TestRegionReadDetails() {
@@ -1667,6 +1715,10 @@ func (ts *testSuiteCore) TestRegionReadDetails() {
 	crDet := cr.GetDetails(ctx)
 	require.NoError(err)
 	assert.Equal(stdDetails, crDet)
+
+	revDel, err := cr.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(crRev, revDel)
 }
 
 func (ts *testSuiteCore) TestZoneReadDetails() {
@@ -1729,6 +1781,10 @@ func (ts *testSuiteCore) TestZoneReadDetails() {
 	zoneDet := zone.GetDetails(ctx)
 	require.NoError(err)
 	assert.Equal(stdDetails, zoneDet)
+
+	revDel, err := zone.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(zoneRev, revDel)
 }
 
 func (ts *testSuiteCore) TestRackReadDetails() {
@@ -1807,6 +1863,10 @@ func (ts *testSuiteCore) TestRackReadDetails() {
 	rackDet := rack.GetDetails(ctx)
 	require.NoError(err)
 	assert.Equal(stdDetails, rackDet)
+
+	revDel, err := rack.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(rackRev, revDel)
 }
 
 func (ts *testSuiteCore) TestPduReadDetails() {
@@ -1897,6 +1957,10 @@ func (ts *testSuiteCore) TestPduReadDetails() {
 	pduPorts := pdu.GetPorts(ctx)
 	require.NoError(err)
 	assert.Equal(stdPorts, pduPorts)
+
+	revDel, err := pdu.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(pduRev, revDel)
 }
 
 func (ts *testSuiteCore) TestTorReadDetails() {
@@ -1987,6 +2051,10 @@ func (ts *testSuiteCore) TestTorReadDetails() {
 	torPorts := tor.GetPorts(ctx)
 	require.NoError(err)
 	assert.Equal(stdPorts, torPorts)
+
+	revDel, err := tor.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(torRev, revDel)
 }
 
 func (ts *testSuiteCore) TestBladeReadDetails() {
@@ -2085,6 +2153,10 @@ func (ts *testSuiteCore) TestBladeReadDetails() {
 	require.NoError(err)
 	assert.Equal(stdBootOnPowerOn, bladeBootOnPowerOn)
 	assert.Equal(stdBootInfo, bladeBootInfo)
+
+	revDel, err := blade.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(bladeRev, revDel)
 }
 
 func (ts *testSuiteCore) TestRegionUpdateDetails() {
@@ -2147,6 +2219,11 @@ func (ts *testSuiteCore) TestRegionUpdateDetails() {
 	// Compare new details with original + deltas
 	//
 	assert.Equal(details, detailsVerify)
+
+	revDel, err := cr.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(revUpdate, revDel)
+
 }
 
 func (ts *testSuiteCore) TestZoneUpdateDetails() {
@@ -2213,6 +2290,10 @@ func (ts *testSuiteCore) TestZoneUpdateDetails() {
 	// Compare new details with original + deltas
 	//
 	assert.Equal(details, detailsVerify)
+
+	revDel, err := cz.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(revUpdate, revDel)
 }
 
 func (ts *testSuiteCore) TestRackUpdateDetails() {
@@ -2284,6 +2365,10 @@ func (ts *testSuiteCore) TestRackUpdateDetails() {
 	// Compare new details with original + deltas
 	//
 	assert.Equal(details, detailsVerify)
+
+	revDel, err := cr.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(revUpdate, revDel)
 }
 
 func (ts *testSuiteCore) TestPduUpdateDetails() {
@@ -2364,6 +2449,10 @@ func (ts *testSuiteCore) TestPduUpdateDetails() {
 	//
 	assert.Equal(details, detailsVerify)
 	assert.Equal(stdPorts, portsVerify)
+
+	revDel, err := cp.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(revUpdate, revDel)
 }
 
 func (ts *testSuiteCore) TestTorUpdateDetails() {
@@ -2444,6 +2533,10 @@ func (ts *testSuiteCore) TestTorUpdateDetails() {
 	//
 	assert.Equal(details, detailsVerify)
 	assert.Equal(stdPorts, portsVerify)
+
+	revDel, err := ct.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(revUpdate, revDel)
 }
 
 func (ts *testSuiteCore) TestBladeUpdateDetails() {
@@ -2532,6 +2625,10 @@ func (ts *testSuiteCore) TestBladeUpdateDetails() {
 	assert.Equal(stdCapacity, capacityVerify)
 	assert.Equal(stdBootInfo, bootInfoVerify)
 	assert.Equal(stdBootOnPowerOn, bootOnPowerOnVerify)
+
+	revDel, err := cb.Delete(ctx, false)
+	require.NoError(err)
+	assert.Less(revUpdate, revDel)
 }
 
 func (ts *testSuiteCore) TestRootListChildren() {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -413,6 +413,28 @@ func (e ErrRegionNotFound) Error() string {
 	return fmt.Sprintf("CloudChamber: %s was not found", regionAddress(e.Region))
 }
 
+// ErrRegionIndexNotFound indicates the attempt to locate a region index record
+// failed as that region index does not exist.
+//
+type ErrRegionIndexNotFound struct {
+	Region string
+}
+
+func (e ErrRegionIndexNotFound) Error() string {
+	return fmt.Sprintf("CloudChamber: index for %s was not found", regionAddress(e.Region))
+}
+
+// ErrRegionChildIndexNotFound indicates the attempt to locate a region child
+// index record failed as that region child index does not exist.
+//
+type ErrRegionChildIndexNotFound struct {
+	Region string
+}
+
+func (e ErrRegionChildIndexNotFound) Error() string {
+	return fmt.Sprintf("CloudChamber: child index for %s was not found", regionAddress(e.Region))
+}
+
 // ErrRegionStaleVersion indicates the attempt to locate a specific version of a
 // region record failed as either that region does not exist, or the specific
 // version is no longer present in the store.
@@ -447,6 +469,30 @@ type ErrZoneNotFound struct {
 
 func (e ErrZoneNotFound) Error() string {
 	return fmt.Sprintf("CloudChamber: %s was not found", zoneAddress(e.Zone, e.Region))
+}
+
+// ErrZoneIndexNotFound indicates the attempt to locate a zone index record
+// failed as that zone index does not exist.
+//
+type ErrZoneIndexNotFound struct {
+	Region string
+	Zone string
+}
+
+func (e ErrZoneIndexNotFound) Error() string {
+	return fmt.Sprintf("CloudChamber: index for %s was not found", zoneAddress(e.Zone, e.Region))
+}
+
+// ErrZoneChildIndexNotFound indicates the attempt to locate a zone child
+// index record failed as that zone child index does not exist.
+//
+type ErrZoneChildIndexNotFound struct {
+	Region string
+	Zone string
+}
+
+func (e ErrZoneChildIndexNotFound) Error() string {
+	return fmt.Sprintf("CloudChamber: child index for %s was not found", zoneAddress(e.Zone, e.Region))
 }
 
 // ErrZoneStaleVersion indicates the attempt to locate a specific version of a
@@ -488,6 +534,61 @@ func (e ErrRackNotFound) Error() string {
 	return fmt.Sprintf("CloudChamber: %s was not found", rackAddress(e.Region, e.Zone, e.Rack))
 }
 
+// ErrRackIndexNotFound indicates the attempt to operate on a rack index record
+// failed as that record cannot be found.
+//
+type ErrRackIndexNotFound struct {
+	Region string
+	Zone string
+	Rack string
+}
+
+func (e ErrRackIndexNotFound) Error() string {
+	return fmt.Sprintf("CloudChamber: index for %s was not found", rackAddress(e.Region, e.Zone, e.Rack))
+}
+
+// ErrRackPduIndexNotFound indicates the attempt to operate on a rack pdu
+// index record failed as that record cannot be found.
+//
+type ErrRackPduIndexNotFound struct {
+	Region string
+	Zone string
+	Rack string
+	Pdu  int64
+}
+
+func (e ErrRackPduIndexNotFound) Error() string {
+	return fmt.Sprintf("CloudChamber: pdu index for %s was not found", pduAddress(e.Region, e.Zone, e.Rack, e.Pdu))
+}
+
+// ErrRackTorIndexNotFound indicates the attempt to operate on a rack tor
+// index record failed as that record cannot be found.
+//
+type ErrRackTorIndexNotFound struct {
+	Region string
+	Zone string
+	Rack string
+	Tor  int64
+}
+
+func (e ErrRackTorIndexNotFound) Error() string {
+	return fmt.Sprintf("CloudChamber: tor index for %s was not found", torAddress(e.Region, e.Zone, e.Rack, e.Tor))
+}
+
+// ErrRackBladeIndexNotFound indicates the attempt to operate on a rack blade
+// index record failed as that record cannot be found.
+//
+type ErrRackBladeIndexNotFound struct {
+	Region string
+	Zone string
+	Rack string
+	Blade  int64
+}
+
+func (e ErrRackBladeIndexNotFound) Error() string {
+	return fmt.Sprintf("CloudChamber: blade index for %s was not found", bladeAddress(e.Region, e.Zone, e.Rack, e.Blade))
+}
+
 // ErrPduIndexInvalid indicates the attempt to locate a record
 // failed as the given index is invalid in some way.
 //
@@ -514,6 +615,20 @@ type ErrPduNotFound struct {
 
 func (e ErrPduNotFound) Error() string {
 	return fmt.Sprintf("CloudChamber: %s was not found", pduAddress(e.Region, e.Zone, e.Rack, e.Pdu))
+}
+
+// ErrPduIndexNotFound indicates the attempt to locate a record
+// failed as the given index is invalid in some way.
+//
+type ErrPduIndexNotFound struct {
+	Region string
+	Zone string
+	Rack string
+	Pdu int64
+}
+
+func (e ErrPduIndexNotFound) Error() string {
+	return fmt.Sprintf("CloudChamber: index for %s was not found", pduAddress(e.Region, e.Zone, e.Rack, e.Pdu))
 }
 
 // ErrPduAlreadyExists indicates the attempt to create a new pdu record
@@ -558,6 +673,20 @@ func (e ErrTorNotFound) Error() string {
 	return fmt.Sprintf("CloudChamber: %s was not found", torAddress(e.Region, e.Zone, e.Rack, e.Tor))
 }
 
+// ErrTorIndexNotFound indicates the attempt to operate on a tor record
+// failed as that record cannot be found.
+//
+type ErrTorIndexNotFound struct {
+	Region string
+	Zone string
+	Rack string
+	Tor int64
+}
+
+func (e ErrTorIndexNotFound) Error() string {
+	return fmt.Sprintf("CloudChamber: index for %s was not found", torAddress(e.Region, e.Zone, e.Rack, e.Tor))
+}
+
 // ErrTorAlreadyExists indicates the attempt to create a new zone record
 // failed as that zone already exists.
 //
@@ -598,6 +727,20 @@ type ErrBladeNotFound struct {
 
 func (e ErrBladeNotFound) Error() string {
 	return fmt.Sprintf("CloudChamber: %s was not found", bladeAddress(e.Region, e.Zone, e.Rack, e.Blade))
+}
+
+// ErrBladeIndexNotFound indicates the attempt to operate on a blade record
+// failed as that record cannot be found.
+//
+type ErrBladeIndexNotFound struct {
+	Region string
+	Zone string
+	Rack string
+	Blade int64
+}
+
+func (e ErrBladeIndexNotFound) Error() string {
+	return fmt.Sprintf("CloudChamber: index for %s was not found", bladeAddress(e.Region, e.Zone, e.Rack, e.Blade))
 }
 
 // ErrBladeAlreadyExists indicates the attempt to create a new blade record


### PR DESCRIPTION
Fixes issues spotted during PR #210 by
1. Adding store.DeleteMultiple() and use it in inventory code to delete record and index
2. Fix issue with error reporting when determining problem deleting index
3. Add full object address when reporting index related errors.

Also updated some of the inventory tests to use conditional delete based on equal revision.

Further tests for store.DeleteMultiple() and inventory cases where one of index or record is missing to be added in future PRs.