### PR TITLE
Create the rest of hte .pb.cs files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,23 @@ PROTO_GEN_FILES = \
     pkg/protos/services/trace_sink.pb.go
 
 PROTO_CS_GEN_FILES = \
-	pkg/protos/admin/simulation.pb.cs \
+    pkg/protos/admin/simulation.pb.cs \
     pkg/protos/admin/users.pb.cs \
     pkg/protos/common/completion.pb.cs \
     pkg/protos/common/timestamp.pb.cs \
     pkg/protos/log/entry.pb.cs \
+    pkg/protos/inventory/capacity.pb.cs \
+    pkg/protos/inventory/common.pb.cs \
+    pkg/protos/inventory/actual.pb.cs \
+    pkg/protos/inventory/definition.pb.cs \
+    pkg/protos/inventory/external.pb.cs \
+    pkg/protos/inventory/internal.pb.cs \
+    pkg/protos/inventory/store.pb.cs \
+    pkg/protos/inventory/target.pb.cs \
+    pkg/protos/workload/actual.pb.cs \
+    pkg/protos/workload/external.pb.cs \
+    pkg/protos/workload/internal.pb.cs \
+    pkg/protos/workload/target.pb.cs \
     pkg/protos/services/requests.pb.cs
 
 ProdFiles = $(filter-out %_test.go, $(wildcard $(1)/*.go))
@@ -263,7 +275,7 @@ run_tests: $(PROTO_GEN_FILES) $(VERSION_MARKER)
 	go test -count=1 $(PROJECT)/internal/clients/inventory
 	go test -count=1 $(PROJECT)/internal/clients/store
 	go test -count=1 $(PROJECT)/internal/clients/timestamp
-	go test -count=1 $(PROJECT)/internal/config
+	go test -count=1 $(PROJECT)/internal/common
 	go test -count=1 $(PROJECT)/internal/services/frontend
 	go test -count=1 $(PROJECT)/internal/services/inventory
 	go test -count=1 $(PROJECT)/internal/services/repair_manager/inventory

--- a/internal/clients/inventory/definition.go
+++ b/internal/clients/inventory/definition.go
@@ -14,7 +14,7 @@ import (
 	pb "github.com/Jim3Things/CloudChamber/pkg/protos/inventory"
 )
 
-// NewRoot returns a root object which acts as a well-knwon point in a namespace
+// NewRoot returns a root object which acts as a well-known point in a namespace
 // and which can be used to navigate the namespace for a given table.
 //
 // Valid tables are
@@ -23,7 +23,7 @@ import (
 //	- ObservedTable
 //	- TargetTable
 //
-func NewRoot(ctx context.Context, store *store.Store, table string) (*Root, error) {
+func NewRoot(_ context.Context, store *store.Store, table string) (*Root, error) {
 
 	k, err := GetKeyForIndexRegion(table)
 
@@ -43,7 +43,7 @@ func NewRoot(ctx context.Context, store *store.Store, table string) (*Root, erro
 // NewRegion is a convenience function used to construct a Region object
 // from scratch rather than relative to its parent.
 //
-func NewRegion(ctx context.Context, store *store.Store, table string, region string) (*Region, error) {
+func NewRegion(_ context.Context, store *store.Store, table string, region string) (*Region, error) {
 
 	keyIndex, err := GetKeyForIndexZone(table, region)
 
@@ -78,7 +78,7 @@ func NewRegion(ctx context.Context, store *store.Store, table string, region str
 // NewZone is a convenience function used to construct a Zone object
 // from scratch rather than relative to its parent.
 //
-func NewZone(ctx context.Context, store *store.Store, table string, region string, zone string) (*Zone, error) {
+func NewZone(_ context.Context, store *store.Store, table string, region string, zone string) (*Zone, error) {
 
 	keyIndex, err := GetKeyForIndexRack(table, region, zone)
 
@@ -114,7 +114,13 @@ func NewZone(ctx context.Context, store *store.Store, table string, region strin
 // NewRack is a convenience function used to construct a Rack object
 // from scratch rather than relative to its parent.
 //
-func NewRack(ctx context.Context, store *store.Store, table string, region string, zone string, rack string) (*Rack, error) {
+func NewRack(
+	_ context.Context,
+	store *store.Store,
+	table string,
+	region string,
+	zone string,
+	rack string) (*Rack, error) {
 
 	keyIndexPdu, err := GetKeyForIndexPdu(table, region, zone, rack)
 
@@ -165,7 +171,14 @@ func NewRack(ctx context.Context, store *store.Store, table string, region strin
 // NewPdu is a convenience function used to construct a Pdu object
 // from scratch rather than relative to its parent.
 //
-func NewPdu(ctx context.Context, store *store.Store, table string, region string, zone string, rack string, id int64) (*Pdu, error) {
+func NewPdu(
+	_ context.Context,
+	store *store.Store,
+	table string,
+	region string,
+	zone string,
+	rack string,
+	id int64) (*Pdu, error) {
 
 	keyIndexEntry, err := GetKeyForIndexEntryPdu(table, region, zone, rack, id)
 
@@ -196,7 +209,14 @@ func NewPdu(ctx context.Context, store *store.Store, table string, region string
 // NewTor is a convenience function used to construct a Tor object
 // from scratch rather than relative to its parent.
 //
-func NewTor(ctx context.Context, store *store.Store, table string, region string, zone string, rack string, id int64) (*Tor, error) {
+func NewTor(
+	_ context.Context,
+	store *store.Store,
+	table string,
+	region string,
+	zone string,
+	rack string,
+	id int64) (*Tor, error) {
 
 	keyIndexEntry, err := GetKeyForIndexEntryTor(table, region, zone, rack, id)
 
@@ -227,7 +247,14 @@ func NewTor(ctx context.Context, store *store.Store, table string, region string
 // NewBlade is a convenience function used to construct a Blade object
 // from scratch rather than relative to its parent.
 //
-func NewBlade(ctx context.Context, store *store.Store, table string, region string, zone string, rack string, id int64) (*Blade, error) {
+func NewBlade(
+	_ context.Context,
+	store *store.Store,
+	table string,
+	region string,
+	zone string,
+	rack string,
+	id int64) (*Blade, error) {
 
 	keyIndexEntry, err := GetKeyForIndexEntryBlade(table, region, zone, rack, id)
 
@@ -256,7 +283,6 @@ func NewBlade(ctx context.Context, store *store.Store, table string, region stri
 }
 
 type revisionInfo struct {
-
 	revision       int64
 	revisionRecord int64
 	revisionStore  int64
@@ -272,7 +298,7 @@ func (r *revisionInfo) GetRevision() int64 {
 	return r.revision
 }
 
-// GetRevisionRecord returns the revision of the underlying store object as 
+// GetRevisionRecord returns the revision of the underlying store object as
 // determined at the time of the last Create(), Read() or Update() for the
 // object. The record revision is not reset by a SetDetails() call and is
 // used when performing either a conditional update or conditional delete
@@ -282,9 +308,9 @@ func (r *revisionInfo) GetRevisionRecord() int64 {
 	return r.revisionRecord
 }
 
-// GetRevisionStore returns the revison of the underlying store ifself as 
+// GetRevisionStore returns the revision of the underlying store itself as
 // determined at the time of the last Create() Read() for the object. The
-// store revision is not reset by a SetDetails() call and is provided 
+// store revision is not reset by a SetDetails() call and is provided
 // for information only.
 //
 func (r *revisionInfo) GetRevisionStore() int64 {
@@ -314,18 +340,18 @@ func (r *revisionInfo) resetRevision() int64 {
 	return store.RevisionInvalid
 }
 
-// updateRevision is used to set/update the current revision information 
-// as part of a successful invokation of a store routine.
+// updateRevision is used to set/update the current revision information
+// as part of a successful invocation of a store routine.
 //
 func (r *revisionInfo) updateRevisionInfo(rev int64) int64 {
-	r.revision       = rev
+	r.revision = rev
 	r.revisionRecord = rev
-	r.revisionStore  = rev
+	r.revisionStore = rev
 
 	return rev
 }
 
-// Root is a structure representing the well-known root of the namespace. It 
+// Root is a structure representing the well-known root of the namespace. It
 // is used to locate the regions within the namespace represented by the table
 // field.
 //
@@ -333,14 +359,13 @@ func (r *revisionInfo) updateRevisionInfo(rev int64) int64 {
 // the store, or retrieved from it.
 //
 type Root struct {
-
 	Store         *store.Store
-	KeyChildIndex  string
-	Table          string
+	KeyChildIndex string
+	Table         string
 
 	revisionInfo
 
-	details        *pb.RootDetails
+	details *pb.RootDetails
 }
 
 // SetDetails is used to attach some attribute information to the object.
@@ -349,8 +374,8 @@ type Root struct {
 //
 // The current revision of the region object is reset
 //
-func (r *Root) SetDetails(ctx context.Context, details *pb.RootDetails) {
-	r.details  = details
+func (r *Root) SetDetails(_ context.Context, details *pb.RootDetails) {
+	r.details = details
 	r.resetRevision()
 }
 
@@ -359,36 +384,36 @@ func (r *Root) SetDetails(ctx context.Context, details *pb.RootDetails) {
 // As the Root object is not persisted, the attribute information will either
 // be the initialisation value, or whatever was last set using SetDetails()
 //
-func (r *Root) GetDetails(ctx context.Context) *pb.RootDetails {
-	return 	r.details
+func (r *Root) GetDetails(_ context.Context) *pb.RootDetails {
+	return r.details
 }
 
 // Create is not used for a Root object as there is no persistence for this
 // object.
 //
-func (r *Root) Create(ctx context.Context) (int64, error) {
+func (r *Root) Create(_ context.Context) (int64, error) {
 	return store.RevisionInvalid, errors.ErrFunctionNotAvailable
 }
 
 // Read is not used for a Root object as there is no persistence for this
 // object.
 //
-func (r *Root) Read(ctx context.Context) (int64, error) {
-	return 	store.RevisionInvalid, errors.ErrFunctionNotAvailable
+func (r *Root) Read(_ context.Context) (int64, error) {
+	return store.RevisionInvalid, errors.ErrFunctionNotAvailable
 }
 
 // Update is not used for a Root object as there is no persistence for this
 // object.
 //
-func (r *Root) Update(ctx context.Context, unconditional bool) (int64, error) {
+func (r *Root) Update(_ context.Context, _ bool) (int64, error) {
 	return store.RevisionInvalid, errors.ErrFunctionNotAvailable
 }
 
 // Delete is not used for a Root object as there is no persistence for this
 // object.
 //
-func (r *Root) Delete(ctx context.Context, unconditional bool) (int64, error) {
-	return 	store.RevisionInvalid, errors.ErrFunctionNotAvailable
+func (r *Root) Delete(_ context.Context, _ bool) (int64, error) {
+	return store.RevisionInvalid, errors.ErrFunctionNotAvailable
 }
 
 // NewChild creates a new region child object within the current
@@ -397,7 +422,7 @@ func (r *Root) Delete(ctx context.Context, unconditional bool) (int64, error) {
 // associated record in the underlying store.
 //
 // No information is fetched from the underlying store so the attribute
-// and revisions fields within the oject are not valid.
+// and revisions fields within the object are not valid.
 //
 func (r *Root) NewChild(ctx context.Context, name string) (*Region, error) {
 
@@ -410,7 +435,7 @@ func (r *Root) NewChild(ctx context.Context, name string) (*Region, error) {
 // NewChild() calls to create new region objects.
 //
 func (r *Root) ListChildren(ctx context.Context) (int64, []string, error) {
-	
+
 	records, rev, err := r.Store.List(ctx, store.KeyRootInventory, r.KeyChildIndex)
 
 	if err == errors.ErrStoreIndexNotFound(r.KeyChildIndex) {
@@ -424,7 +449,7 @@ func (r *Root) ListChildren(ctx context.Context) (int64, []string, error) {
 	names := make([]string, 0, len(*records))
 
 	for k, v := range *records {
-	
+
 		name := strings.TrimPrefix(k, r.KeyChildIndex)
 
 		if name != store.GetNormalizedName(v.Value) {
@@ -463,7 +488,7 @@ func (r *Root) FetchChildren(ctx context.Context) (int64, *map[string]Region, er
 		if err != nil {
 			return store.RevisionInvalid, nil, err
 		}
-	
+
 		_, err = child.Read(ctx)
 
 		if err != nil {
@@ -483,18 +508,17 @@ func (r *Root) FetchChildren(ctx context.Context) (int64, *map[string]Region, er
 // to the store.
 //
 type Region struct {
-
-	Store          *store.Store
-	KeyChildIndex  string
-	KeyIndexEntry  string
-	Key            string
-	Table          string
-	Region         string
+	Store         *store.Store
+	KeyChildIndex string
+	KeyIndexEntry string
+	Key           string
+	Table         string
+	Region        string
 
 	revisionInfo
 
-	details       *pb.RegionDetails
-	record        *pb.StoreRecordDefinitionRegion
+	details *pb.RegionDetails
+	record  *pb.Store_RecordDefinition_Region
 }
 
 // SetDetails is used to attach some attribute information to the object.
@@ -504,8 +528,8 @@ type Region struct {
 //
 // The current revision of the region object is reset
 //
-func (r *Region) SetDetails(ctx context.Context, details *pb.RegionDetails) {
-	r.details  = details
+func (r *Region) SetDetails(_ context.Context, details *pb.RegionDetails) {
+	r.details = details
 	r.resetRevision()
 }
 
@@ -515,7 +539,7 @@ func (r *Region) SetDetails(ctx context.Context, details *pb.RegionDetails) {
 //
 // May return nil if there are no attributes currently held in the object.
 //
-func (r *Region) GetDetails(ctx context.Context) *pb.RegionDetails {
+func (r *Region) GetDetails(_ context.Context) *pb.RegionDetails {
 	return r.details
 }
 
@@ -527,8 +551,8 @@ func (r *Region) GetDetails(ctx context.Context) *pb.RegionDetails {
 //
 // Once the store operation completes successfully, the revision fields
 // in the object will be updated to that returned by the store. These can
-// either be reetrieved by one of the GetRevisionXxx() call or used for
-// subsequent conditional operaions such as a conditional Update() call.
+// either be retrieved by one of the GetRevisionXxx() call or used for
+// subsequent conditional operations such as a conditional Update() call.
 //
 func (r *Region) Create(ctx context.Context) (int64, error) {
 
@@ -536,7 +560,7 @@ func (r *Region) Create(ctx context.Context) (int64, error) {
 		return store.RevisionInvalid, errors.ErrDetailsNotAvailable("region")
 	}
 
-	record := &pb.StoreRecordDefinitionRegion{
+	record := &pb.Store_RecordDefinition_Region{
 		Details: r.details,
 	}
 
@@ -549,8 +573,8 @@ func (r *Region) Create(ctx context.Context) (int64, error) {
 	// Create the child and its index as an atomic pair.
 	//
 	keySet := &map[string]string{
-		r.KeyIndexEntry : r.Region,
-		r.Key           : v,
+		r.KeyIndexEntry: r.Region,
+		r.Key:           v,
 	}
 
 	rev, err := r.Store.CreateMultiple(ctx, store.KeyRootInventory, keySet)
@@ -570,7 +594,7 @@ func (r *Region) Create(ctx context.Context) (int64, error) {
 //
 // Once the Read() has completed successfully the details and other
 // information for the object can be retrieved by any of the GetXxx() methods
-// for that obect.
+// for that object.
 //
 func (r *Region) Read(ctx context.Context) (int64, error) {
 
@@ -580,14 +604,14 @@ func (r *Region) Read(ctx context.Context) (int64, error) {
 		return store.RevisionInvalid, err
 	}
 
-	record := &pb.StoreRecordDefinitionRegion{}
+	record := &pb.Store_RecordDefinition_Region{}
 
 	if err = store.Decode(*v, record); err != nil {
 		return store.RevisionInvalid, err
 	}
 
 	r.details = record.Details
-	r.record  = record
+	r.record = record
 
 	return r.updateRevisionInfo(rev), nil
 }
@@ -609,7 +633,7 @@ func (r *Region) Update(ctx context.Context, unconditional bool) (int64, error) 
 		return store.RevisionInvalid, errors.ErrDetailsNotAvailable("region")
 	}
 
-	record := &pb.StoreRecordDefinitionRegion{
+	record := &pb.Store_RecordDefinition_Region{
 		Details: r.details,
 	}
 
@@ -652,8 +676,8 @@ func (r *Region) Delete(ctx context.Context, unconditional bool) (int64, error) 
 	// Delete the record and its index as an atomic pair.
 	//
 	keySet := &map[string]int64{
-		r.KeyIndexEntry : store.RevisionInvalid,
-		r.Key           : r.GetRevisionForRequest(unconditional),
+		r.KeyIndexEntry: store.RevisionInvalid,
+		r.Key:           r.GetRevisionForRequest(unconditional),
 	}
 
 	rev, err := r.Store.DeleteMultiple(ctx, store.KeyRootInventory, keySet)
@@ -673,7 +697,7 @@ func (r *Region) Delete(ctx context.Context, unconditional bool) (int64, error) 
 // associated record in the underlying store.
 //
 // No information is fetched from the underlying store so the attribute
-// and revisions fields within the oject are not valid.
+// and revisions fields within the object are not valid.
 //
 func (r *Region) NewChild(ctx context.Context, name string) (*Zone, error) {
 
@@ -686,7 +710,7 @@ func (r *Region) NewChild(ctx context.Context, name string) (*Zone, error) {
 // NewChild() calls to create new zone objects.
 //
 func (r *Region) ListChildren(ctx context.Context) (int64, []string, error) {
-	
+
 	records, rev, err := r.Store.List(ctx, store.KeyRootInventory, r.KeyChildIndex)
 
 	if err = r.mapErrStoreValue(err); err != nil {
@@ -696,7 +720,7 @@ func (r *Region) ListChildren(ctx context.Context) (int64, []string, error) {
 	names := make([]string, 0, len(*records))
 
 	for k, v := range *records {
-	
+
 		name := strings.TrimPrefix(k, r.KeyChildIndex)
 
 		if name != store.GetNormalizedName(v.Value) {
@@ -724,7 +748,7 @@ func (r *Region) FetchChildren(ctx context.Context) (int64, *map[string]Zone, er
 
 	children := make(map[string]Zone, len(names))
 
-	// TODO - use read multiple? If broken out into "groups", returned rev is the highest found 
+	// TODO - use read multiple? If broken out into "groups", returned rev is the highest found
 	//
 	for _, v := range names {
 
@@ -733,7 +757,7 @@ func (r *Region) FetchChildren(ctx context.Context) (int64, *map[string]Zone, er
 		if err != nil {
 			return store.RevisionInvalid, nil, err
 		}
-	
+
 		rev, err = child.Read(ctx)
 
 		if err != nil {
@@ -747,7 +771,7 @@ func (r *Region) FetchChildren(ctx context.Context) (int64, *map[string]Zone, er
 }
 
 func (r *Region) mapErrStoreValue(err error) error {
-	switch(err){
+	switch err {
 	case errors.ErrStoreKeyNotFound(r.Key):
 		return errors.ErrRegionNotFound{Region: r.Region}
 
@@ -760,7 +784,7 @@ func (r *Region) mapErrStoreValue(err error) error {
 	case errors.ErrStoreAlreadyExists(r.KeyIndexEntry), errors.ErrStoreAlreadyExists(r.Key):
 		return errors.ErrRegionAlreadyExists{Region: r.Region}
 	}
-	
+
 	return err
 }
 
@@ -771,19 +795,18 @@ func (r *Region) mapErrStoreValue(err error) error {
 // to the store.
 //
 type Zone struct {
-
-	Store          *store.Store
-	KeyChildIndex  string
-	KeyIndexEntry  string
-	Key            string
-	Table          string
-	Region         string
-	Zone           string
+	Store         *store.Store
+	KeyChildIndex string
+	KeyIndexEntry string
+	Key           string
+	Table         string
+	Region        string
+	Zone          string
 
 	revisionInfo
 
-	details        *pb.ZoneDetails
-	record         *pb.StoreRecordDefinitionZone
+	details *pb.ZoneDetails
+	record  *pb.Store_RecordDefinition_Zone
 }
 
 // SetDetails is used to attach some attribute information to the object.
@@ -793,7 +816,7 @@ type Zone struct {
 //
 // The current revision of the zone object is reset
 //
-func (z *Zone) SetDetails(ctx context.Context, details *pb.ZoneDetails) {
+func (z *Zone) SetDetails(_ context.Context, details *pb.ZoneDetails) {
 	z.details = details
 	z.resetRevision()
 }
@@ -804,7 +827,7 @@ func (z *Zone) SetDetails(ctx context.Context, details *pb.ZoneDetails) {
 //
 // May return nil if there are no attributes currently held in the object.
 //
-func (z *Zone) GetDetails(ctx context.Context) *pb.ZoneDetails {
+func (z *Zone) GetDetails(_ context.Context) *pb.ZoneDetails {
 	return z.details
 }
 
@@ -816,8 +839,8 @@ func (z *Zone) GetDetails(ctx context.Context) *pb.ZoneDetails {
 //
 // Once the store operation completes successfully, the revision fields
 // in the object will be updated to that returned by the store. These can
-// either be reetrieved by one of the GetRevisionXxx() call or used for
-// subsequent conditional operaions such as a conditional Update() call.
+// either be retrieved by one of the GetRevisionXxx() call or used for
+// subsequent conditional operations such as a conditional Update() call.
 //
 func (z *Zone) Create(ctx context.Context) (int64, error) {
 
@@ -825,7 +848,7 @@ func (z *Zone) Create(ctx context.Context) (int64, error) {
 		return store.RevisionInvalid, errors.ErrDetailsNotAvailable("zone")
 	}
 
-	record := &pb.StoreRecordDefinitionZone{
+	record := &pb.Store_RecordDefinition_Zone{
 		Details: z.details,
 	}
 
@@ -838,8 +861,8 @@ func (z *Zone) Create(ctx context.Context) (int64, error) {
 	// Create the child and its index as an atomic pair.
 	//
 	keySet := &map[string]string{
-		z.KeyIndexEntry : z.Zone,
-		z.Key           : v,
+		z.KeyIndexEntry: z.Zone,
+		z.Key:           v,
 	}
 
 	rev, err := z.Store.CreateMultiple(ctx, store.KeyRootInventory, keySet)
@@ -859,7 +882,7 @@ func (z *Zone) Create(ctx context.Context) (int64, error) {
 //
 // Once the Read() has completed successfully the details and other
 // information for the object can be retrieved by any of the GetXxx() methods
-// for that obect.
+// for that object.
 //
 func (z *Zone) Read(ctx context.Context) (int64, error) {
 
@@ -869,14 +892,14 @@ func (z *Zone) Read(ctx context.Context) (int64, error) {
 		return store.RevisionInvalid, err
 	}
 
-	record := &pb.StoreRecordDefinitionZone{}
+	record := &pb.Store_RecordDefinition_Zone{}
 
 	if err = store.Decode(*v, record); err != nil {
 		return store.RevisionInvalid, err
 	}
 
 	z.details = record.Details
-	z.record  = record
+	z.record = record
 
 	return z.updateRevisionInfo(rev), nil
 }
@@ -898,7 +921,7 @@ func (z *Zone) Update(ctx context.Context, unconditional bool) (int64, error) {
 		return store.RevisionInvalid, errors.ErrDetailsNotAvailable("zone")
 	}
 
-	record := &pb.StoreRecordDefinitionZone{
+	record := &pb.Store_RecordDefinition_Zone{
 		Details: z.details,
 	}
 
@@ -941,8 +964,8 @@ func (z *Zone) Delete(ctx context.Context, unconditional bool) (int64, error) {
 	// Delete the record and its index as an atomic pair.
 	//
 	keySet := &map[string]int64{
-		z.KeyIndexEntry : store.RevisionInvalid,
-		z.Key           : z.GetRevisionForRequest(unconditional),
+		z.KeyIndexEntry: store.RevisionInvalid,
+		z.Key:           z.GetRevisionForRequest(unconditional),
 	}
 
 	rev, err := z.Store.DeleteMultiple(ctx, store.KeyRootInventory, keySet)
@@ -962,7 +985,7 @@ func (z *Zone) Delete(ctx context.Context, unconditional bool) (int64, error) {
 // associated record in the underlying store.
 //
 // No information is fetched from the underlying store so the attribute
-// and revisions fields within the oject are not valid.
+// and revisions fields within the object are not valid.
 //
 func (z *Zone) NewChild(ctx context.Context, name string) (*Rack, error) {
 
@@ -975,7 +998,7 @@ func (z *Zone) NewChild(ctx context.Context, name string) (*Rack, error) {
 // NewChild() calls to create new rack objects.
 //
 func (z *Zone) ListChildren(ctx context.Context) (int64, []string, error) {
-	
+
 	records, rev, err := z.Store.List(ctx, store.KeyRootInventory, z.KeyChildIndex)
 
 	if err = z.mapErrStoreValue(err); err != nil {
@@ -985,7 +1008,7 @@ func (z *Zone) ListChildren(ctx context.Context) (int64, []string, error) {
 	names := make([]string, 0, len(*records))
 
 	for k, v := range *records {
-	
+
 		name := strings.TrimPrefix(k, z.KeyChildIndex)
 
 		if name != store.GetNormalizedName(v.Value) {
@@ -1020,7 +1043,7 @@ func (z *Zone) FetchChildren(ctx context.Context) (int64, *map[string]Rack, erro
 		if err != nil {
 			return store.RevisionInvalid, nil, err
 		}
-	
+
 		_, err = child.Read(ctx)
 
 		if err != nil {
@@ -1034,7 +1057,7 @@ func (z *Zone) FetchChildren(ctx context.Context) (int64, *map[string]Rack, erro
 }
 
 func (z *Zone) mapErrStoreValue(err error) error {
-	switch(err){
+	switch err {
 	case errors.ErrStoreKeyNotFound(z.Key):
 		return errors.ErrZoneNotFound{Region: z.Region, Zone: z.Zone}
 
@@ -1047,7 +1070,7 @@ func (z *Zone) mapErrStoreValue(err error) error {
 	case errors.ErrStoreAlreadyExists(z.KeyIndexEntry), errors.ErrStoreAlreadyExists(z.Key):
 		return errors.ErrZoneAlreadyExists{Region: z.Region, Zone: z.Zone}
 	}
-	
+
 	return err
 }
 
@@ -1058,23 +1081,21 @@ func (z *Zone) mapErrStoreValue(err error) error {
 // preparation for updates to the store.
 //
 type Rack struct {
-
-	Store          *store.Store
-	KeyIndexPdu    string
-	KeyIndexTor    string
-	KeyIndexBlade  string
-	KeyIndexEntry  string
-	Key            string
-	Table          string
-	Region         string
-	Zone           string
-	Rack           string
+	Store         *store.Store
+	KeyIndexPdu   string
+	KeyIndexTor   string
+	KeyIndexBlade string
+	KeyIndexEntry string
+	Key           string
+	Table         string
+	Region        string
+	Zone          string
+	Rack          string
 
 	revisionInfo
 
-	details       *pb.RackDetails
-	record        *pb.StoreRecordDefinitionRack
-
+	details *pb.RackDetails
+	record  *pb.Store_RecordDefinition_Rack
 }
 
 // SetDetails is used to attach some attribute information to the object.
@@ -1084,8 +1105,8 @@ type Rack struct {
 //
 // The current revision of the rack object is reset
 //
-func (r *Rack) SetDetails(ctx context.Context, details *pb.RackDetails) {
-	r.details  = details
+func (r *Rack) SetDetails(_ context.Context, details *pb.RackDetails) {
+	r.details = details
 	r.resetRevision()
 }
 
@@ -1095,7 +1116,7 @@ func (r *Rack) SetDetails(ctx context.Context, details *pb.RackDetails) {
 //
 // May return nil if there are no attributes currently held in the object.
 //
-func (r *Rack) GetDetails(ctx context.Context) *pb.RackDetails {
+func (r *Rack) GetDetails(_ context.Context) *pb.RackDetails {
 	return r.details
 }
 
@@ -1107,8 +1128,8 @@ func (r *Rack) GetDetails(ctx context.Context) *pb.RackDetails {
 //
 // Once the store operation completes successfully, the revision fields
 // in the object will be updated to that returned by the store. These can
-// either be reetrieved by one of the GetRevisionXxx() call or used for
-// subsequent conditional operaions such as a conditional Update() call.
+// either be retrieved by one of the GetRevisionXxx() call or used for
+// subsequent conditional operations such as a conditional Update() call.
 //
 func (r *Rack) Create(ctx context.Context) (int64, error) {
 
@@ -1116,7 +1137,7 @@ func (r *Rack) Create(ctx context.Context) (int64, error) {
 		return store.RevisionInvalid, errors.ErrDetailsNotAvailable("rack")
 	}
 
-	record := &pb.StoreRecordDefinitionRack{
+	record := &pb.Store_RecordDefinition_Rack{
 		Details: r.details,
 	}
 
@@ -1129,8 +1150,8 @@ func (r *Rack) Create(ctx context.Context) (int64, error) {
 	// Create the child and its index as an atomic pair.
 	//
 	keySet := &map[string]string{
-		r.KeyIndexEntry : r.Rack,
-		r.Key           : v,
+		r.KeyIndexEntry: r.Rack,
+		r.Key:           v,
 	}
 
 	rev, err := r.Store.CreateMultiple(ctx, store.KeyRootInventory, keySet)
@@ -1150,7 +1171,7 @@ func (r *Rack) Create(ctx context.Context) (int64, error) {
 //
 // Once the Read() has completed successfully the details and other
 // information for the object can be retrieved by any of the GetXxx() methods
-// for that obect.
+// for that object.
 //
 func (r *Rack) Read(ctx context.Context) (int64, error) {
 
@@ -1160,14 +1181,14 @@ func (r *Rack) Read(ctx context.Context) (int64, error) {
 		return store.RevisionInvalid, err
 	}
 
-	record := &pb.StoreRecordDefinitionRack{}
+	record := &pb.Store_RecordDefinition_Rack{}
 
 	if err = store.Decode(*v, record); err != nil {
 		return store.RevisionInvalid, err
 	}
 
 	r.details = record.Details
-	r.record  = record
+	r.record = record
 
 	return r.updateRevisionInfo(rev), nil
 }
@@ -1189,7 +1210,7 @@ func (r *Rack) Update(ctx context.Context, unconditional bool) (int64, error) {
 		return store.RevisionInvalid, errors.ErrDetailsNotAvailable("rack")
 	}
 
-	record := &pb.StoreRecordDefinitionRack{
+	record := &pb.Store_RecordDefinition_Rack{
 		Details: r.details,
 	}
 
@@ -1232,8 +1253,8 @@ func (r *Rack) Delete(ctx context.Context, unconditional bool) (int64, error) {
 	// Delete the record and its index as an atomic pair.
 	//
 	keySet := &map[string]int64{
-		r.KeyIndexEntry : store.RevisionInvalid,
-		r.Key           : r.GetRevisionForRequest(unconditional),
+		r.KeyIndexEntry: store.RevisionInvalid,
+		r.Key:           r.GetRevisionForRequest(unconditional),
 	}
 
 	rev, err := r.Store.DeleteMultiple(ctx, store.KeyRootInventory, keySet)
@@ -1257,7 +1278,7 @@ func (r *Rack) Delete(ctx context.Context, unconditional bool) (int64, error) {
 // should be called to construct an object for the appropriate specialized
 // child.
 //
-func (r *Rack) NewChild(ctx context.Context, name string) (*Zone, error) {
+func (r *Rack) NewChild(_ context.Context, _ string) (*Zone, error) {
 	return nil, errors.ErrFunctionNotAvailable
 }
 
@@ -1267,7 +1288,7 @@ func (r *Rack) NewChild(ctx context.Context, name string) (*Zone, error) {
 // the underlying store.
 //
 // No information is fetched from the underlying store so the attribute
-// and revisions fields within the oject are not valid.
+// and revisions fields within the object are not valid.
 //
 func (r *Rack) NewPdu(ctx context.Context, ID int64) (*Pdu, error) {
 
@@ -1280,7 +1301,7 @@ func (r *Rack) NewPdu(ctx context.Context, ID int64) (*Pdu, error) {
 // the underlying store.
 //
 // No information is fetched from the underlying store so the attribute
-// and revisions fields within the oject are not valid.
+// and revisions fields within the object are not valid.
 //
 func (r *Rack) NewTor(ctx context.Context, ID int64) (*Tor, error) {
 
@@ -1293,7 +1314,7 @@ func (r *Rack) NewTor(ctx context.Context, ID int64) (*Tor, error) {
 // the underlying store.
 //
 // No information is fetched from the underlying store so the attribute
-// and revisions fields within the oject are not valid.
+// and revisions fields within the object are not valid.
 //
 func (r *Rack) NewBlade(ctx context.Context, ID int64) (*Blade, error) {
 
@@ -1310,7 +1331,7 @@ func (r *Rack) NewBlade(ctx context.Context, ID int64) (*Blade, error) {
 // should be called to construct an object for the appropriate specialized
 // child.
 //
-func (r *Rack) ListChildren(ctx context.Context) (int64, *[]string, error) {
+func (r *Rack) ListChildren(_ context.Context) (int64, *[]string, error) {
 	return store.RevisionInvalid, nil, errors.ErrFunctionNotAvailable
 }
 
@@ -1324,7 +1345,7 @@ func (r *Rack) ListChildren(ctx context.Context) (int64, *[]string, error) {
 // should be called to construct an object for the appropriate specialized
 // child.
 //
-func (r *Rack) FetchChildren(ctx context.Context) (int64, *map[string]interface{}, error) {
+func (r *Rack) FetchChildren(_ context.Context) (int64, *map[string]interface{}, error) {
 	return store.RevisionInvalid, nil, errors.ErrFunctionNotAvailable
 }
 
@@ -1344,7 +1365,7 @@ func (r *Rack) ListPdus(ctx context.Context) (int64, []int64, error) {
 	names := make([]int64, 0, len(*records))
 
 	for k, v := range *records {
-	
+
 		name := strings.TrimPrefix(k, r.KeyIndexPdu)
 
 		// Verify that the "index" part of the name is numeric
@@ -1352,17 +1373,31 @@ func (r *Rack) ListPdus(ctx context.Context) (int64, []int64, error) {
 		intName, err := strconv.ParseInt(name, 10, 64)
 
 		if err != nil {
-			return store.RevisionInvalid, nil, errors.ErrPduIndexInvalid{Region: r.Region, Zone: r.Zone, Rack: r.Rack, Pdu: name}
+			return store.RevisionInvalid, nil, errors.ErrPduIndexInvalid{
+				Region: r.Region,
+				Zone:   r.Zone,
+				Rack:   r.Rack,
+				Pdu:    name,
+			}
 		}
 
 		intValue, err := strconv.ParseInt(v.Value, 10, 64)
 
 		if err != nil {
-			return store.RevisionInvalid, nil, errors.ErrPduIndexInvalid{Region: r.Region, Zone: r.Zone, Rack: r.Rack, Pdu: v.Value}
+			return store.RevisionInvalid, nil, errors.ErrPduIndexInvalid{
+				Region: r.Region,
+				Zone:   r.Zone,
+				Rack:   r.Rack,
+				Pdu:    v.Value,
+			}
 		}
 
 		if intName != intValue {
-			return store.RevisionInvalid, nil, errors.ErrIndexKeyValueMismatch{Namespace: r.Table, Key: name, Value: v.Value}
+			return store.RevisionInvalid, nil, errors.ErrIndexKeyValueMismatch{
+				Namespace: r.Table,
+				Key:       name,
+				Value:     v.Value,
+			}
 		}
 
 		names = append(names, intValue)
@@ -1387,7 +1422,7 @@ func (r *Rack) ListTors(ctx context.Context) (int64, []int64, error) {
 	names := make([]int64, 0, len(*records))
 
 	for k, v := range *records {
-	
+
 		name := strings.TrimPrefix(k, r.KeyIndexTor)
 
 		// Verify that the "index" part of the name is numeric
@@ -1395,17 +1430,31 @@ func (r *Rack) ListTors(ctx context.Context) (int64, []int64, error) {
 		intName, err := strconv.ParseInt(name, 10, 64)
 
 		if err != nil {
-			return store.RevisionInvalid, nil, errors.ErrTorIndexInvalid{Region: r.Region, Zone: r.Zone, Rack: r.Rack, Tor: name}
+			return store.RevisionInvalid, nil, errors.ErrTorIndexInvalid{
+				Region: r.Region,
+				Zone:   r.Zone,
+				Rack:   r.Rack,
+				Tor:    name,
+			}
 		}
 
 		intValue, err := strconv.ParseInt(v.Value, 10, 64)
 
 		if err != nil {
-			return store.RevisionInvalid, nil, errors.ErrTorIndexInvalid{Region: r.Region, Zone: r.Zone, Rack: r.Rack, Tor: v.Value}
+			return store.RevisionInvalid, nil, errors.ErrTorIndexInvalid{
+				Region: r.Region,
+				Zone:   r.Zone,
+				Rack:   r.Rack,
+				Tor:    v.Value,
+			}
 		}
 
 		if intName != intValue {
-			return store.RevisionInvalid, nil, errors.ErrIndexKeyValueMismatch{Namespace: r.Table, Key: name, Value: v.Value}
+			return store.RevisionInvalid, nil, errors.ErrIndexKeyValueMismatch{
+				Namespace: r.Table,
+				Key:       name,
+				Value:     v.Value,
+			}
 		}
 
 		names = append(names, intValue)
@@ -1430,7 +1479,7 @@ func (r *Rack) ListBlades(ctx context.Context) (int64, []int64, error) {
 	names := make([]int64, 0, len(*records))
 
 	for k, v := range *records {
-	
+
 		name := strings.TrimPrefix(k, r.KeyIndexBlade)
 
 		// Verify that the "index" part of the name is numeric
@@ -1438,17 +1487,31 @@ func (r *Rack) ListBlades(ctx context.Context) (int64, []int64, error) {
 		intName, err := strconv.ParseInt(name, 10, 64)
 
 		if err != nil {
-			return store.RevisionInvalid, nil, errors.ErrBladeIndexInvalid{Region: r.Table, Zone: r.Zone, Rack: r.Rack, Blade: name}
+			return store.RevisionInvalid, nil, errors.ErrBladeIndexInvalid{
+				Region: r.Table,
+				Zone:   r.Zone,
+				Rack:   r.Rack,
+				Blade:  name,
+			}
 		}
 
 		intValue, err := strconv.ParseInt(v.Value, 10, 64)
 
 		if err != nil {
-			return store.RevisionInvalid, nil, errors.ErrBladeIndexInvalid{Region: r.Table, Zone: r.Zone, Rack: r.Rack, Blade: v.Value}
+			return store.RevisionInvalid, nil, errors.ErrBladeIndexInvalid{
+				Region: r.Table,
+				Zone:   r.Zone,
+				Rack:   r.Rack,
+				Blade:  v.Value,
+			}
 		}
 
 		if intName != intValue {
-			return store.RevisionInvalid, nil, errors.ErrIndexKeyValueMismatch{Namespace: r.Table, Key: name, Value: v.Value}
+			return store.RevisionInvalid, nil, errors.ErrIndexKeyValueMismatch{
+				Namespace: r.Table,
+				Key:       name,
+				Value:     v.Value,
+			}
 		}
 
 		names = append(names, intValue)
@@ -1479,7 +1542,7 @@ func (r *Rack) FetchPdus(ctx context.Context) (int64, *map[int64]Pdu, error) {
 		if err != nil {
 			return store.RevisionInvalid, nil, err
 		}
-	
+
 		_, err = pdu.Read(ctx)
 
 		if err != nil {
@@ -1514,7 +1577,7 @@ func (r *Rack) FetchTors(ctx context.Context) (int64, *map[int64]Tor, error) {
 		if err != nil {
 			return store.RevisionInvalid, nil, err
 		}
-	
+
 		_, err = tor.Read(ctx)
 
 		if err != nil {
@@ -1549,7 +1612,7 @@ func (r *Rack) FetchBlades(ctx context.Context) (int64, *map[int64]Blade, error)
 		if err != nil {
 			return store.RevisionInvalid, nil, err
 		}
-	
+
 		_, err = blade.Read(ctx)
 
 		if err != nil {
@@ -1563,7 +1626,7 @@ func (r *Rack) FetchBlades(ctx context.Context) (int64, *map[int64]Blade, error)
 }
 
 func (r *Rack) mapErrStoreValue(err error) error {
-	switch(err) {
+	switch err {
 	case errors.ErrStoreKeyNotFound(r.Key):
 		return errors.ErrRackNotFound{Region: r.Region, Zone: r.Zone, Rack: r.Rack}
 
@@ -1582,7 +1645,7 @@ func (r *Rack) mapErrStoreValue(err error) error {
 	case errors.ErrStoreAlreadyExists(r.KeyIndexEntry), errors.ErrStoreAlreadyExists(r.Key):
 		return errors.ErrRackAlreadyExists{Region: r.Region, Zone: r.Zone, Rack: r.Rack}
 	}
-	
+
 	return err
 }
 
@@ -1594,21 +1657,20 @@ func (r *Rack) mapErrStoreValue(err error) error {
 // Pdu is a specialization of a child object for a rack parent.
 //
 type Pdu struct {
-
-	Store          *store.Store
-	Key            string
-	KeyIndexEntry  string
-	Table          string
-	Region         string
-	Zone           string
-	Rack           string
-	ID             int64
+	Store         *store.Store
+	Key           string
+	KeyIndexEntry string
+	Table         string
+	Region        string
+	Zone          string
+	Rack          string
+	ID            int64
 
 	revisionInfo
 
-	details        *pb.PduDetails
-	ports          *map[int64]*pb.PowerPort
-	record         *pb.StoreRecordDefinitionPdu
+	details *pb.PduDetails
+	ports   *map[int64]*pb.PowerPort
+	record  *pb.Store_RecordDefinition_Pdu
 }
 
 // SetDetails is used to attach some attribute information to the object.
@@ -1618,8 +1680,8 @@ type Pdu struct {
 //
 // The current revision of the pdu object is reset
 //
-func (p *Pdu) SetDetails(ctx context.Context, details *pb.PduDetails) {
-	p.details  = details
+func (p *Pdu) SetDetails(_ context.Context, details *pb.PduDetails) {
+	p.details = details
 	p.resetRevision()
 }
 
@@ -1629,8 +1691,8 @@ func (p *Pdu) SetDetails(ctx context.Context, details *pb.PduDetails) {
 //
 // May return nil if there are no attributes currently held in the object.
 //
-func (p *Pdu) GetDetails(ctx context.Context) *pb.PduDetails {
-	return 	p.details
+func (p *Pdu) GetDetails(_ context.Context) *pb.PduDetails {
+	return p.details
 }
 
 // SetPorts is used to attach some power port information to the object.
@@ -1640,8 +1702,8 @@ func (p *Pdu) GetDetails(ctx context.Context) *pb.PduDetails {
 //
 // The current revision of the pdu object is reset
 //
-func (p *Pdu) SetPorts(ctx context.Context, ports *map[int64]*pb.PowerPort) {
-	p.ports    = ports
+func (p *Pdu) SetPorts(_ context.Context, ports *map[int64]*pb.PowerPort) {
+	p.ports = ports
 	p.resetRevision()
 }
 
@@ -1652,7 +1714,7 @@ func (p *Pdu) SetPorts(ctx context.Context, ports *map[int64]*pb.PowerPort) {
 // May return nil if there are no power port information currently held
 // in the object.
 //
-func (p *Pdu) GetPorts(ctx context.Context) *map[int64]*pb.PowerPort {
+func (p *Pdu) GetPorts(_ context.Context) *map[int64]*pb.PowerPort {
 	return p.ports
 }
 
@@ -1664,8 +1726,8 @@ func (p *Pdu) GetPorts(ctx context.Context) *map[int64]*pb.PowerPort {
 //
 // Once the store operation completes successfully, the revision fields
 // in the object will be updated to that returned by the store. These can
-// either be reetrieved by one of the GetRevisionXxx() call or used for
-// subsequent conditional operaions such as a conditional Update() call.
+// either be retrieved by one of the GetRevisionXxx() call or used for
+// subsequent conditional operations such as a conditional Update() call.
 //
 func (p *Pdu) Create(ctx context.Context) (int64, error) {
 
@@ -1677,7 +1739,7 @@ func (p *Pdu) Create(ctx context.Context) (int64, error) {
 		return store.RevisionInvalid, errors.ErrPortsNotAvailable("pdu")
 	}
 
-	record := &pb.StoreRecordDefinitionPdu{
+	record := &pb.Store_RecordDefinition_Pdu{
 		Details: p.details,
 		Ports:   *p.ports,
 	}
@@ -1691,8 +1753,8 @@ func (p *Pdu) Create(ctx context.Context) (int64, error) {
 	// Create the child and its index as an atomic pair.
 	//
 	keySet := &map[string]string{
-		p.KeyIndexEntry : fmt.Sprintf("%d", p.ID),
-		p.Key           : v,
+		p.KeyIndexEntry: fmt.Sprintf("%d", p.ID),
+		p.Key:           v,
 	}
 
 	rev, err := p.Store.CreateMultiple(ctx, store.KeyRootInventory, keySet)
@@ -1712,7 +1774,7 @@ func (p *Pdu) Create(ctx context.Context) (int64, error) {
 //
 // Once the Read() has completed successfully the details and other
 // information for the object can be retrieved by any of the GetXxx() methods
-// for that obect.
+// for that object.
 //
 func (p *Pdu) Read(ctx context.Context) (int64, error) {
 
@@ -1722,15 +1784,15 @@ func (p *Pdu) Read(ctx context.Context) (int64, error) {
 		return store.RevisionInvalid, err
 	}
 
-	record := &pb.StoreRecordDefinitionPdu{}
+	record := &pb.Store_RecordDefinition_Pdu{}
 
 	if err = store.Decode(*v, record); err != nil {
 		return store.RevisionInvalid, err
 	}
 
 	p.details = record.Details
-	p.ports   = &record.Ports
-	p.record  = record
+	p.ports = &record.Ports
+	p.record = record
 
 	return p.updateRevisionInfo(rev), nil
 }
@@ -1756,9 +1818,9 @@ func (p *Pdu) Update(ctx context.Context, unconditional bool) (int64, error) {
 		return store.RevisionInvalid, errors.ErrPortsNotAvailable("pdu")
 	}
 
-	record := &pb.StoreRecordDefinitionPdu{
+	record := &pb.Store_RecordDefinition_Pdu{
 		Details: p.details,
-		Ports: *p.ports,
+		Ports:   *p.ports,
 	}
 
 	v, err := store.Encode(record)
@@ -1800,8 +1862,8 @@ func (p *Pdu) Delete(ctx context.Context, unconditional bool) (int64, error) {
 	// Delete the record and its index as an atomic pair.
 	//
 	keySet := &map[string]int64{
-		p.KeyIndexEntry : store.RevisionInvalid,
-		p.Key           : p.GetRevisionForRequest(unconditional),
+		p.KeyIndexEntry: store.RevisionInvalid,
+		p.Key:           p.GetRevisionForRequest(unconditional),
 	}
 
 	rev, err := p.Store.DeleteMultiple(ctx, store.KeyRootInventory, keySet)
@@ -1816,7 +1878,7 @@ func (p *Pdu) Delete(ctx context.Context, unconditional bool) (int64, error) {
 }
 
 func (p *Pdu) mapErrStoreValue(err error) error {
-	switch (err) {
+	switch err {
 	case errors.ErrStoreKeyNotFound(p.Key):
 		return errors.ErrPduNotFound{Region: p.Region, Zone: p.Zone, Rack: p.Rack, Pdu: p.ID}
 
@@ -1826,7 +1888,7 @@ func (p *Pdu) mapErrStoreValue(err error) error {
 	case errors.ErrStoreAlreadyExists(p.KeyIndexEntry), errors.ErrStoreAlreadyExists(p.Key):
 		return errors.ErrPduAlreadyExists{Region: p.Region, Zone: p.Zone, Rack: p.Rack, Pdu: p.ID}
 	}
-	
+
 	return err
 }
 
@@ -1838,21 +1900,20 @@ func (p *Pdu) mapErrStoreValue(err error) error {
 // Tor is a specialization of a child object for a rack parent.
 //
 type Tor struct {
-
-	Store          *store.Store
-	Key            string
-	KeyIndexEntry  string
-	Table          string
-	Region         string
-	Zone           string
-	Rack           string
-	ID             int64
+	Store         *store.Store
+	Key           string
+	KeyIndexEntry string
+	Table         string
+	Region        string
+	Zone          string
+	Rack          string
+	ID            int64
 
 	revisionInfo
 
-	details        *pb.TorDetails
-	ports          *map[int64]*pb.NetworkPort
-	record         *pb.StoreRecordDefinitionTor
+	details *pb.TorDetails
+	ports   *map[int64]*pb.NetworkPort
+	record  *pb.Store_RecordDefinition_Tor
 }
 
 // SetDetails is used to attach some attribute information to the object.
@@ -1862,8 +1923,8 @@ type Tor struct {
 //
 // The current revision of the tor object is reset
 //
-func (t *Tor) SetDetails(ctx context.Context, details *pb.TorDetails) {
-	t.details  = details
+func (t *Tor) SetDetails(_ context.Context, details *pb.TorDetails) {
+	t.details = details
 	t.resetRevision()
 }
 
@@ -1873,8 +1934,8 @@ func (t *Tor) SetDetails(ctx context.Context, details *pb.TorDetails) {
 //
 // May return nil if there are no attributes currently held in the object.
 //
-func (t *Tor) GetDetails(ctx context.Context) *pb.TorDetails {
-	return 	t.details
+func (t *Tor) GetDetails(_ context.Context) *pb.TorDetails {
+	return t.details
 }
 
 // SetPorts is used to attach some network port information to the object.
@@ -1884,8 +1945,8 @@ func (t *Tor) GetDetails(ctx context.Context) *pb.TorDetails {
 //
 // The current revision of the tor object is reset
 //
-func (t *Tor) SetPorts(ctx context.Context, ports *map[int64]*pb.NetworkPort) {
-	t.ports    = ports
+func (t *Tor) SetPorts(_ context.Context, ports *map[int64]*pb.NetworkPort) {
+	t.ports = ports
 	t.resetRevision()
 }
 
@@ -1896,7 +1957,7 @@ func (t *Tor) SetPorts(ctx context.Context, ports *map[int64]*pb.NetworkPort) {
 // May return nil if there are no network port information currently held
 // in the object.
 //
-func (t *Tor) GetPorts(ctx context.Context) *map[int64]*pb.NetworkPort {
+func (t *Tor) GetPorts(_ context.Context) *map[int64]*pb.NetworkPort {
 	return t.ports
 }
 
@@ -1908,8 +1969,8 @@ func (t *Tor) GetPorts(ctx context.Context) *map[int64]*pb.NetworkPort {
 //
 // Once the store operation completes successfully, the revision fields
 // in the object will be updated to that returned by the store. These can
-// either be reetrieved by one of the GetRevisionXxx() call or used for
-// subsequent conditional operaions such as a conditional Update() call.
+// either be retrieved by one of the GetRevisionXxx() call or used for
+// subsequent conditional operations such as a conditional Update() call.
 //
 func (t *Tor) Create(ctx context.Context) (int64, error) {
 
@@ -1921,7 +1982,7 @@ func (t *Tor) Create(ctx context.Context) (int64, error) {
 		return store.RevisionInvalid, errors.ErrPortsNotAvailable("tor")
 	}
 
-	record := &pb.StoreRecordDefinitionTor{
+	record := &pb.Store_RecordDefinition_Tor{
 		Details: t.details,
 		Ports:   *t.ports,
 	}
@@ -1935,8 +1996,8 @@ func (t *Tor) Create(ctx context.Context) (int64, error) {
 	// Create the child and its index as an atomic pair.
 	//
 	keySet := &map[string]string{
-		t.KeyIndexEntry : fmt.Sprintf("%d", t.ID),
-		t.Key           : v,
+		t.KeyIndexEntry: fmt.Sprintf("%d", t.ID),
+		t.Key:           v,
 	}
 
 	rev, err := t.Store.CreateMultiple(ctx, store.KeyRootInventory, keySet)
@@ -1956,7 +2017,7 @@ func (t *Tor) Create(ctx context.Context) (int64, error) {
 //
 // Once the Read() has completed successfully the details and other
 // information for the object can be retrieved by any of the GetXxx() methods
-// for that obect.
+// for that object.
 //
 func (t *Tor) Read(ctx context.Context) (int64, error) {
 
@@ -1966,15 +2027,15 @@ func (t *Tor) Read(ctx context.Context) (int64, error) {
 		return store.RevisionInvalid, err
 	}
 
-	record := &pb.StoreRecordDefinitionTor{}
+	record := &pb.Store_RecordDefinition_Tor{}
 
 	if err = store.Decode(*v, record); err != nil {
 		return store.RevisionInvalid, err
 	}
 
 	t.details = record.Details
-	t.ports   = &record.Ports
-	t.record  = record
+	t.ports = &record.Ports
+	t.record = record
 
 	return t.updateRevisionInfo(rev), nil
 }
@@ -2000,9 +2061,9 @@ func (t *Tor) Update(ctx context.Context, unconditional bool) (int64, error) {
 		return store.RevisionInvalid, errors.ErrPortsNotAvailable("tor")
 	}
 
-	record := &pb.StoreRecordDefinitionTor{
+	record := &pb.Store_RecordDefinition_Tor{
 		Details: t.details,
-		Ports: *t.ports,
+		Ports:   *t.ports,
 	}
 
 	v, err := store.Encode(record)
@@ -2044,8 +2105,8 @@ func (t *Tor) Delete(ctx context.Context, unconditional bool) (int64, error) {
 	// Delete the record and its index as an atomic pair.
 	//
 	keySet := &map[string]int64{
-		t.KeyIndexEntry : store.RevisionInvalid,
-		t.Key           : t.GetRevisionForRequest(unconditional),
+		t.KeyIndexEntry: store.RevisionInvalid,
+		t.Key:           t.GetRevisionForRequest(unconditional),
 	}
 
 	rev, err := t.Store.DeleteMultiple(ctx, store.KeyRootInventory, keySet)
@@ -2060,7 +2121,7 @@ func (t *Tor) Delete(ctx context.Context, unconditional bool) (int64, error) {
 }
 
 func (t *Tor) mapErrStoreValue(err error) error {
-	switch (err) {
+	switch err {
 	case errors.ErrStoreKeyNotFound(t.Key):
 		return errors.ErrTorNotFound{Region: t.Region, Zone: t.Zone, Rack: t.Rack, Tor: t.ID}
 
@@ -2070,7 +2131,7 @@ func (t *Tor) mapErrStoreValue(err error) error {
 	case errors.ErrStoreAlreadyExists(t.KeyIndexEntry), errors.ErrStoreAlreadyExists(t.Key):
 		return errors.ErrTorAlreadyExists{Region: t.Region, Zone: t.Zone, Rack: t.Rack, Tor: t.ID}
 	}
-	
+
 	return err
 }
 
@@ -2082,23 +2143,22 @@ func (t *Tor) mapErrStoreValue(err error) error {
 // Blade is a specialization of a child object for a rack parent.
 //
 type Blade struct {
-
-	Store          *store.Store
-	Key            string
-	KeyIndexEntry  string
-	Table          string
-	Region         string
-	Zone           string
-	Rack           string
-	ID             int64
+	Store         *store.Store
+	Key           string
+	KeyIndexEntry string
+	Table         string
+	Region        string
+	Zone          string
+	Rack          string
+	ID            int64
 
 	revisionInfo
 
-	details        *pb.BladeDetails
-	capacity       *pb.BladeCapacity
-	bootInfo       *pb.BladeBootInfo
-	bootOnPowerOn  bool
-	record         *pb.StoreRecordDefinitionBlade
+	details       *pb.BladeDetails
+	capacity      *pb.BladeCapacity
+	bootInfo      *pb.BladeBootInfo
+	bootOnPowerOn bool
+	record        *pb.Store_RecordDefinition_Blade
 }
 
 // SetDetails is used to attach some attribute information to the object.
@@ -2108,8 +2168,8 @@ type Blade struct {
 //
 // The current revision of the blade object is reset
 //
-func (b *Blade) SetDetails(ctx context.Context, details *pb.BladeDetails) {
-	b.details  = details
+func (b *Blade) SetDetails(_ context.Context, details *pb.BladeDetails) {
+	b.details = details
 	b.resetRevision()
 }
 
@@ -2119,8 +2179,8 @@ func (b *Blade) SetDetails(ctx context.Context, details *pb.BladeDetails) {
 //
 // May return nil if there are no attributes currently held in the object.
 //
-func (b *Blade) GetDetails(ctx context.Context) *pb.BladeDetails {
-	return 	b.details
+func (b *Blade) GetDetails(_ context.Context) *pb.BladeDetails {
+	return b.details
 }
 
 // SetCapacity is used to attach some capacity information to the object.
@@ -2130,7 +2190,7 @@ func (b *Blade) GetDetails(ctx context.Context) *pb.BladeDetails {
 //
 // The current revision of the blade object is reset
 //
-func (b *Blade) SetCapacity(ctx context.Context, capacity *pb.BladeCapacity) {
+func (b *Blade) SetCapacity(_ context.Context, capacity *pb.BladeCapacity) {
 	b.capacity = capacity
 	b.resetRevision()
 }
@@ -2142,9 +2202,9 @@ func (b *Blade) SetCapacity(ctx context.Context, capacity *pb.BladeCapacity) {
 //
 // The current revision of the blade object is reset
 //
-func (b *Blade) SetBootInfo(ctx context.Context, bootOnPowerOn bool, bootInfo *pb.BladeBootInfo) {
+func (b *Blade) SetBootInfo(_ context.Context, bootOnPowerOn bool, bootInfo *pb.BladeBootInfo) {
 	b.bootOnPowerOn = bootOnPowerOn
-	b.bootInfo      = bootInfo
+	b.bootInfo = bootInfo
 	b.resetRevision()
 }
 
@@ -2155,7 +2215,7 @@ func (b *Blade) SetBootInfo(ctx context.Context, bootOnPowerOn bool, bootInfo *p
 // May return nil if there are no capacity information currently held
 // in the object.
 //
-func (b *Blade) GetCapacity(ctx context.Context) *pb.BladeCapacity {
+func (b *Blade) GetCapacity(_ context.Context) *pb.BladeCapacity {
 	return b.capacity
 }
 
@@ -2166,7 +2226,7 @@ func (b *Blade) GetCapacity(ctx context.Context) *pb.BladeCapacity {
 // May return nil if there are no boot information currently held
 // in the object.
 //
-func (b *Blade) GetBootInfo(ctx context.Context) (bool, *pb.BladeBootInfo) {
+func (b *Blade) GetBootInfo(_ context.Context) (bool, *pb.BladeBootInfo) {
 	return b.bootOnPowerOn, b.bootInfo
 }
 
@@ -2178,10 +2238,10 @@ func (b *Blade) GetBootInfo(ctx context.Context) (bool, *pb.BladeBootInfo) {
 //
 // Once the store operation completes successfully, the revision fields
 // in the object will be updated to that returned by the store. These can
-// either be reetrieved by one of the GetRevisionXxx() call or used for
-// subsequent conditional operaions such as a conditional Update() call.
+// either be retrieved by one of the GetRevisionXxx() call or used for
+// subsequent conditional operations such as a conditional Update() call.
 //
-func (b *Blade) Create(ctx context.Context)  (int64, error)  {
+func (b *Blade) Create(ctx context.Context) (int64, error) {
 
 	if b.details == nil {
 		return store.RevisionInvalid, errors.ErrDetailsNotAvailable("blade")
@@ -2195,7 +2255,7 @@ func (b *Blade) Create(ctx context.Context)  (int64, error)  {
 		return store.RevisionInvalid, errors.ErrBootInfoNotAvailable("blade")
 	}
 
-	record := &pb.StoreRecordDefinitionBlade{
+	record := &pb.Store_RecordDefinition_Blade{
 		Details:       b.details,
 		Capacity:      b.capacity,
 		BootOnPowerOn: b.bootOnPowerOn,
@@ -2211,8 +2271,8 @@ func (b *Blade) Create(ctx context.Context)  (int64, error)  {
 	// Create the child and its index as an atomic pair.
 	//
 	keySet := &map[string]string{
-		b.KeyIndexEntry : fmt.Sprintf("%d", b.ID),
-		b.Key           : v,
+		b.KeyIndexEntry: fmt.Sprintf("%d", b.ID),
+		b.Key:           v,
 	}
 
 	rev, err := b.Store.CreateMultiple(ctx, store.KeyRootInventory, keySet)
@@ -2232,7 +2292,7 @@ func (b *Blade) Create(ctx context.Context)  (int64, error)  {
 //
 // Once the Read() has completed successfully the details and other
 // information for the object can be retrieved by any of the GetXxx() methods
-// for that obect.
+// for that object.
 //
 func (b *Blade) Read(ctx context.Context) (int64, error) {
 
@@ -2242,17 +2302,17 @@ func (b *Blade) Read(ctx context.Context) (int64, error) {
 		return store.RevisionInvalid, err
 	}
 
-	record := &pb.StoreRecordDefinitionBlade{}
+	record := &pb.Store_RecordDefinition_Blade{}
 
 	if err = store.Decode(*v, record); err != nil {
 		return store.RevisionInvalid, err
 	}
 
-	b.details       = record.Details
-	b.capacity      = record.Capacity
-	b.bootInfo      = record.BootInfo
+	b.details = record.Details
+	b.capacity = record.Capacity
+	b.bootInfo = record.BootInfo
 	b.bootOnPowerOn = record.BootOnPowerOn
-	b.record        = record
+	b.record = record
 
 	return b.updateRevisionInfo(rev), nil
 }
@@ -2282,7 +2342,7 @@ func (b *Blade) Update(ctx context.Context, unconditional bool) (int64, error) {
 		return store.RevisionInvalid, errors.ErrBootInfoNotAvailable("blade")
 	}
 
-	record := &pb.StoreRecordDefinitionBlade{
+	record := &pb.Store_RecordDefinition_Blade{
 		Details:       b.details,
 		Capacity:      b.capacity,
 		BootInfo:      b.bootInfo,
@@ -2328,8 +2388,8 @@ func (b *Blade) Delete(ctx context.Context, unconditional bool) (int64, error) {
 	// Delete the record and its index as an atomic pair.
 	//
 	keySet := &map[string]int64{
-		b.KeyIndexEntry : store.RevisionInvalid,
-		b.Key           : b.GetRevisionForRequest(unconditional),
+		b.KeyIndexEntry: store.RevisionInvalid,
+		b.Key:           b.GetRevisionForRequest(unconditional),
 	}
 
 	rev, err := b.Store.DeleteMultiple(ctx, store.KeyRootInventory, keySet)
@@ -2344,7 +2404,7 @@ func (b *Blade) Delete(ctx context.Context, unconditional bool) (int64, error) {
 }
 
 func (b *Blade) mapErrStoreValue(err error) error {
-	switch (err) {
+	switch err {
 	case errors.ErrStoreKeyNotFound(b.Key):
 		return errors.ErrBladeNotFound{Region: b.Region, Zone: b.Zone, Rack: b.Rack, Blade: b.ID}
 
@@ -2354,6 +2414,6 @@ func (b *Blade) mapErrStoreValue(err error) error {
 	case errors.ErrStoreAlreadyExists(b.KeyIndexEntry), errors.ErrStoreAlreadyExists(b.Key):
 		return errors.ErrBladeAlreadyExists{Region: b.Region, Zone: b.Zone, Rack: b.Rack, Blade: b.ID}
 	}
-	
+
 	return err
 }

--- a/internal/services/frontend/DBInventory_test.go
+++ b/internal/services/frontend/DBInventory_test.go
@@ -11,7 +11,6 @@ import (
 	pb "github.com/Jim3Things/CloudChamber/pkg/protos/inventory"
 )
 
-
 type DBInventoryTestSuite struct {
 	testSuiteCore
 
@@ -25,24 +24,24 @@ type DBInventoryTestSuite struct {
 }
 
 func (ts *DBInventoryTestSuite) SetupSuite() {
-//	require := ts.Require()
+	//	require := ts.Require()
 
 	ts.testSuiteCore.SetupSuite()
 
-//	configPath := flag.String("config", "./testdata", "path to the configuration file")
-//	flag.Parse()
+	//	configPath := flag.String("config", "./testdata", "path to the configuration file")
+	//	flag.Parse()
 
-//	cfg, err := config.ReadGlobalConfig(*configPath)
-//	require.NoError(err)
-//	require.NotNil(cfg)
+	//	cfg, err := config.ReadGlobalConfig(*configPath)
+	//	require.NoError(err)
+	//	require.NotNil(cfg)
 
-//	ts.cfg = cfg
+	//	ts.cfg = cfg
 
 	ts.zoneName = "zoneBasic"
 	ts.rackName = "rackBasic"
-	ts.pduID    = int64(17)
-	ts.torID    = int64(31)
-	ts.bladeID  = int64(100)
+	ts.pduID = int64(17)
+	ts.torID = int64(31)
+	ts.bladeID = int64(100)
 }
 
 func (ts *DBInventoryTestSuite) SetupTest() {
@@ -50,12 +49,12 @@ func (ts *DBInventoryTestSuite) SetupTest() {
 
 	_ = ts.utf.Open(ts.T())
 
-	ts.db =  &DBInventory{
-		mutex: sync.RWMutex{},
-		Zone: nil,
+	ts.db = &DBInventory{
+		mutex:         sync.RWMutex{},
+		Zone:          nil,
 		MaxBladeCount: 0,
 		MaxCapacity:   &pb.BladeCapacity{},
-		Store: store.NewStore(),
+		Store:         store.NewStore(),
 	}
 
 	err := ts.db.Store.Connect()
@@ -66,8 +65,6 @@ func (ts *DBInventoryTestSuite) TearDownTest() {
 	ts.utf.Close()
 }
 
-
-
 func (ts *DBInventoryTestSuite) ensureInventoryLoaded() {
 	// require := ts.Require()
 
@@ -75,13 +72,13 @@ func (ts *DBInventoryTestSuite) ensureInventoryLoaded() {
 
 	// if ts.db == nil {
 
-		// err := db.Initialize(ctx, ts.cfg)
-		// require.NoError(err)
-		// require.NotNil(dbInventory)
+	// err := db.Initialize(ctx, ts.cfg)
+	// require.NoError(err)
+	// require.NotNil(dbInventory)
 
-		// if ts.db == nil {
-		// 	ts.db = db
-		// }
+	// if ts.db == nil {
+	// 	ts.db = db
+	// }
 	// }
 }
 
@@ -93,12 +90,12 @@ func (ts *DBInventoryTestSuite) ensureBasicZone() {
 	_, err := ts.db.CreateZone(
 		ctx,
 		ts.zoneName,
-		&pb.DefinitionZone{
+		&pb.Definition_Zone{
 			Details: &pb.ZoneDetails{
-				Enabled:   true,
-				State:     pb.State_in_service,
-				Location:  "Pacific NW",
-				Notes:     "Basic Zone for test",
+				Enabled:  true,
+				State:    pb.State_in_service,
+				Location: "Pacific NW",
+				Notes:    "Basic Zone for test",
 			},
 		},
 	)
@@ -109,50 +106,50 @@ func (ts *DBInventoryTestSuite) ensureBasicZone() {
 		ctx,
 		ts.zoneName,
 		ts.rackName,
-		&pb.DefinitionRack{
+		&pb.Definition_Rack{
 			Details: &pb.RackDetails{
 				Enabled:   true,
-				Condition:     pb.Condition_operational,
+				Condition: pb.Condition_operational,
 				Location:  "In " + ts.zoneName,
 				Notes:     "Basic rack for test",
-				},
 			},
-		)
+		},
+	)
 
 	require.NoError(err)
 
-	pdu := pb.DefinitionPdu{
+	pdu := pb.Definition_Pdu{
 		Details: &pb.PduDetails{
-			Enabled: true,
+			Enabled:   true,
 			Condition: pb.Condition_operational,
 		},
 		Ports: make(map[int64]*pb.PowerPort),
 	}
 
-	tor := pb.DefinitionTor{
+	tor := pb.Definition_Tor{
 		Details: &pb.TorDetails{
-			Enabled: true,
+			Enabled:   true,
 			Condition: pb.Condition_operational,
 		},
 		Ports: make(map[int64]*pb.NetworkPort),
 	}
 
-	blade := pb.DefinitionBlade{
+	blade := pb.Definition_Blade{
 		Details: &pb.BladeDetails{
-			Enabled: true,
+			Enabled:   true,
 			Condition: pb.Condition_operational,
 		},
 		Capacity: &pb.BladeCapacity{
-			Cores: 8,
+			Cores:      8,
 			MemoryInMb: 8192,
-			DiskInGb: 8192,
+			DiskInGb:   8192,
 		},
 	}
 
 	_, err = ts.db.CreatePdu(ctx, ts.zoneName, ts.rackName, ts.pduID, &pdu)
 	require.NoError(err)
 
-	_, err = ts.db.CreateTor(ctx, ts.zoneName, ts.rackName, ts.torID, &tor,)
+	_, err = ts.db.CreateTor(ctx, ts.zoneName, ts.rackName, ts.torID, &tor)
 	require.NoError(err)
 
 	_, err = ts.db.CreateBlade(ctx, ts.zoneName, ts.rackName, ts.bladeID, &blade)
@@ -162,12 +159,12 @@ func (ts *DBInventoryTestSuite) ensureBasicZone() {
 func (ts *DBInventoryTestSuite) TestInitializeInventory() {
 	assert := ts.Assert()
 
-	db :=  &DBInventory{
-		mutex: sync.RWMutex{},
-		Zone: nil,
+	db := &DBInventory{
+		mutex:         sync.RWMutex{},
+		Zone:          nil,
 		MaxBladeCount: 0,
 		MaxCapacity:   &pb.BladeCapacity{},
-		Store: store.NewStore(),
+		Store:         store.NewStore(),
 	}
 
 	assert.NotNil(db.Store)
@@ -185,12 +182,12 @@ func (ts *DBInventoryTestSuite) TestCreateZone() {
 
 	zoneName := "zone1"
 
-	zone := &pb.DefinitionZone{
+	zone := &pb.Definition_Zone{
 		Details: &pb.ZoneDetails{
-			Enabled: true,
-			State: pb.State_in_service,
+			Enabled:  true,
+			State:    pb.State_in_service,
 			Location: "Nowhere in particular",
-			Notes: "empty notes",
+			Notes:    "empty notes",
 		},
 	}
 
@@ -203,12 +200,12 @@ func (ts *DBInventoryTestSuite) TestCreateZone() {
 	assert.Equal(revCreate, revRead)
 	require.NotNil(z)
 
-	assert.Equal(zone.Details.Enabled,  z.Details.Enabled)
-	assert.Equal(zone.Details.State,    z.Details.State)
+	assert.Equal(zone.Details.Enabled, z.Details.Enabled)
+	assert.Equal(zone.Details.State, z.Details.State)
 	assert.Equal(zone.Details.Location, z.Details.Location)
-	assert.Equal(zone.Details.Notes,    z.Details.Notes)
-	}
-	
+	assert.Equal(zone.Details.Notes, z.Details.Notes)
+}
+
 func (ts *DBInventoryTestSuite) TestCreateRack() {
 	assert := ts.Assert()
 	require := ts.Require()
@@ -217,7 +214,7 @@ func (ts *DBInventoryTestSuite) TestCreateRack() {
 
 	rackName := "rack1"
 
-	rack := &pb.DefinitionRack{
+	rack := &pb.Definition_Rack{
 		Details: &pb.RackDetails{
 			Enabled:   true,
 			Condition: pb.Condition_operational,
@@ -234,10 +231,10 @@ func (ts *DBInventoryTestSuite) TestCreateRack() {
 	assert.Equal(revCreate, revRead)
 	require.NotNil(r)
 
-	assert.Equal(rack.Details.Enabled,   r.Details.Enabled)
+	assert.Equal(rack.Details.Enabled, r.Details.Enabled)
 	assert.Equal(rack.Details.Condition, r.Details.Condition)
-	assert.Equal(rack.Details.Location,  r.Details.Location)
-	assert.Equal(rack.Details.Notes,     r.Details.Notes)
+	assert.Equal(rack.Details.Location, r.Details.Location)
+	assert.Equal(rack.Details.Notes, r.Details.Notes)
 }
 
 func (ts *DBInventoryTestSuite) TestCreatePdu() {
@@ -248,7 +245,7 @@ func (ts *DBInventoryTestSuite) TestCreatePdu() {
 
 	pduID := int64(1)
 
-	pdu := &pb.DefinitionPdu{
+	pdu := &pb.Definition_Pdu{
 		Details: &pb.PduDetails{
 			Enabled:   true,
 			Condition: pb.Condition_operational,
@@ -262,65 +259,64 @@ func (ts *DBInventoryTestSuite) TestCreatePdu() {
 
 	pdu.Ports[1] = &pb.PowerPort{
 		Wired: true,
-		Item:  &pb.Hardware{
+		Item: &pb.Hardware{
 			Type: pb.Hardware_unknown,
 		},
 	}
 
 	pdu.Ports[2] = &pb.PowerPort{
 		Wired: true,
-		Item:  &pb.Hardware{
+		Item: &pb.Hardware{
 			Type: pb.Hardware_tor,
-			Id: 0,
+			Id:   0,
 			Port: 0,
 		},
 	}
 
 	pdu.Ports[3] = &pb.PowerPort{
 		Wired: true,
-		Item:  &pb.Hardware{
+		Item: &pb.Hardware{
 			Type: pb.Hardware_tor,
-			Id: 1,
+			Id:   1,
 			Port: 0,
 		},
 	}
 
 	pdu.Ports[4] = &pb.PowerPort{
 		Wired: true,
-		Item:  &pb.Hardware{
+		Item: &pb.Hardware{
 			Type: pb.Hardware_blade,
-			Id: 0,
+			Id:   0,
 			Port: 0,
 		},
 	}
 
 	pdu.Ports[5] = &pb.PowerPort{
 		Wired: true,
-		Item:  &pb.Hardware{
+		Item: &pb.Hardware{
 			Type: pb.Hardware_blade,
-			Id: 0,
+			Id:   0,
 			Port: 1,
 		},
 	}
 
 	pdu.Ports[6] = &pb.PowerPort{
 		Wired: true,
-		Item:  &pb.Hardware{
+		Item: &pb.Hardware{
 			Type: pb.Hardware_blade,
-			Id: 1,
+			Id:   1,
 			Port: 0,
 		},
 	}
 
 	pdu.Ports[7] = &pb.PowerPort{
 		Wired: true,
-		Item:  &pb.Hardware{
+		Item: &pb.Hardware{
 			Type: pb.Hardware_blade,
-			Id: 1,
+			Id:   1,
 			Port: 1,
 		},
 	}
-
 
 	revCreate, err := ts.db.CreatePdu(ctx, ts.zoneName, ts.rackName, pduID, pdu)
 	require.NoError(err)
@@ -330,7 +326,7 @@ func (ts *DBInventoryTestSuite) TestCreatePdu() {
 	assert.Equal(revCreate, revRead)
 	require.NotNil(t)
 
-	assert.Equal(pdu.Details.Enabled,   t.Details.Enabled)
+	assert.Equal(pdu.Details.Enabled, t.Details.Enabled)
 	assert.Equal(pdu.Details.Condition, t.Details.Condition)
 	assert.Equal(len(pdu.Ports), len(t.Ports))
 
@@ -345,7 +341,7 @@ func (ts *DBInventoryTestSuite) TestCreatePdu() {
 			require.NotNil(tp.Item)
 
 			assert.Equal(p.Item.Type, tp.Item.Type)
-			assert.Equal(p.Item.Id,   tp.Item.Id)
+			assert.Equal(p.Item.Id, tp.Item.Id)
 			assert.Equal(p.Item.Port, tp.Item.Port)
 		}
 	}
@@ -359,13 +355,13 @@ func (ts *DBInventoryTestSuite) TestCreateTor() {
 
 	torID := int64(1)
 
-	tor := &pb.DefinitionTor{
+	tor := &pb.Definition_Tor{
 		Details: &pb.TorDetails{
 			Enabled:   true,
 			Condition: pb.Condition_operational,
 		},
 		Ports: make(map[int64]*pb.NetworkPort),
-		}
+	}
 
 	tor.Ports[0] = &pb.NetworkPort{
 		Wired: false,
@@ -373,61 +369,61 @@ func (ts *DBInventoryTestSuite) TestCreateTor() {
 
 	tor.Ports[1] = &pb.NetworkPort{
 		Wired: true,
-		Item:  &pb.Hardware{
-			Type: pb.Hardware_unknown,			
+		Item: &pb.Hardware{
+			Type: pb.Hardware_unknown,
 		},
 	}
 
 	tor.Ports[2] = &pb.NetworkPort{
 		Wired: true,
-		Item:  &pb.Hardware{
+		Item: &pb.Hardware{
 			Type: pb.Hardware_pdu,
-			Id: 0,
+			Id:   0,
 			Port: 0,
 		},
 	}
 
 	tor.Ports[3] = &pb.NetworkPort{
 		Wired: true,
-		Item:  &pb.Hardware{
+		Item: &pb.Hardware{
 			Type: pb.Hardware_pdu,
-			Id: 1,
+			Id:   1,
 			Port: 0,
 		},
 	}
 
 	tor.Ports[4] = &pb.NetworkPort{
 		Wired: true,
-		Item:  &pb.Hardware{
+		Item: &pb.Hardware{
 			Type: pb.Hardware_blade,
-			Id: 0,
+			Id:   0,
 			Port: 0,
 		},
 	}
 
 	tor.Ports[5] = &pb.NetworkPort{
 		Wired: true,
-		Item:  &pb.Hardware{
+		Item: &pb.Hardware{
 			Type: pb.Hardware_blade,
-			Id: 0,
+			Id:   0,
 			Port: 1,
 		},
 	}
 
 	tor.Ports[6] = &pb.NetworkPort{
 		Wired: true,
-		Item:  &pb.Hardware{
+		Item: &pb.Hardware{
 			Type: pb.Hardware_blade,
-			Id: 1,
+			Id:   1,
 			Port: 0,
 		},
 	}
 
 	tor.Ports[7] = &pb.NetworkPort{
 		Wired: true,
-		Item:  &pb.Hardware{
+		Item: &pb.Hardware{
 			Type: pb.Hardware_blade,
-			Id: 1,
+			Id:   1,
 			Port: 1,
 		},
 	}
@@ -440,7 +436,7 @@ func (ts *DBInventoryTestSuite) TestCreateTor() {
 	assert.Equal(revCreate, revRead)
 	require.NotNil(t)
 
-	assert.Equal(tor.Details.Enabled,   t.Details.Enabled)
+	assert.Equal(tor.Details.Enabled, t.Details.Enabled)
 	assert.Equal(tor.Details.Condition, t.Details.Condition)
 	assert.Equal(len(tor.Ports), len(t.Ports))
 
@@ -455,7 +451,7 @@ func (ts *DBInventoryTestSuite) TestCreateTor() {
 			require.NotNil(tp.Item)
 
 			assert.Equal(p.Item.Type, tp.Item.Type)
-			assert.Equal(p.Item.Id,   tp.Item.Id)
+			assert.Equal(p.Item.Id, tp.Item.Id)
 			assert.Equal(p.Item.Port, tp.Item.Port)
 		}
 	}
@@ -469,25 +465,25 @@ func (ts *DBInventoryTestSuite) TestCreateBlade() {
 
 	bladeID := int64(1)
 
-	blade := &pb.DefinitionBlade{
+	blade := &pb.Definition_Blade{
 		Details: &pb.BladeDetails{
-			Enabled: true,
+			Enabled:   true,
 			Condition: pb.Condition_operational,
 		},
 		Capacity: &pb.BladeCapacity{
-			Cores: 8,
-			MemoryInMb: 8192,
-			DiskInGb: 8192,
+			Cores:                  8,
+			MemoryInMb:             8192,
+			DiskInGb:               8192,
 			NetworkBandwidthInMbps: 1024,
-			Arch: "vax",
-			Accelerators: nil,
+			Arch:                   "vax",
+			Accelerators:           nil,
 		},
 		BootOnPowerOn: true,
 		BootInfo: &pb.BladeBootInfo{
 			Source:     pb.BladeBootInfo_local,
 			Image:      "test-image.vhdx",
 			Version:    "20201225-0000",
-			Parameters: "-param1=val1 -param2=val2",	
+			Parameters: "-param1=val1 -param2=val2",
 		},
 	}
 
@@ -499,22 +495,22 @@ func (ts *DBInventoryTestSuite) TestCreateBlade() {
 	assert.Equal(revCreate, revRead)
 	require.NotNil(b)
 
-	assert.Equal(blade.Details.Enabled,   b.Details.Enabled)
+	assert.Equal(blade.Details.Enabled, b.Details.Enabled)
 	assert.Equal(blade.Details.Condition, b.Details.Condition)
-	
-	assert.Equal(blade.Capacity.Cores,                  b.Capacity.Cores)
-	assert.Equal(blade.Capacity.MemoryInMb,             b.Capacity.MemoryInMb)
-	assert.Equal(blade.Capacity.DiskInGb,               b.Capacity.DiskInGb)
+
+	assert.Equal(blade.Capacity.Cores, b.Capacity.Cores)
+	assert.Equal(blade.Capacity.MemoryInMb, b.Capacity.MemoryInMb)
+	assert.Equal(blade.Capacity.DiskInGb, b.Capacity.DiskInGb)
 	assert.Equal(blade.Capacity.NetworkBandwidthInMbps, b.Capacity.NetworkBandwidthInMbps)
-	assert.Equal(blade.Capacity.Arch,                   b.Capacity.Arch)
-	assert.Equal(blade.Capacity.Accelerators,           b.Capacity.Accelerators)
+	assert.Equal(blade.Capacity.Arch, b.Capacity.Arch)
+	assert.Equal(blade.Capacity.Accelerators, b.Capacity.Accelerators)
 
-	assert.Equal(blade.BootOnPowerOn,                   b.BootOnPowerOn)
+	assert.Equal(blade.BootOnPowerOn, b.BootOnPowerOn)
 
-	assert.Equal(blade.BootInfo.Source,                 b.BootInfo.Source)
-	assert.Equal(blade.BootInfo.Image,                  b.BootInfo.Image)
-	assert.Equal(blade.BootInfo.Version,                b.BootInfo.Version)
-	assert.Equal(blade.BootInfo.Parameters,             b.BootInfo.Parameters)
+	assert.Equal(blade.BootInfo.Source, b.BootInfo.Source)
+	assert.Equal(blade.BootInfo.Image, b.BootInfo.Image)
+	assert.Equal(blade.BootInfo.Version, b.BootInfo.Version)
+	assert.Equal(blade.BootInfo.Parameters, b.BootInfo.Parameters)
 }
 
 func TestDBInventoryTestSuite(t *testing.T) {

--- a/internal/services/frontend/inventory.go
+++ b/internal/services/frontend/inventory.go
@@ -66,8 +66,8 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	rackCount, maxBlades, maxCapacity := dbInventory.GetMemoData()
-	res := &pb.ExternalZoneSummary{
-		Racks:         make(map[string]*pb.ExternalRackSummary, rackCount),
+	res := &pb.External_ZoneSummary{
+		Racks:         make(map[string]*pb.External_RackSummary, rackCount),
 		MaxBladeCount: maxBlades,
 		MaxCapacity:   maxCapacity,
 	}
@@ -84,7 +84,7 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 	err = dbInventory.ScanRacks(func(name string) error {
 		target := fmt.Sprintf("%s%s/", b, name)
 
-		res.Racks[name] = &pb.ExternalRackSummary{Uri: target}
+		res.Racks[name] = &pb.External_RackSummary{Uri: target}
 
 		tracing.Info(ctx, "   Listing rack %q at %q", name, target)
 

--- a/internal/services/frontend/inventory_test.go
+++ b/internal/services/frontend/inventory_test.go
@@ -20,9 +20,9 @@ type InventoryTestSuite struct {
 	testSuiteCore
 }
 
-func (ts *InventoryTestSuite) racksPath() string { return ts.baseURI + "/api/racks/" }
-func (ts *InventoryTestSuite) rackInPath(rack string) string { return ts.racksPath() + rack + "/"}
-func (ts *InventoryTestSuite) bladesInPath(rack string) string { return ts.rackInPath(rack) + "blades/"}
+func (ts *InventoryTestSuite) racksPath() string               { return ts.baseURI + "/api/racks/" }
+func (ts *InventoryTestSuite) rackInPath(rack string) string   { return ts.racksPath() + rack + "/" }
+func (ts *InventoryTestSuite) bladesInPath(rack string) string { return ts.rackInPath(rack) + "blades/" }
 func (ts *InventoryTestSuite) bladeInPath(rack string, bladeID int) string {
 	return fmt.Sprintf("%s%d", ts.bladesInPath(rack), bladeID)
 }
@@ -38,7 +38,7 @@ func (ts *InventoryTestSuite) TestListRacks() {
 	assert.Equal(http.StatusOK, response.StatusCode, "Handler returned unexpected error: %v", response.StatusCode)
 	assert.Equal("application/json", strings.ToLower(response.Header.Get("Content-Type")))
 
-	list := &pb.ExternalZoneSummary{}
+	list := &pb.External_ZoneSummary{}
 	err := ts.getJSONBody(response, list)
 	assert.Nilf(err, "Failed to convert racks list to valid json.  err: %v", err)
 
@@ -73,7 +73,7 @@ func (ts *InventoryTestSuite) TestRackRead() {
 
 	assert.Equal(http.StatusOK, response.StatusCode, "Handler returned unexpected error: %v", response.StatusCode)
 
-	rack := &pb.ExternalRack{}
+	rack := &pb.External_Rack{}
 	err := ts.getJSONBody(response, rack)
 	assert.NoError(err, "Failed to convert body to valid json.  err: %v", err)
 
@@ -183,7 +183,7 @@ func (ts *InventoryTestSuite) TestStringBlade() {
 
 	response := ts.doLogin(ts.randomCase(ts.adminAccountName()), ts.adminPassword(), nil)
 
-	request := httptest.NewRequest("GET", ts.bladesInPath("rack1") + "Jeff", nil)
+	request := httptest.NewRequest("GET", ts.bladesInPath("rack1")+"Jeff", nil)
 	request.Header.Set("Content-Type", "application/json")
 	response = ts.doHTTP(request, response.Cookies())
 

--- a/internal/services/inventory/pdu.go
+++ b/internal/services/inventory/pdu.go
@@ -41,7 +41,7 @@ const (
 // containing Rack.  Note that it currently does not fill in the cable
 // information, as that is missing from the inventory definition.  That is
 // done is the fixConnection function below.
-func newPdu(_ *pb.ExternalPdu, r *Rack) *pdu {
+func newPdu(_ *pb.External_Pdu, r *Rack) *pdu {
 	p := &pdu{
 		cables: make(map[int64]*cable),
 		holder: r,

--- a/internal/services/inventory/rack.go
+++ b/internal/services/inventory/rack.go
@@ -52,7 +52,7 @@ const (
 // entries to determine its structure.  The resulting Rack is healthy, not yet
 // started, all blades are powered off, and all network connections are not yet
 // programmed.
-func newRack(ctx context.Context, name string, def *pb.ExternalRack, timers *timestamp.Timers) *Rack {
+func newRack(ctx context.Context, name string, def *pb.External_Rack, timers *timestamp.Timers) *Rack {
 	return newRackInternal(ctx, name, def, timers, newPdu, newTor)
 }
 
@@ -62,10 +62,10 @@ func newRack(ctx context.Context, name string, def *pb.ExternalRack, timers *tim
 func newRackInternal(
 	ctx context.Context,
 	name string,
-	def *pb.ExternalRack,
+	def *pb.External_Rack,
 	timers *timestamp.Timers,
-	pduFunc func(*pb.ExternalPdu, *Rack) *pdu,
-	torFunc func(*pb.ExternalTor, *Rack) *tor) *Rack {
+	pduFunc func(*pb.External_Pdu, *Rack) *pdu,
+	torFunc func(*pb.External_Tor, *Rack) *tor) *Rack {
 	r := &Rack{
 		name:      name,
 		ch:        make(chan sm.Envelope, rackQueueDepth),

--- a/internal/services/inventory/rack_test.go
+++ b/internal/services/inventory/rack_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/Jim3Things/CloudChamber/internal/services/inventory/messages"
 	"github.com/Jim3Things/CloudChamber/internal/sm"
 	"github.com/Jim3Things/CloudChamber/internal/tracing"
-    "github.com/Jim3Things/CloudChamber/pkg/errors"
-    "github.com/Jim3Things/CloudChamber/test/utilities"
+	"github.com/Jim3Things/CloudChamber/pkg/errors"
+	"github.com/Jim3Things/CloudChamber/test/utilities"
 )
 
 type RackTestSuite struct {

--- a/internal/services/inventory/testSuiteCore.go
+++ b/internal/services/inventory/testSuiteCore.go
@@ -58,10 +58,10 @@ func (ts *testSuiteCore) TearDownTest() {
 	ts.utf.Close()
 }
 
-func (ts *testSuiteCore) createDummyRack(bladeCount int) *pb.ExternalRack {
-	rackDef := &pb.ExternalRack{
-		Pdu:    &pb.ExternalPdu{},
-		Tor:    &pb.ExternalTor{},
+func (ts *testSuiteCore) createDummyRack(bladeCount int) *pb.External_Rack {
+	rackDef := &pb.External_Rack{
+		Pdu:    &pb.External_Pdu{},
+		Tor:    &pb.External_Tor{},
 		Blades: make(map[int64]*pb.BladeCapacity),
 	}
 

--- a/internal/services/inventory/tor.go
+++ b/internal/services/inventory/tor.go
@@ -41,7 +41,7 @@ const (
 // and the containing Rack.  Note that it currently does not fill in the cable
 // information, as that is missing from the inventory definition.  That is
 // done is the fixConnection function below.
-func newTor(_ *pb.ExternalTor, r *Rack) *tor {
+func newTor(_ *pb.External_Tor, r *Rack) *tor {
 	t := &tor{
 		cables: make(map[int64]*cable),
 		holder: r,

--- a/pkg/protos/inventory/actual.proto
+++ b/pkg/protos/inventory/actual.proto
@@ -7,30 +7,31 @@ syntax = "proto3";
 package inventory;
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/inventory";
+option csharp_namespace = "CloudChamber.Protos.Inventory";
 
-message actual {
+message Actual {
 
-    enum condition {
+    enum Condition {
         not_in_service = 0;
         operational = 1;
         faulted = 2;
     }
 
-    message pdu {
+    message Pdu {
 
-        condition condition = 1;
-
-    }
-
-    message tor {
-
-        condition condition = 1;
+        Condition condition = 1;
 
     }
 
-    message blade {
-        
-        condition condition = 1;
+    message Tor {
+
+        Condition condition = 1;
+
+    }
+
+    message Blade {
+
+        Condition condition = 1;
 
     }
 }

--- a/pkg/protos/inventory/capacity.proto
+++ b/pkg/protos/inventory/capacity.proto
@@ -12,12 +12,13 @@ syntax = "proto3";
 package inventory;
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/inventory";
+option csharp_namespace = "CloudChamber.Protos.Inventory";
 
 // Describe the capabilities of a physical blade
 // TODO: Do we need anything about host system software, or is this purely physical attributes?
 
 // Define the set of known accelerators, such as GPUs or FPGAs.
-message accelerator {
+message Accelerator {
     message NVIDIA_V100 {}
 
     oneof accelerator_type {
@@ -26,15 +27,15 @@ message accelerator {
 }
 
 // Defines the capacity dimensions and values for a blade
-message blade_capacity {
+message BladeCapacity {
     // The number of cores on the blade.
     int64 cores = 1;
 
     // The amount of memory, in megabytes
     int64 memory_in_mb = 2;
 
-    // The amount of local disk space, in gigabytes.  Note that this assumes either one disk, or that the disks are
-    // mounted collectively as a single volume
+    // The amount of local disk space, in gigabytes.  Note that this assumes either one disk,
+    // or that the disks are mounted collectively as a single volume
     int64 disk_in_gb = 3;
 
     // The network bandwidth from the host in megabits per second
@@ -44,10 +45,10 @@ message blade_capacity {
     string arch = 5;
 
     // Supply the set of accelerators for this blade, including none.
-    repeated accelerator accelerators = 6;
+    repeated Accelerator accelerators = 6;
 }
 
-message instance_requirements {
+message InstanceRequirements {
     // The number of (potentially fractional) cores used by the instance.
     float cores = 1;
 
@@ -61,5 +62,5 @@ message instance_requirements {
     string arch = 5;
 
     // Supply the set of accelerators required by this instance, including none.
-    repeated accelerator accelerators = 6;
+    repeated Accelerator accelerators = 6;
 }

--- a/pkg/protos/inventory/common.proto
+++ b/pkg/protos/inventory/common.proto
@@ -12,11 +12,12 @@ syntax = "proto3";
 package inventory;
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/inventory";
+option csharp_namespace = "CloudChamber.Protos.Inventory";
 
 // Underlying condition of hardware items within the inventory. Allows control of the basic
 // state of the item. Can be applied to racks, blades, tors, pdus, cables (power and network).
 //
-enum condition {
+enum Condition {
     not_in_service = 0;
     operational = 1;
     burn_in = 2;
@@ -28,24 +29,24 @@ enum condition {
 // Underlying state of logical items within the inventory. Allows the basic state to be
 // described. Applies to zones and regions.
 //
-enum state {
+enum State {
     out_of_service = 0;
     in_service = 1;
     commissioning = 2;
     assumed_failed = 3;
-    decommisioning = 4;
-    decommisioned = 5;
+    decommissioning = 4;
+    decommissioned = 5;
 }
 
 
 // Describes potential targets for wiring connections between a Pdu or Tor port and a specific
 // item of equipment.
 //
-message hardware {
+message Hardware {
 
     // Defines the type of hardware that can be wired up to a Pdu power port or a Tor network port.
     //
-    enum hw_type {
+    enum HwType {
         // The type of hardware is not yet known
         //
         unknown = 0;
@@ -65,7 +66,7 @@ message hardware {
 
     // The type or item or piece of equipment
     //
-    hw_type type = 1;
+    HwType type = 1;
 
     // Defines an instance of the piece of equipment. For example there are likely to be multiple
     // blades and the id is used to distinguish amongst them.
@@ -78,33 +79,33 @@ message hardware {
     int64 port = 3;
 }
 
-message power_port {
+message PowerPort {
     // Defines whether or not the port is actually connected to the associated item of equipment.
     //
     bool wired = 1;
 
     // Defines what the port is wired up to.
     //
-    hardware item = 2;
+    Hardware item = 2;
 }
 
-message network_port {
+message NetworkPort {
     // Defines whether or not the port is actually connected to the associated item of equipment.
     //
     bool wired = 1;
 
     // Defines what the port is wired up to.
     //
-    hardware item = 2;
+    Hardware item = 2;
 }
-    
-message blade_boot_info {
-    enum method {
+
+message BladeBootInfo {
+    enum Method {
         local = 0;
         network = 1;
     }
 
-    method source = 1;
+    Method source = 1;
     string image = 2;
     string version = 3;
     string parameters = 4;
@@ -112,71 +113,71 @@ message blade_boot_info {
 
 // Power distribution unit.  Network accessible power controller
 //
-message pdu_details {
+message PduDetails {
     // Note that full internal name for a pdu is <rackname>-pdu-0
 
-    // Whether or not the pdu is enabled. This is orthoganal to the condition of the
-    // pdu. For resources within the pdu to be schedulable, the pdu must be both
-    // enabled and the condition must be operational.
+    // Whether or not the pdu is enabled. This is orthogonal to the condition of the
+    // pdu. To schedule resources within the pdu, the pdu must be both enabled and
+    // the condition must be operational.
     //
     bool enabled = 1;
 
-    // Defines the overall condition of the pdu. This is orthoganal to the enabling of
-    // the pdu. For resources within the pdu to be schedulable, the pdu must be both
-    // enabled and the condition must be operational.
+    // Defines the overall condition of the pdu. This is orthogonal to the enabling of
+    // the pdu. To schedule resources within the pdu, the pdu must be both enabled and
+    // the condition must be operational.
     //
-    condition condition = 2;
+    Condition condition = 2;
 }
 
 // Rack-level network switch.
 //
-message tor_details {
+message TorDetails {
     // Note that full internal name for a tor is <rackname>-tor-0
 
-    // Whether or not the tor is enabled. This is orthoganal to the condition of the
-    // tor. For resources within the tor to be schedulable, the tor must be both
-    // enabled and the condition must be operational.
+    // Whether or not the tor is enabled. This is orthogonal to the condition of the
+    // tor. To schedule resources within the tor, the tor must be both enabled and
+    // the condition must be operational.
     //
     bool enabled = 1;
 
-    // Defines the overall condition of the tor. This is orthoganal to the enabling of
-    // the tor. For resources within the tor to be schedulable, the tor must be both
-    // enabled and the condition must be operational.
+    // Defines the overall condition of the tor. This is orthogonal to the enabling of
+    // the tor. To schedule resources within the tor, the tor must be both enabled and
+    // the condition must be operational.
     //
-    condition condition = 2;
+    Condition condition = 2;
 }
 
 // Rack-level blade computer
 //
-message blade_details {
-    // Whether or not the blade is enabled. This is orthoganal to the condition of the
-    // blade. For resources within the blade to be schedulable, the blade must be both
-    // enabled and the condition must be operational.
+message BladeDetails {
+    // Whether or not the blade is enabled. This is orthogonal to the condition of the
+    // blade. To schedule resources within the blade, the blade must be both enabled
+    // and the condition must be operational.
     //
     bool enabled = 1;
 
-    // Defines the overall condition of the blade. This is orthoganal to the enabling of
-    // the blade. For resources within the blade to be schedulable, the blade must be both
-    // enabled and the condition must be operational.
+    // Defines the overall condition of the blade. This is orthogonal to the enabling of
+    // the blade. To schedule resources within the blade, the blade must be both enabled
+    // and the condition must be operational.
     //
-    condition condition = 2;
+    Condition condition = 2;
 }
 
-message rack_details {
+message RackDetails {
     // This assumes a single overhead item per rack.  May want to allow multiple to handle
     // subdivisions for power or network, say.
 
-    // Whether or not the rack as a whole is enabled. This is orthoganal to the condition
-    // of the rack. For resources within the rack to be schedulable, the rack must be both
-    // enabled and the condition must be operational.
+    // Whether or not the rack as a whole is enabled. This is orthogonal to the condition
+    // of the rack. To schedule resources within the rack, the rack must be both enabled
+    // and the condition must be operational.
     //
     bool enabled = 1;
 
-    // Defines the overall condition of the rack. This is orthoganal to the enabling of
-    // the rack. For resources within the rack to be schedulable, the rack must be both
-    // enabled and the condition must be operational.
+    // Defines the overall condition of the rack. This is orthogonal to the enabling of
+    // the rack. To schedule resources within the rack, the rack must be both enabled
+    // and the condition must be operational.
     //
-    condition condition = 2;
+    Condition condition = 2;
 
     // Arbitrary string used to allow the physical location of the rack to be recorded in
     // a user defined format. Has no effect on the operation of the rack, for display
@@ -191,18 +192,18 @@ message rack_details {
     string notes = 4;
 }
 
-message zone_details {
-    // Whether or not the zone as a whole is enabled. This is orthoganal to the condition
-    // of the zone. For resources within the zone to be schedulable, the zone must be both
-    // enabled and the condition must be operational.
+message ZoneDetails {
+    // Whether or not the zone as a whole is enabled. This is orthogonal to the condition
+    // of the zone. To schedule resources within the zone, the zone must be both enabled
+    // and the condition must be operational.
     //
     bool enabled = 1;
 
-    // Defines the overall condition of the zone. This is orthoganal to the enabling of
-    // the zone. For resources within the zone to be schedulable, the zone must be both
-    // enabled and the condition must be operational.
+    // Defines the overall condition of the zone. This is orthogonal to the enabling of
+    // the zone. To schedule resources within the zone, the zone must be both enabled
+    // and the condition must be operational.
     //
-    state state = 2;
+    State state = 2;
 
     // Arbitrary string used to allow the physical location of the zone to be recorded in
     // a user defined format. Has no effect on the operation of the zone, for display
@@ -217,18 +218,18 @@ message zone_details {
     string notes = 4;
 }
 
-message region_details {
-    // The name of a region. 
+message RegionDetails {
+    // The name of a region.
     //
-    // NOTE: Not sure we need an explicit name field since the name of the record is 
+    // NOTE: Not sure we need an explicit name field since the name of the record is
     // implicit in identifying the record.
     //
     string name = 1;
 
-    // Defines the overall condition of the region. For resources within the region to
-    // be schedulable, the region  condition must be operational.
+    // Defines the overall condition of the region. To schedule resources within the
+    // region, the region's condition must be operational.
     //
-    state state = 2;
+    State state = 2;
 
     // Arbitrary string used to allow the physical location of the zone to be recorded in
     // a user defined format. Has no effect on the operation of the zone, for display
@@ -243,10 +244,10 @@ message region_details {
     string notes = 4;
 }
 
-message root_details {
-    // The name of the root of the configuration / simulation. 
+message RootDetails {
+    // The name of the root of the configuration / simulation.
     //
-    // NOTE: Not sure we need an explicit name field since the name of the record is 
+    // NOTE: Not sure we need an explicit name field since the name of the record is
     // implicit in identifying the record.
     //
     string name = 1;

--- a/pkg/protos/inventory/definition.Validate.go
+++ b/pkg/protos/inventory/definition.Validate.go
@@ -14,7 +14,7 @@ const maxPorts = int64(1000)
 // Validate is a method that verifies that the associated DefinitionPdu instance
 // has the expected number of ports and is semantically legal
 //
-func(x *DefinitionPdu) Validate(prefix string, ports int64) error {
+func(x *Definition_Pdu) Validate(prefix string, ports int64) error {
 
 	actual := int64(len(x.Ports))
 
@@ -35,7 +35,7 @@ func(x *DefinitionPdu) Validate(prefix string, ports int64) error {
 // For example, check for errors such as the pdu being wired to itself, the
 // port being wired but without an associated item etc.
 //
-func(x *DefinitionPdu) Verify() error {
+func(x *Definition_Pdu) Verify() error {
 
 	return x.check("")
 }
@@ -46,7 +46,7 @@ func(x *DefinitionPdu) Verify() error {
 // For example, check for errors such as the pdu being wired to itself, the
 // port being wired but without an associated item etc.
 //
-func(x *DefinitionPdu) check(prefix string) error {
+func(x *Definition_Pdu) check(prefix string) error {
 
 	prefixedPorts := prefix + "Ports"
 	prefixedItem  := prefix + "Item"
@@ -116,7 +116,7 @@ func(x *DefinitionPdu) check(prefix string) error {
 // Validate is a method that verifies that the associated DefinitionTor instance
 // has the expected number of ports and is semantically legal
 //
-func(x *DefinitionTor) Validate(prefix string, ports int64) error {
+func(x *Definition_Tor) Validate(prefix string, ports int64) error {
 
 	actual := int64(len(x.Ports))
 
@@ -137,7 +137,7 @@ func(x *DefinitionTor) Validate(prefix string, ports int64) error {
 // For example, check for errors such as the tor being wired to itself, the
 // port being wired but without an associated item etc.
 //
-func(x *DefinitionTor) Verify() error {
+func(x *Definition_Tor) Verify() error {
 
 	return x.check("")
 }
@@ -148,7 +148,7 @@ func(x *DefinitionTor) Verify() error {
 // For example, check for errors such as the tor being wired to itself, the
 // port being wired but without an associated item etc.
 //
-func(x *DefinitionTor) check(prefix string) error {
+func(x *Definition_Tor) check(prefix string) error {
 
 	prefixedPorts := prefix + "Ports"
 	prefixedItem  := prefix + "Item"
@@ -218,7 +218,7 @@ func(x *DefinitionTor) check(prefix string) error {
 // Validate is a method that verifies that the associated DefinitionRack instance
 // is structurally legal
 //
-func (x *DefinitionRack) Validate(prefix string) error {
+func (x *Definition_Rack) Validate(prefix string) error {
 	// Verify that rack has at least one Pdu
 	//
 	// NOTE: at present we expect there to be exactly one Pdu per-rack
@@ -288,7 +288,7 @@ func (x *DefinitionRack) Validate(prefix string) error {
 // Validate is a method that verifies that the associated DefinitionZone instance
 // is structurally legal
 //
-func (x *DefinitionZone) Validate() error {
+func (x *Definition_Zone) Validate() error {
 	// Verify that zone has at least one rack
 	//
 	actual := int64(len(x.Racks))

--- a/pkg/protos/inventory/definition.proto
+++ b/pkg/protos/inventory/definition.proto
@@ -1,8 +1,9 @@
 // This file contains the definitions used by configuration definitions for describing the simulated
-// inventory.  These definitions describe the items, but do not define any observed or actual status for them.
+// inventory.  These definitions describe the items, but do not define any observed or actual status
+// for them.
 //
-// Note that we may, at some point, want to add an initial status definition in order to define inventory that begins
-// in a partially failed manner.
+// Note that we may, at some point, want to add an initial status definition in order to define
+// inventory that begins in a partially failed manner.
 
 syntax = "proto3";
 
@@ -12,100 +13,101 @@ import "github.com/Jim3Things/CloudChamber/pkg/protos/inventory/capacity.proto";
 import "github.com/Jim3Things/CloudChamber/pkg/protos/inventory/common.proto";
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/inventory";
+option csharp_namespace = "CloudChamber.Protos.Inventory";
 
-message definition {
+message Definition {
 
     // The two types here are common overhead items in a rack.  All are pure skeletons at this point.
-    // Note that all have implied connectivity with all other items in a rack.  Currently elided in the external model,
-    // but used in the other models.
+    // Note that all have implied connectivity with all other items in a rack.  Currently elided in
+    // the external model, but used in the other models.
 
     // Power distribution unit.  Network accessible power controller
     //
-    message pdu {
+    message Pdu {
 
-        pdu_details details = 1;
+        PduDetails details = 1;
 
         // Defines a power "socket" which is used to provide power to a blade. There is
         // a 1 to 1 mapping of a power port to a blade within a single rack and it is an
         // error if there fewer power ports than blades.
         //
-        map<int64, power_port> ports = 10;
+        map<int64, PowerPort> ports = 10;
     }
 
     // Rack-level network switch.
     //
-    message tor {
-        tor_details details = 1;
+    message Tor {
+        TorDetails details = 1;
 
         // Defines a network "port" which is used to provide a network connection to a
         // blade. There is a 1 to 1 mapping of a network port to a blade within a single
         // rack and it is an error if there fewer network ports than blades.
         //
-        map<int64, network_port> ports = 10;
+        map<int64, NetworkPort> ports = 10;
     }
 
     // Individual blade within the rack
     //
-    message blade {
-        blade_details details = 1;
+    message Blade {
+        BladeDetails details = 1;
 
-        blade_capacity capacity = 10;
+        BladeCapacity capacity = 10;
 
         // Defines whether or not the blade automatically begins a boot sequence when power is
-        // appplied to the blade.
+        // applied to the blade.
         //
         bool boot_on_power_on = 11;
 
         // Describes the default boot mechanism
         //
-        blade_boot_info boot_info = 12;
+        BladeBootInfo boot_info = 12;
     }
 
 
-    message rack {
-        rack_details details = 1;
+    message Rack {
+        RackDetails details = 1;
 
         // Specify the pdus in the rack.  Each pdu is defined by an integer index within
         // that rack, which is used here as the key.
         //
-        map<int64, pdu> pdus = 10;
-    
+        map<int64, Pdu> pdus = 10;
+
         // specify the tors in the rack.  Each tor is defined by an integer index within
         // that rack, which is used here as the key.
         //
-        map<int64, tor> tors = 11;
-    
+        map<int64, Tor> tors = 11;
+
         // specify the blades in the rack.  Each blade is defined by an integer index within
         // that rack, which is used here as the key.
         //
-        map<int64, blade> blades = 12;
+        map<int64, Blade> blades = 12;
     }
 
-    // A complete description of a zone internal "in-memory" usage as oppoesed to reading
+    // A complete description of a zone internal "in-memory" usage as opposed to reading
     // and/or writing individual zone records from the store, i.e. a "container" structure.
     //
-    message zone {
-        zone_details details = 1;
+    message Zone {
+        ZoneDetails details = 1;
 
         // The set of racks forming an individual zone. All racks in the zone are affected
         // by the properties of the zone or any conditions affecting the zone. Each rack is
         // defined by a string name within the zone, and that name is used here as a key.
         //
-        map<string, rack> racks = 10;
+        map<string, Rack> racks = 10;
     }
 
     // A complete description of a region internal "in-memory" usage as opposed to reading
     // and/or writing individual region records from the store, i.e. a "container" structure.
     //
-    message region {
-        region_details details = 1;
+    message Region {
+        RegionDetails details = 1;
 
-        map<string, zone> zones = 10;
+        map<string, Zone> zones = 10;
     }
 
-    message root {
-        root_details details = 1;
+    message Root {
+        RootDetails details = 1;
 
-        map<string, region> regions = 10;
+        map<string, Region> regions = 10;
     }
 }

--- a/pkg/protos/inventory/external.Validate.go
+++ b/pkg/protos/inventory/external.Validate.go
@@ -10,7 +10,7 @@ import (
 
 // Validate is a method that verifies that the associated ExternalRack instance
 // is structurally legal
-func (x *ExternalRack) Validate() error {
+func (x *External_Rack) Validate() error {
 	// Verify that a rack has at least one blade
 	actual := int64(len(x.Blades))
 	if actual < 1 {

--- a/pkg/protos/inventory/external.proto
+++ b/pkg/protos/inventory/external.proto
@@ -11,38 +11,40 @@ package inventory;
 import "github.com/Jim3Things/CloudChamber/pkg/protos/inventory/capacity.proto";
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/inventory";
+option csharp_namespace = "CloudChamber.Protos.Inventory";
 
-message external {
+message External {
 
     // The two types here are common overhead items in a rack.  All are pure skeletons at this point.
-    // Note that all have implied connectivity with all other items in a rack.  Currently elided in the external model,
-    // but used in the other models.
+    // Note that all have implied connectivity with all other items in a rack.  Currently elided in
+    // the external model, but used in the other models.
 
     // Power distribution unit.  Network accessible power controller
-    message pdu {
+    message Pdu {
         // Note that full internal name for a pdu is <rackname>-pdu-0
     }
 
     // Rack-level network switch.
-    message tor {
+    message Tor {
         // Note that full internal name for a tor is <rackname>-tor-0
     }
 
-    message rack {
+    message Rack {
         // This assumes a single overhead item per rack.  May want to allow multiple to handle
         // subdivisions for power or network, say.
 
-        pdu pdu = 1;
-        tor tor = 2;
+        Pdu pdu = 1;
+        Tor tor = 2;
 
-        // specify the blades in the rack.  Each blade is defined by an integer index within that rack, which is used
-        // here as the key.
-        map<int64, blade_capacity> blades = 3;
+        // specify the blades in the rack.  Each blade is defined by an integer index within that
+        // rack, which is used here as the key.
+        map<int64, BladeCapacity> blades = 3;
     }
 
-    // Finally, a zone is a collection of racks.  Each rack has a name, which is used as a key in the map below.
-    message zone {
-        map<string, rack> racks = 1;
+    // Finally, a zone is a collection of racks.  Each rack has a name, which is used as a key in
+    // the map below.
+    message Zone {
+        map<string, Rack> racks = 1;
     }
 
     // The following messages are used to format JSON strings for use by
@@ -50,20 +52,20 @@ message external {
     // to be needed by the common callers.
 
     // Rack list entry item
-    message rack_summary {
+    message RackSummary {
         // host relative URI that can be used to retrieve its details
         string uri = 1;
     }
 
     // Summary of the full inventory
-    message zone_summary {
+    message ZoneSummary {
         // Summary information about all known racks
-        map<string, rack_summary> racks = 1;
+        map<string, RackSummary> racks = 1;
 
         // The largest number of blades held in any rack
         int64 max_blade_count = 2;
 
         // The largest capacity values found in any blade
-        blade_capacity max_capacity = 3;
+        BladeCapacity max_capacity = 3;
     }
 }

--- a/pkg/protos/inventory/internal.proto
+++ b/pkg/protos/inventory/internal.proto
@@ -1,4 +1,4 @@
-// This file contains the internal definitions used by the stor to provide the
+// This file contains the internal definitions used by the store to provide the
 // internal, universal representation of the various items in the inventory. All
 // other forms can be converted into the internal format and likewise, all the
 // other forms can be generated from the internal format.
@@ -13,86 +13,87 @@ import "github.com/Jim3Things/CloudChamber/pkg/protos/inventory/definition.proto
 import "github.com/Jim3Things/CloudChamber/pkg/protos/inventory/target.proto";
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/inventory";
+option csharp_namespace = "CloudChamber.Protos.Inventory";
 
-message internal {
+message Internal {
 
-    message pdu {
-        definition.pdu definition = 1;
-        target.pdu target = 2;
-        actual.pdu actual = 3;
+    message Pdu {
+        Definition.Pdu definition = 1;
+        Target.Pdu target = 2;
+        Actual.Pdu actual = 3;
     }
 
-    message tor {
-        definition.tor definition = 1;
-        target.tor target = 2;
-        actual.tor actual = 3;
+    message Tor {
+        Definition.Tor definition = 1;
+        Target.Tor target = 2;
+        Actual.Tor actual = 3;
     }
 
-    message blade {
-        definition.blade definition = 1;
-        target.blade target = 2;
-        actual.blade actual = 3;
+    message Blade {
+        Definition.Blade definition = 1;
+        Target.Blade target = 2;
+        Actual.Blade actual = 3;
     }
 
-    message rack {
-        rack_details details = 1;
+    message Rack {
+        RackDetails details = 1;
 
         // Specify the pdus in the rack.  Each pdu is defined by an integer index within
         // that rack, which is used here as the key.
         //
-        map<int64, definition.pdu> pdus = 10;
-    
+        map<int64, Definition.Pdu> pdus = 10;
+
         // specify the tors in the rack.  Each tor is defined by an integer index within
         // that rack, which is used here as the key.
         //
-        map<int64, definition.tor> tors = 11;
-    
+        map<int64, Definition.Tor> tors = 11;
+
         // specify the blades in the rack.  Each blade is defined by an integer index within
         // that rack, which is used here as the key.
         //
-        map<int64, definition.blade> blades = 12;
+        map<int64, Definition.Blade> blades = 12;
     }
 
-    // A complete description of a zone internal "in-memory" usage as oppoesed to reading
+    // A complete description of a zone internal "in-memory" usage as opposed to reading
     // and/or writing individual zone records from the store, i.e. a "container" structure.
     //
-    message zone {
-        zone_details details = 1;
+    message Zone {
+        ZoneDetails details = 1;
 
         // The set of racks forming an individual zone. All racks in the zone are affected
         // by the properties of the zone or any conditions affecting the zone. Each rack is
         // defined by a string name within the zone, and that name is used here as a key.
         //
-        map<string, definition.rack> racks = 10;
+        map<string, Definition.Rack> racks = 10;
     }
 
     // A complete description of a region internal "in-memory" usage as opposed to reading
     // and/or writing individual region records from the store, i.e. a "container" structure.
     //
-    message region {
-        region_details details = 1;
+    message Region {
+        RegionDetails details = 1;
 
-        map<string, definition.zone> zones = 10;
+        map<string, Definition.Zone> zones = 10;
     }
 
     // Current tgt and act are experimental to see what they look like and how they might
     // operate. Expect changes in this area.
     //
     message record_target {
-        map<int64, target.pdu>   pdus   = 10;
-        map<int64, target.tor>   tors   = 11;
-        map<int64, target.blade> blades = 12;
+        map<int64, Target.Pdu>   pdus   = 10;
+        map<int64, Target.Tor>   tors   = 11;
+        map<int64, Target.Blade> blades = 12;
     }
 
     message record_actual {
-        map<int64, actual.pdu>   pdus   = 10;
-        map<int64, actual.tor>   tors   = 11;
-        map<int64, actual.blade> blades = 12;
+        map<int64, Actual.Pdu>   pdus   = 10;
+        map<int64, Actual.Tor>   tors   = 11;
+        map<int64, Actual.Blade> blades = 12;
     }
 
     message record_observed {
-        map<int64, actual.pdu>   pdus   = 10;
-        map<int64, actual.tor>   tors   = 11;
-        map<int64, actual.blade> blades = 12;
+        map<int64, Actual.Pdu>   pdus   = 10;
+        map<int64, Actual.Tor>   tors   = 11;
+        map<int64, Actual.Blade> blades = 12;
     }
 }

--- a/pkg/protos/inventory/store.proto
+++ b/pkg/protos/inventory/store.proto
@@ -11,85 +11,86 @@ import "github.com/Jim3Things/CloudChamber/pkg/protos/inventory/target.proto";
 import "github.com/Jim3Things/CloudChamber/pkg/protos/inventory/actual.proto";
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/inventory";
+option csharp_namespace = "CloudChamber.Protos.Inventory";
 
 
-// A complete description of a rack internal "in-memory" usage as oppoesed to reading
+// A complete description of a rack internal "in-memory" usage as opposed to reading
 // and/or writing individual rack records from the store, i.e. a "container" structure.
 //
-message store {
+message Store {
 
-    message record_definition {
+    message RecordDefinition {
 
-        message pdu {
-            pdu_details            details = 1;
-            map<int64, power_port> ports   = 10;
+        message Pdu {
+            PduDetails            details = 1;
+            map<int64, PowerPort> ports   = 10;
         }
 
-        message tor {
-            tor_details              details = 1;
-            map<int64, network_port> ports   = 10;
+        message Tor {
+            TorDetails              details = 1;
+            map<int64, NetworkPort> ports   = 10;
         }
 
-        message blade {
-            blade_details   details          =  1;
-            blade_capacity  capacity         = 10;
-            bool            boot_on_power_on = 11;
-            blade_boot_info boot_info        = 12;
+        message Blade {
+            BladeDetails  details          =  1;
+            BladeCapacity capacity         = 10;
+            bool          boot_on_power_on = 11;
+            BladeBootInfo boot_info        = 12;
         }
 
-        message rack {
-            rack_details details = 1;
+        message Rack {
+            RackDetails details = 1;
         }
 
-        message zone {
-            zone_details details = 1;
+        message Zone {
+            ZoneDetails details = 1;
         }
 
-        message region {
-            region_details details = 1;
+        message Region {
+            RegionDetails details = 1;
         }
     }
 
     // Current tgt and act are experimental to see what they look like and how they might
     // operate. Expect changes in this area.
     //
-    message record_target {
+    message RecordTarget {
 
-        message pdu {
-            target.pdu target = 1;
+        message Pdu {
+            Target.Pdu target = 1;
         }
 
-        message tor {
-            target.tor target = 1;
+        message Tor {
+            Target.Tor target = 1;
         }
 
-        message blade {
-            target.tor target = 1;
+        message Blade {
+            Target.Blade target = 1;
         }
 
         message rack {
-            target.tor target = 1;
+            Target.Tor target = 1;
         }
 
-        message zone {
-            target.tor target = 1;
+        message Zone {
+            Target.Tor target = 1;
         }
 
-        message region {
-            target.tor target = 1;
+        message Region {
+            Target.Tor target = 1;
         }
     }
 
-    message record_actual {
-        map<int64, actual.pdu>   pdus   = 10;
-        map<int64, actual.tor>   tors   = 11;
-        map<int64, actual.blade> blades = 12;
+    message RecordActual {
+        map<int64, Actual.Pdu>   pdus   = 10;
+        map<int64, Actual.Tor>   tors   = 11;
+        map<int64, Actual.Blade> blades = 12;
     }
 
     message record_observed {
-        map<int64, actual.pdu>   pdus   = 10;
-        map<int64, actual.tor>   tors   = 11;
-        map<int64, actual.blade> blades = 12;
+        map<int64, Actual.Pdu>   pdus   = 10;
+        map<int64, Actual.Tor>   tors   = 11;
+        map<int64, Actual.Blade> blades = 12;
     }
 }
 

--- a/pkg/protos/inventory/target.proto
+++ b/pkg/protos/inventory/target.proto
@@ -6,30 +6,31 @@ syntax = "proto3";
 package inventory;
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/inventory";
+option csharp_namespace = "CloudChamber.Protos.Inventory";
 
-message target {
+message Target {
 
-    enum condition {
+    enum Condition {
         not_in_service = 0;
         operational = 1;
         faulted = 2;
     }
 
-    message pdu {
+    message Pdu {
 
-        condition condition = 1;
-
-    }
-
-    message tor {
-
-        condition condition = 1;
+        Condition condition = 1;
 
     }
 
-    message blade {
-        
-        condition condition = 1;
+    message Tor {
+
+        Condition condition = 1;
+
+    }
+
+    message Blade {
+
+        Condition condition = 1;
 
     }
 }

--- a/pkg/protos/services/monitor.proto
+++ b/pkg/protos/services/monitor.proto
@@ -51,8 +51,8 @@ message actual {
         message blade_details {
             base_status status = 1;
 
-            inventory.blade_capacity present = 2;
-            inventory.blade_capacity used = 3;
+            inventory.BladeCapacity present = 2;
+            inventory.BladeCapacity used = 3;
 
             // TODO: We will probably want a list of the scheduling decision IDs that
             //       are represented in the used capacity.

--- a/pkg/protos/workload/actual.proto
+++ b/pkg/protos/workload/actual.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package workload;
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/workload";
+option csharp_namespace = "CloudChamber.Protos.Workload";
 
 message actual {
 

--- a/pkg/protos/workload/external.proto
+++ b/pkg/protos/workload/external.proto
@@ -5,11 +5,12 @@ package workload;
 import "github.com/Jim3Things/CloudChamber/pkg/protos/inventory/capacity.proto";
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/workload";
+option csharp_namespace = "CloudChamber.Protos.Workload";
 
-message external {
+message External {
     // Define a disk volume
-    message volume {
-        enum attr {
+    message Volume {
+        enum Attr {
             Invalid = 0;
 
             // Volume can be dynamically created, implicitly writable
@@ -26,32 +27,32 @@ message external {
         int64 size_in_gb = 1;
 
         // Constraint on the volume type.
-        attr attribute = 2;
+        Attr attribute = 2;
 
         // Address where the volume is located
         string uri = 3;
     }
 
     // Define a single instance
-    message instance {
+    message Instance {
         // Define the logical affinity group where this instance belongs.
         int64 affinity_group = 1;
 
         // Defined the required blade capacity used by this instance
-        inventory.instance_requirements required_capacity = 2;
+        inventory.InstanceRequirements required_capacity = 2;
 
         // Boot volume name
         string system_name = 3;
 
         // all volumes, must include the boot volume
-        map<string, volume> volumes = 4;
+        map<string, Volume> volumes = 4;
 
         // configuration / metadata to pass to the instance
         string config = 5;
     }
 
     // Define the policy for how to manage affinity groups
-    enum affinity_type {
+    enum AffinityType {
         // No placement restrictions, ignore affinity groups
         None = 0;
 
@@ -70,15 +71,15 @@ message external {
     }
 
     // Define a workload.  This is a logical service made up of one or more instances
-    message workload {
+    message Workload {
         // Specify the workload's name
         string name = 1;
 
         // Specify the affinity policy to apply to the instances
-        affinity_type affinity = 2;
+        AffinityType affinity = 2;
 
         // Define the set of instances in this workload.  Each instance has a name that is unique within
         // the workload.  That name is used as the key in the instance map.
-        map<string, instance> instances = 3;
+        map<string, Instance> instances = 3;
     }
 }

--- a/pkg/protos/workload/internal.proto
+++ b/pkg/protos/workload/internal.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package workload;
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/workload";
+option csharp_namespace = "CloudChamber.Protos.Workload";
 
 message internal {
 

--- a/pkg/protos/workload/target.proto
+++ b/pkg/protos/workload/target.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package workload;
 
 option go_package = "github.com/Jim3Things/CloudChamber/pkg/protos/workload";
+option csharp_namespace = "CloudChamber.Protos.Workload";
 
 message target {
 


### PR DESCRIPTION
Capitalize message and enum types.  Fix up .go files as required.
format cleanup of modified .go files.