### PR TITLE
Convert  inventory definition tests to be based on the testify test suite package

### DIFF
--- a/simulation/internal/clients/inventory/TestSuiteCore.go
+++ b/simulation/internal/clients/inventory/TestSuiteCore.go
@@ -29,19 +29,6 @@ type testSuiteCore struct {
 	store *store.Store
 }
 
-func runOnceRequired() bool{
-	lock.Lock()
-	defer lock.Unlock()
-
-	if initialized {
-		return false
-	}
-
-	initialized = true
-
-	return true
-}
-
 func runOnce() (*config.GlobalConfig, error) {
 	lock.Lock()
 	defer lock.Unlock()

--- a/simulation/internal/clients/inventory/TestSuiteCore.go
+++ b/simulation/internal/clients/inventory/TestSuiteCore.go
@@ -1,0 +1,93 @@
+package inventory
+
+import (
+	"flag"
+	"sync"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/Jim3Things/CloudChamber/simulation/internal/clients/store"
+	"github.com/Jim3Things/CloudChamber/simulation/internal/config"
+	"github.com/Jim3Things/CloudChamber/simulation/internal/tracing/exporters"
+)
+
+var (
+	lock         sync.Mutex
+	globalCfg    *config.GlobalConfig
+	initialized  bool = false
+)
+
+type testSuiteCore struct {
+	suite.Suite
+
+	baseURI string
+
+	utf *exporters.Exporter
+
+	cfg *config.GlobalConfig
+
+	store *store.Store
+}
+
+func runOnceRequired() bool{
+	lock.Lock()
+	defer lock.Unlock()
+
+	if initialized {
+		return false
+	}
+
+	initialized = true
+
+	return true
+}
+
+func runOnce() (*config.GlobalConfig, error) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	if !initialized {
+		configPath := flag.String("config", "./testdata", "path to the configuration file")
+
+		flag.Parse()
+
+		cfg, err := config.ReadGlobalConfig(*configPath)
+		if err != nil {
+			return nil, err
+		}
+
+		globalCfg = cfg
+		initialized = true
+	}
+
+	return globalCfg, nil
+}
+
+func (ts *testSuiteCore) SetupSuite() {
+	require := ts.Require()
+
+	cfg, err := runOnce()
+	require.NoError(err, "failed to process the global configuration")
+
+	ts.utf = exporters.NewExporter(exporters.NewUTForwarder())
+	exporters.ConnectToProvider(ts.utf)
+
+	store.Initialize(cfg)
+
+	ts.cfg = cfg
+	ts.store = store.NewStore()
+}
+
+func (ts *testSuiteCore) SetupTest() {
+	require := ts.Require()
+
+	require.NoError(ts.utf.Open(ts.T()))
+	require.NoError(ts.store.Connect())
+}
+
+func (ts *testSuiteCore) TearDownTest() {
+	ts.store.Disconnect()
+	ts.utf.Close()
+}
+
+

--- a/simulation/internal/clients/inventory/definition_test.go
+++ b/simulation/internal/clients/inventory/definition_test.go
@@ -2,29 +2,18 @@ package inventory
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/Jim3Things/CloudChamber/simulation/internal/clients/store"
-	"github.com/Jim3Things/CloudChamber/simulation/internal/config"
-	"github.com/Jim3Things/CloudChamber/simulation/internal/tracing/exporters"
 	"github.com/Jim3Things/CloudChamber/simulation/pkg/errors"
 	pb "github.com/Jim3Things/CloudChamber/simulation/pkg/protos/inventory"
 )
 
-type testSuiteCore struct {
-	suite.Suite
-
-	baseURI string
-
-	utf *exporters.Exporter
-
-	cfg *config.GlobalConfig
-
-	store *store.Store
+type definitionTestSuite struct {
+	testSuiteCore
 
 	regionCount    int
 	zonesPerRegion int
@@ -37,22 +26,23 @@ type testSuiteCore struct {
 	portsPerTor int
 }
 
-func (ts *testSuiteCore) rootName(suffix string) string   { return "StandardRoot-" + suffix }
-func (ts *testSuiteCore) regionName(suffix string) string { return "REG-PNW-" + suffix }
-func (ts *testSuiteCore) zoneName(suffix string) string   { return "Zone-01-" + suffix }
-func (ts *testSuiteCore) rackName(suffix string) string   { return "Rack-01-" + suffix }
-func (ts *testSuiteCore) pduID(ID int64) int64            { return int64(ID) }
-func (ts *testSuiteCore) torID(ID int64) int64            { return int64(ID) }
-func (ts *testSuiteCore) bladeID(ID int64) int64          { return int64(ID) }
+func (ts *definitionTestSuite) rootName(suffix string)   string { return "StandardRoot-" + suffix }
+func (ts *definitionTestSuite) regionName(suffix string) string { return "REG-PNW-"      + suffix }
+func (ts *definitionTestSuite) zoneName(suffix string)   string { return "Zone-01-"      + suffix }
+func (ts *definitionTestSuite) rackName(suffix string)   string { return "Rack-01-"      + suffix }
+func (ts *definitionTestSuite) pduID(ID int64)      int64  { return int64(ID)}
+func (ts *definitionTestSuite) torID(ID int64)      int64  { return int64(ID)}
+func (ts *definitionTestSuite) bladeID(ID int64)    int64  { return int64(ID)}
 
-func (ts *testSuiteCore) stdRootDetails(suffix string) *pb.RootDetails {
+
+func (ts *definitionTestSuite) stdRootDetails(suffix string) *pb.RootDetails {
 	return &pb.RootDetails{
 		Name:  ts.rootName(suffix),
 		Notes: "root for inventory definition test",
 	}
 }
 
-func (ts *testSuiteCore) stdRegionDetails(suffix string) *pb.RegionDetails {
+func (ts *definitionTestSuite) stdRegionDetails(suffix string) *pb.RegionDetails {
 	return &pb.RegionDetails{
 		Name:     ts.regionName(suffix),
 		State:    pb.State_in_service,
@@ -61,7 +51,7 @@ func (ts *testSuiteCore) stdRegionDetails(suffix string) *pb.RegionDetails {
 	}
 }
 
-func (ts *testSuiteCore) stdZoneDetails(suffix string) *pb.ZoneDetails {
+func (ts *definitionTestSuite) stdZoneDetails(suffix string) *pb.ZoneDetails {
 	return &pb.ZoneDetails{
 		Enabled:  true,
 		State:    pb.State_in_service,
@@ -70,7 +60,7 @@ func (ts *testSuiteCore) stdZoneDetails(suffix string) *pb.ZoneDetails {
 	}
 }
 
-func (ts *testSuiteCore) stdRackDetails(suffix string) *pb.RackDetails {
+func (ts *definitionTestSuite) stdRackDetails(suffix string) *pb.RackDetails {
 	return &pb.RackDetails{
 		Enabled:   true,
 		Condition: pb.Condition_operational,
@@ -79,14 +69,14 @@ func (ts *testSuiteCore) stdRackDetails(suffix string) *pb.RackDetails {
 	}
 }
 
-func (ts *testSuiteCore) stdPduDetails(ID int64) *pb.PduDetails {
+func (ts *definitionTestSuite) stdPduDetails(ID int64) *pb.PduDetails {
 	return &pb.PduDetails{
 		Enabled:   true,
 		Condition: pb.Condition_operational,
 	}
 }
 
-func (ts *testSuiteCore) stdPowerPorts(count int) *map[int64]*pb.PowerPort {
+func (ts *definitionTestSuite) stdPowerPorts(count int) *map[int64]*pb.PowerPort {
 	ports := make(map[int64]*pb.PowerPort)
 
 	for i := 0; i < count; i++ {
@@ -103,14 +93,14 @@ func (ts *testSuiteCore) stdPowerPorts(count int) *map[int64]*pb.PowerPort {
 	return &ports
 }
 
-func (ts *testSuiteCore) stdTorDetails() *pb.TorDetails {
+func (ts *definitionTestSuite) stdTorDetails() *pb.TorDetails {
 	return &pb.TorDetails{
 		Enabled:   true,
 		Condition: pb.Condition_operational,
 	}
 }
 
-func (ts *testSuiteCore) stdNetworkPorts(count int) *map[int64]*pb.NetworkPort {
+func (ts *definitionTestSuite) stdNetworkPorts(count int) *map[int64]*pb.NetworkPort {
 	ports := make(map[int64]*pb.NetworkPort)
 
 	for i := 0; i < count; i++ {
@@ -127,14 +117,14 @@ func (ts *testSuiteCore) stdNetworkPorts(count int) *map[int64]*pb.NetworkPort {
 	return &ports
 }
 
-func (ts *testSuiteCore) stdBladeDetails() *pb.BladeDetails {
+func (ts *definitionTestSuite) stdBladeDetails() *pb.BladeDetails {
 	return &pb.BladeDetails{
 		Enabled:   true,
 		Condition: pb.Condition_operational,
 	}
 }
 
-func (ts *testSuiteCore) stdBladeCapacity() *pb.BladeCapacity {
+func (ts *definitionTestSuite) stdBladeCapacity() *pb.BladeCapacity {
 	return &pb.BladeCapacity{
 		Cores:                  16,
 		MemoryInMb:             1024,
@@ -144,7 +134,7 @@ func (ts *testSuiteCore) stdBladeCapacity() *pb.BladeCapacity {
 	}
 }
 
-func (ts *testSuiteCore) stdBladeBootInfo() *pb.BladeBootInfo {
+func (ts *definitionTestSuite) stdBladeBootInfo() *pb.BladeBootInfo {
 	return &pb.BladeBootInfo{
 		Source:     pb.BladeBootInfo_local,
 		Image:      "test-image.vhdx",
@@ -153,7 +143,7 @@ func (ts *testSuiteCore) stdBladeBootInfo() *pb.BladeBootInfo {
 	}
 }
 
-func (ts *testSuiteCore) createStandardInventory(ctx context.Context) error {
+func (ts *definitionTestSuite)createStandardInventory(ctx context.Context) error {
 
 	err := ts.createInventory(
 		ctx,
@@ -168,7 +158,7 @@ func (ts *testSuiteCore) createStandardInventory(ctx context.Context) error {
 	return err
 }
 
-func (ts *testSuiteCore) verifyStandardInventoryRegionDetails(name string, details *pb.RegionDetails) {
+func (ts *definitionTestSuite)verifyStandardInventoryRegionDetails(name string, details *pb.RegionDetails) {
 	assert := ts.Assert()
 
 	check := ts.stdRegionDetails(name)
@@ -179,7 +169,7 @@ func (ts *testSuiteCore) verifyStandardInventoryRegionDetails(name string, detai
 	assert.Equal(check.Notes, details.Notes)
 }
 
-func (ts *testSuiteCore) verifyStandardInventoryZoneDetails(name string, details *pb.ZoneDetails) {
+func (ts *definitionTestSuite)verifyStandardInventoryZoneDetails(name string, details *pb.ZoneDetails) {
 	assert := ts.Assert()
 
 	check := ts.stdZoneDetails(name)
@@ -190,7 +180,7 @@ func (ts *testSuiteCore) verifyStandardInventoryZoneDetails(name string, details
 	assert.Equal(check.Notes, details.Notes)
 }
 
-func (ts *testSuiteCore) verifyStandardInventoryRackDetails(name string, details *pb.RackDetails) {
+func (ts *definitionTestSuite)verifyStandardInventoryRackDetails(name string, details *pb.RackDetails) {
 	assert := ts.Assert()
 
 	check := ts.stdRackDetails(name)
@@ -201,7 +191,7 @@ func (ts *testSuiteCore) verifyStandardInventoryRackDetails(name string, details
 	assert.Equal(check.Notes, details.Notes)
 }
 
-func (ts *testSuiteCore) verifyStandardInventoryPdu(index int64, pdu Pdu) {
+func (ts *definitionTestSuite) verifyStandardInventoryPdu(index int64, pdu Pdu) {
 	assert := ts.Assert()
 
 	details := ts.stdPduDetails(index)
@@ -223,7 +213,7 @@ func (ts *testSuiteCore) verifyStandardInventoryPdu(index int64, pdu Pdu) {
 	}
 }
 
-func (ts *testSuiteCore) verifyStandardInventoryTor(index int64, tor *Tor) {
+func (ts *definitionTestSuite) verifyStandardInventoryTor(index int64, tor *Tor) {
 	assert := ts.Assert()
 
 	details := ts.stdTorDetails()
@@ -245,7 +235,7 @@ func (ts *testSuiteCore) verifyStandardInventoryTor(index int64, tor *Tor) {
 	}
 }
 
-func (ts *testSuiteCore) verifyStandardInventoryBlade(index int64, blade *Blade) {
+func (ts *definitionTestSuite) verifyStandardInventoryBlade(index int64, blade *Blade) {
 	assert := ts.Assert()
 
 	details := ts.stdTorDetails()
@@ -271,7 +261,7 @@ func (ts *testSuiteCore) verifyStandardInventoryBlade(index int64, blade *Blade)
 	assert.True(blade.bootOnPowerOn)
 }
 
-func (ts *testSuiteCore) createInventory(
+func (ts *definitionTestSuite)createInventory(
 	ctx context.Context,
 	table string,
 	regions int,
@@ -373,24 +363,12 @@ func (ts *testSuiteCore) createInventory(
 	return nil
 }
 
-func (ts *testSuiteCore) SetupSuite() {
+func (ts *definitionTestSuite) SetupSuite() {
 	require := ts.Require()
 
 	ctx := context.Background()
 
-	configPath := flag.String("config", "./testdata", "path to the configuration file")
-	flag.Parse()
-
-	cfg, err := config.ReadGlobalConfig(*configPath)
-	require.NoError(err, "failed to process the global configuration")
-
-	ts.utf = exporters.NewExporter(exporters.NewUTForwarder())
-	exporters.ConnectToProvider(ts.utf)
-
-	store.Initialize(cfg)
-
-	ts.cfg = cfg
-	ts.store = store.NewStore()
+	ts.testSuiteCore.SetupSuite()
 
 	// These values are relatively arbitrary. The only criteria is that different
 	// constants were chosen to help separate different multiples of different
@@ -410,14 +388,14 @@ func (ts *testSuiteCore) SetupSuite() {
 	require.NoError(ts.utf.Open(ts.T()))
 	require.NoError(ts.store.Connect())
 
-	err = ts.createStandardInventory(ctx)
+	err := ts.createStandardInventory(ctx)
 	require.NoError(err, "failed to create standard inventory")
 
 	ts.store.Disconnect()
 	ts.utf.Close()
 }
 
-func (ts *testSuiteCore) SetupTest() {
+func (ts *definitionTestSuite) SetupTest() {
 	require := ts.Require()
 
 	require.NoError(ts.utf.Open(ts.T()))
@@ -425,12 +403,12 @@ func (ts *testSuiteCore) SetupTest() {
 	require.NoError(ts.store.Connect())
 }
 
-func (ts *testSuiteCore) TearDownTest() {
+func (ts *definitionTestSuite) TearDownTest() {
 	ts.store.Disconnect()
 	ts.utf.Close()
 }
 
-func (ts *testSuiteCore) TestNewRoot() {
+func (ts *definitionTestSuite) TestNewRoot() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -496,7 +474,7 @@ func (ts *testSuiteCore) TestNewRoot() {
 	assert.Equal(store.RevisionInvalid, rev)
 }
 
-func (ts *testSuiteCore) TestNewRegion() {
+func (ts *definitionTestSuite) TestNewRegion() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -579,7 +557,7 @@ func (ts *testSuiteCore) TestNewRegion() {
 	// assert.Equal(store.RevisionInvalid, rev)
 }
 
-func (ts *testSuiteCore) TestNewZone() {
+func (ts *definitionTestSuite) TestNewZone() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -662,7 +640,7 @@ func (ts *testSuiteCore) TestNewZone() {
 	// assert.Equal(store.RevisionInvalid, rev)
 }
 
-func (ts *testSuiteCore) TestNewRack() {
+func (ts *definitionTestSuite) TestNewRack() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -752,7 +730,7 @@ func (ts *testSuiteCore) TestNewRack() {
 	// assert.Equal(store.RevisionInvalid, rev)
 }
 
-func (ts *testSuiteCore) TestNewPdu() {
+func (ts *definitionTestSuite) TestNewPdu() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -913,7 +891,7 @@ func (ts *testSuiteCore) TestNewPdu() {
 	// assert.Equal(store.RevisionInvalid, rev)
 }
 
-func (ts *testSuiteCore) TestNewTor() {
+func (ts *definitionTestSuite) TestNewTor() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1074,7 +1052,7 @@ func (ts *testSuiteCore) TestNewTor() {
 	// assert.Equal(store.RevisionInvalid, rev)
 }
 
-func (ts *testSuiteCore) TestNewBlade() {
+func (ts *definitionTestSuite) TestNewBlade() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1243,7 +1221,7 @@ func (ts *testSuiteCore) TestNewBlade() {
 	// assert.Equal(store.RevisionInvalid, rev)
 }
 
-func (ts *testSuiteCore) TestNewRegionWithCreate() {
+func (ts *definitionTestSuite) TestNewRegionWithCreate() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1267,7 +1245,7 @@ func (ts *testSuiteCore) TestNewRegionWithCreate() {
 	assert.Less(rev, revDel)
 }
 
-func (ts *testSuiteCore) TestNewZoneWithCreate() {
+func (ts *definitionTestSuite) TestNewZoneWithCreate() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1291,7 +1269,7 @@ func (ts *testSuiteCore) TestNewZoneWithCreate() {
 	assert.Less(rev, revDel)
 }
 
-func (ts *testSuiteCore) TestNewRackWithCreate() {
+func (ts *definitionTestSuite) TestNewRackWithCreate() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1322,7 +1300,7 @@ func (ts *testSuiteCore) TestNewRackWithCreate() {
 	assert.Less(rev, revDel)
 }
 
-func (ts *testSuiteCore) TestNewPduWithCreate() {
+func (ts *definitionTestSuite) TestNewPduWithCreate() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1356,7 +1334,7 @@ func (ts *testSuiteCore) TestNewPduWithCreate() {
 	assert.Less(rev, revDel)
 }
 
-func (ts *testSuiteCore) TestNewTorWithCreate() {
+func (ts *definitionTestSuite) TestNewTorWithCreate() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1390,7 +1368,7 @@ func (ts *testSuiteCore) TestNewTorWithCreate() {
 	assert.Less(rev, revDel)
 }
 
-func (ts *testSuiteCore) TestNewBladeWithCreate() {
+func (ts *definitionTestSuite) TestNewBladeWithCreate() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1427,7 +1405,7 @@ func (ts *testSuiteCore) TestNewBladeWithCreate() {
 	assert.Less(rev, revDel)
 }
 
-func (ts *testSuiteCore) TestRootNewChild() {
+func (ts *definitionTestSuite) TestRootNewChild() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1456,7 +1434,7 @@ func (ts *testSuiteCore) TestRootNewChild() {
 	assert.Less(rev, revDel)
 }
 
-func (ts *testSuiteCore) TestNewChildZone() {
+func (ts *definitionTestSuite) TestNewChildZone() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1487,7 +1465,7 @@ func (ts *testSuiteCore) TestNewChildZone() {
 	assert.Less(rev, revDel)
 }
 
-func (ts *testSuiteCore) TestNewChildRack() {
+func (ts *definitionTestSuite) TestNewChildRack() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1522,7 +1500,7 @@ func (ts *testSuiteCore) TestNewChildRack() {
 	assert.Less(rev, revDel)
 }
 
-func (ts *testSuiteCore) TestNewChildPdu() {
+func (ts *definitionTestSuite) TestNewChildPdu() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1562,7 +1540,7 @@ func (ts *testSuiteCore) TestNewChildPdu() {
 	assert.Less(rev, revDel)
 }
 
-func (ts *testSuiteCore) TestNewChildTor() {
+func (ts *definitionTestSuite) TestNewChildTor() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1602,7 +1580,7 @@ func (ts *testSuiteCore) TestNewChildTor() {
 	assert.Less(rev, revDel)
 }
 
-func (ts *testSuiteCore) TestNewChildBlade() {
+func (ts *definitionTestSuite) TestNewChildBlade() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1649,7 +1627,7 @@ func (ts *testSuiteCore) TestNewChildBlade() {
 	assert.Less(rev, revDel)
 }
 
-func (ts *testSuiteCore) TestRegionReadDetails() {
+func (ts *definitionTestSuite) TestRegionReadDetails() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1709,7 +1687,7 @@ func (ts *testSuiteCore) TestRegionReadDetails() {
 	assert.Less(crRev, revDel)
 }
 
-func (ts *testSuiteCore) TestZoneReadDetails() {
+func (ts *definitionTestSuite) TestZoneReadDetails() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1773,7 +1751,7 @@ func (ts *testSuiteCore) TestZoneReadDetails() {
 	assert.Less(zoneRev, revDel)
 }
 
-func (ts *testSuiteCore) TestRackReadDetails() {
+func (ts *definitionTestSuite) TestRackReadDetails() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1855,7 +1833,7 @@ func (ts *testSuiteCore) TestRackReadDetails() {
 	assert.Less(rackRev, revDel)
 }
 
-func (ts *testSuiteCore) TestPduReadDetails() {
+func (ts *definitionTestSuite) TestPduReadDetails() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -1949,7 +1927,7 @@ func (ts *testSuiteCore) TestPduReadDetails() {
 	assert.Less(pduRev, revDel)
 }
 
-func (ts *testSuiteCore) TestTorReadDetails() {
+func (ts *definitionTestSuite) TestTorReadDetails() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -2043,7 +2021,7 @@ func (ts *testSuiteCore) TestTorReadDetails() {
 	assert.Less(torRev, revDel)
 }
 
-func (ts *testSuiteCore) TestBladeReadDetails() {
+func (ts *definitionTestSuite) TestBladeReadDetails() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -2145,7 +2123,7 @@ func (ts *testSuiteCore) TestBladeReadDetails() {
 	assert.Less(bladeRev, revDel)
 }
 
-func (ts *testSuiteCore) TestRegionUpdateDetails() {
+func (ts *definitionTestSuite) TestRegionUpdateDetails() {
 
 	assert := ts.Assert()
 	require := ts.Require()
@@ -2212,7 +2190,7 @@ func (ts *testSuiteCore) TestRegionUpdateDetails() {
 
 }
 
-func (ts *testSuiteCore) TestZoneUpdateDetails() {
+func (ts *definitionTestSuite) TestZoneUpdateDetails() {
 
 	assert := ts.Assert()
 	require := ts.Require()
@@ -2282,7 +2260,7 @@ func (ts *testSuiteCore) TestZoneUpdateDetails() {
 	assert.Less(revUpdate, revDel)
 }
 
-func (ts *testSuiteCore) TestRackUpdateDetails() {
+func (ts *definitionTestSuite) TestRackUpdateDetails() {
 
 	assert := ts.Assert()
 	require := ts.Require()
@@ -2357,7 +2335,7 @@ func (ts *testSuiteCore) TestRackUpdateDetails() {
 	assert.Less(revUpdate, revDel)
 }
 
-func (ts *testSuiteCore) TestPduUpdateDetails() {
+func (ts *definitionTestSuite) TestPduUpdateDetails() {
 
 	assert := ts.Assert()
 	require := ts.Require()
@@ -2441,7 +2419,7 @@ func (ts *testSuiteCore) TestPduUpdateDetails() {
 	assert.Less(revUpdate, revDel)
 }
 
-func (ts *testSuiteCore) TestTorUpdateDetails() {
+func (ts *definitionTestSuite) TestTorUpdateDetails() {
 
 	assert := ts.Assert()
 	require := ts.Require()
@@ -2525,7 +2503,7 @@ func (ts *testSuiteCore) TestTorUpdateDetails() {
 	assert.Less(revUpdate, revDel)
 }
 
-func (ts *testSuiteCore) TestBladeUpdateDetails() {
+func (ts *definitionTestSuite) TestBladeUpdateDetails() {
 
 	assert := ts.Assert()
 	require := ts.Require()
@@ -2617,7 +2595,7 @@ func (ts *testSuiteCore) TestBladeUpdateDetails() {
 	assert.Less(revUpdate, revDel)
 }
 
-func (ts *testSuiteCore) TestRootListChildren() {
+func (ts *definitionTestSuite) TestRootListChildren() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -2631,7 +2609,7 @@ func (ts *testSuiteCore) TestRootListChildren() {
 	assert.Equal(ts.regionCount, len(regions))
 }
 
-func (ts *testSuiteCore) TestRegionListChildren() {
+func (ts *definitionTestSuite) TestRegionListChildren() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -2653,7 +2631,7 @@ func (ts *testSuiteCore) TestRegionListChildren() {
 	}
 }
 
-func (ts *testSuiteCore) TestZoneListChildren() {
+func (ts *definitionTestSuite) TestZoneListChildren() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -2683,7 +2661,7 @@ func (ts *testSuiteCore) TestZoneListChildren() {
 	}
 }
 
-func (ts *testSuiteCore) TestRackListChildren() {
+func (ts *definitionTestSuite) TestRackListChildren() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -2729,7 +2707,7 @@ func (ts *testSuiteCore) TestRackListChildren() {
 	}
 }
 
-func (ts *testSuiteCore) TestRootFetchChildren() {
+func (ts *definitionTestSuite) TestRootFetchChildren() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -2747,7 +2725,7 @@ func (ts *testSuiteCore) TestRootFetchChildren() {
 	}
 }
 
-func (ts *testSuiteCore) TestRegionFetchChildren() {
+func (ts *definitionTestSuite) TestRegionFetchChildren() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -2775,7 +2753,7 @@ func (ts *testSuiteCore) TestRegionFetchChildren() {
 	}
 }
 
-func (ts *testSuiteCore) TestZoneFetchChildren() {
+func (ts *definitionTestSuite) TestZoneFetchChildren() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -2813,7 +2791,7 @@ func (ts *testSuiteCore) TestZoneFetchChildren() {
 	}
 }
 
-func (ts *testSuiteCore) TestRackFetchChildren() {
+func (ts *definitionTestSuite) TestRackFetchChildren() {
 	assert := ts.Assert()
 	require := ts.Require()
 
@@ -2887,5 +2865,5 @@ func (ts *testSuiteCore) TestRackFetchChildren() {
 }
 
 func TestInventoryTestSuite(t *testing.T) {
-	suite.Run(t, new(testSuiteCore))
+	suite.Run(t, new(definitionTestSuite))
 }

--- a/simulation/internal/clients/inventory/reader_test.go
+++ b/simulation/internal/clients/inventory/reader_test.go
@@ -4,279 +4,264 @@ package inventory
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/spf13/viper"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
-	"github.com/Jim3Things/CloudChamber/simulation/internal/tracing/exporters"
 	pb "github.com/Jim3Things/CloudChamber/simulation/pkg/protos/inventory"
 )
 
-var (
-	utf *exporters.Exporter
-)
-
-// Common test startup method.  This is the _only_ Test* function in this
-// file.
-func TestMain(m *testing.M) {
-	commonSetup()
-
-	os.Exit(m.Run())
+type readerTestSuite struct {
+	testSuiteCore	
 }
 
-// Establish the test environment, including starting a test frontend service
-// over a faked http connection.
-func commonSetup() {
-	utf = exporters.NewExporter(exporters.NewUTForwarder())
-	exporters.ConnectToProvider(utf)
+func (ts *readerTestSuite) SetupSuite() {
+	ts.testSuiteCore.SetupSuite()
+}
+
+func (ts *readerTestSuite) SetupTest() {
+	require := ts.Require()
+
+	require.NoError(ts.utf.Open(ts.T()))
+	require.NoError(ts.store.Connect())
+
+	viper.Reset()
+}
+
+func (ts *readerTestSuite) TearDownTest() {
+	ts.store.Disconnect()
+	ts.utf.Close()
 }
 
 // first inventory definition test
 
-func TestReadInventoryDefinition(t *testing.T) {
-
-	_ = utf.Open(t)
-	defer utf.Close()
+func (ts *readerTestSuite) TestReadInventoryDefinition() {
+	assert := ts.Assert()
+	require := ts.Require()
 
 	response, err := ReadInventoryDefinition(context.Background(), "./testdata/Basic")
-	require.Nil(t, err)
+	require.Nil(err)
 
-	require.Equal(t, 2, len(response.Racks))
+	require.Equal(2, len(response.Racks))
 
 	r, ok := response.Racks["rack1"]
-	require.True(t, ok)
-	assert.Equal(t, 2, len(r.Blades))
+	require.True(ok)
+	assert.Equal(2, len(r.Blades))
 
 	b, ok := r.Blades[1]
-	require.True(t, ok)
-	assert.Equal(t, int64(16), b.Cores)
-	assert.Equal(t, int64(16834), b.MemoryInMb)
-	assert.Equal(t, int64(240), b.DiskInGb)
-	assert.Equal(t, int64(2048), b.NetworkBandwidthInMbps)
-	assert.Equal(t, "X64", b.Arch)
+	require.True(ok)
+	assert.Equal(int64(16), b.Cores)
+	assert.Equal(int64(16834), b.MemoryInMb)
+	assert.Equal(int64(240), b.DiskInGb)
+	assert.Equal(int64(2048), b.NetworkBandwidthInMbps)
+	assert.Equal("X64", b.Arch)
 
 	s, ok := response.Racks["rack2"]
-	require.True(t, ok)
-	assert.Equal(t, 2, len(s.Blades))
+	require.True(ok)
+	assert.Equal(2, len(s.Blades))
 
 	c, ok := r.Blades[2]
-	require.True(t, ok)
-	assert.Equal(t, int64(8), c.Cores)
-	assert.Equal(t, int64(16834), c.MemoryInMb)
-	assert.Equal(t, int64(120), c.DiskInGb)
-	assert.Equal(t, int64(2048), c.NetworkBandwidthInMbps)
+	require.True(ok)
+	assert.Equal(int64(8), c.Cores)
+	assert.Equal(int64(16834), c.MemoryInMb)
+	assert.Equal(int64(120), c.DiskInGb)
+	assert.Equal(int64(2048), c.NetworkBandwidthInMbps)
 }
 
-func TestReadInventoryBogusPath(t *testing.T) {
-	_ = utf.Open(t)
-	defer utf.Close()
-	viper.Reset()
+func (ts *readerTestSuite) TestReadInventoryBogusPath() {
+	assert := ts.Assert()
+	require := ts.Require()
 
 	response, err := ReadInventoryDefinition(context.Background(), "./missing/path")
-	require.NotNil(t, err)
-	assert.NotEqual(t, "%v", response)
+	require.NotNil(err)
+	assert.NotEqual("%v", response)
 }
 
 // TestInventoryUniqueRack test to check that zone always contain unique rack numbers
-func TestInventoryUniqueRack(t *testing.T) {
-
-	_ = utf.Open(t)
-	defer utf.Close()
-	viper.Reset()
+func (ts *readerTestSuite) TestInventoryUniqueRack() {
+	assert := ts.Assert()
+	require := ts.Require()
 
 	_, err := ReadInventoryDefinition(context.Background(), "./testdata/BadYaml")
-	require.NotNil(t, err)
-	assert.Equal(t, "Duplicate rack \"rack1\" detected", err.Error())
+	require.NotNil(err)
+	assert.Equal("Duplicate rack \"rack1\" detected", err.Error())
 }
 
-func TestInventoryUniqueBlade(t *testing.T) {
-
-	_ = utf.Open(t)
-	defer utf.Close()
-	viper.Reset()
+func (ts *readerTestSuite) TestInventoryUniqueBlade() {
+	assert := ts.Assert()
+	require := ts.Require()
 
 	_, err := ReadInventoryDefinition(context.Background(), "./testdata/BadYamlBlade")
-	require.NotNil(t, err)
-	assert.Equal(t, "Duplicate Blade 1 in Rack \"rack1\" detected", err.Error())
+	require.NotNil(err)
+	assert.Equal("Duplicate Blade 1 in Rack \"rack1\" detected", err.Error())
 }
 
-func TestInventoryValidateBlade(t *testing.T) {
-
-	_ = utf.Open(t)
-	defer utf.Close()
-	viper.Reset()
+func (ts *readerTestSuite) TestInventoryValidateBlade() {
+	assert := ts.Assert()
+	require := ts.Require()
 
 	_, err := ReadInventoryDefinition(context.Background(), "./testdata/BadYamlValidate")
-	require.NotNil(t, err)
-	assert.Equal(t,
-		"In rack \"rack1\": the field \"Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid",
-		err.Error())
+	require.NotNil(err)
+	assert.Equal("In rack \"rack1\": the field \"Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid",
+				 err.Error())
 }
 
-func TestReadInventoryDefinitionFromFile(t *testing.T) {
-
-	_ = utf.Open(t)
-	defer utf.Close()
-	viper.Reset()
+func (ts *readerTestSuite) TestReadInventoryDefinitionFromFile() {
+	assert := ts.Assert()
+	require := ts.Require()
 
 	zonemap, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/Basic")
-	require.NoError(t, err)
+	require.NoError(err)
 
 	// There should only be a single zone.
 	//
-	require.Equal(t, 1, len(zonemap.Zones))
+	require.Equal(1, len(zonemap.Zones))
 
 	zone, ok := zonemap.Zones[DefaultZone]
-	require.True(t, ok)
+	require.True(ok)
 
-	assert.True(t, zone.Details.Enabled)
-	assert.Equal(t, pb.State_in_service, zone.Details.State)
-	assert.Equal(t, "DC-PNW-0", zone.Details.Location)
-	assert.Equal(t, "Base zone", zone.Details.Notes)
+	assert.True(zone.Details.Enabled)
+	assert.Equal(pb.State_in_service, zone.Details.State)
+	assert.Equal("DC-PNW-0", zone.Details.Location)
+	assert.Equal("Base zone", zone.Details.Notes)
 
-	require.Equal(t, 2, len(zone.Racks))
+	require.Equal(2, len(zone.Racks))
 
 	for i := 1; i <= 2; i++ {
 
 		name := fmt.Sprintf("rack%d", i)
 
 		r, ok := zone.Racks[name]
-		require.True(t, ok)
+		require.True(ok)
 
-		assert.True(t, r.Details.Enabled)
-		assert.Equal(t, pb.Condition_operational, r.Details.Condition)
-		assert.Equal(t, "DC-PNW-0-"+name, r.Details.Location)
-		assert.Equal(t, "RackName: "+name, r.Details.Notes)
+		assert.True(r.Details.Enabled)
+		assert.Equal(pb.Condition_operational, r.Details.Condition)
+		assert.Equal("DC-PNW-0-" + name, r.Details.Location)
+		assert.Equal("RackName: " + name, r.Details.Notes)
 
-		assert.Equal(t, 1, len(r.Pdus))
-		assert.Equal(t, 1, len(r.Tors))
-		assert.Equal(t, 2, len(r.Blades))
+		assert.Equal(1, len(r.Pdus))
+		assert.Equal(1, len(r.Tors))
+		assert.Equal(2, len(r.Blades))
 
 		// There should be a single PDU at index 0
 		//
 		p0, ok := r.Pdus[0]
-		require.True(t, ok)
+		require.True(ok)
 
 		// The PDU should have a wired port for each of the two expected blades.
 		//
-		assert.Equal(t, 2, len(p0.Ports))
+		assert.Equal(2, len(p0.Ports))
 
 		p0b1, ok := p0.Ports[1]
-		require.True(t, ok)
+		require.True(ok)
 
-		assert.True(t, p0b1.Wired)
-		assert.Equal(t, pb.Hardware_blade, p0b1.Item.Type)
-		assert.Equal(t, int64(1), p0b1.Item.Id)
-		assert.Equal(t, int64(0), p0b1.Item.Port)
+		assert.True(p0b1.Wired)
+		assert.Equal(pb.Hardware_blade, p0b1.Item.Type)
+		assert.Equal(int64(1), p0b1.Item.Id)
+		assert.Equal(int64(0), p0b1.Item.Port)
 
 		p0b2, ok := p0.Ports[2]
-		require.True(t, ok)
+		require.True(ok)
 
-		assert.True(t, p0b2.Wired)
-		assert.Equal(t, pb.Hardware_blade, p0b2.Item.Type)
-		assert.Equal(t, int64(2), p0b2.Item.Id)
-		assert.Equal(t, int64(0), p0b2.Item.Port)
+		assert.True(p0b2.Wired)
+		assert.Equal(pb.Hardware_blade, p0b2.Item.Type)
+		assert.Equal(int64(2), p0b2.Item.Id)
+		assert.Equal(int64(0), p0b2.Item.Port)
 
 		// There should be a single TOR at index 0
 		//
 		t0, ok := r.Tors[0]
-		require.True(t, ok)
+		require.True(ok)
 
 		// The TOR should have a wired port for each of the two expected blades.
 		//
-		assert.Equal(t, 2, len(t0.Ports))
+		assert.Equal(2, len(t0.Ports))
 
 		t0b1, ok := t0.Ports[1]
-		require.True(t, ok)
+		require.True(ok)
 
-		assert.True(t, t0b1.Wired)
-		assert.Equal(t, pb.Hardware_blade, t0b1.Item.Type)
-		assert.Equal(t, int64(1), t0b1.Item.Id)
-		assert.Equal(t, int64(0), t0b1.Item.Port)
+		assert.True(t0b1.Wired)
+		assert.Equal(pb.Hardware_blade, t0b1.Item.Type)
+		assert.Equal(int64(1), t0b1.Item.Id)
+		assert.Equal(int64(0), t0b1.Item.Port)
 
 		t0b2, ok := p0.Ports[2]
-		require.True(t, ok)
+		require.True(ok)
 
-		assert.True(t, t0b2.Wired)
-		assert.Equal(t, pb.Hardware_blade, t0b2.Item.Type)
-		assert.Equal(t, int64(2), t0b2.Item.Id)
-		assert.Equal(t, int64(0), t0b2.Item.Port)
+		assert.True(t0b2.Wired)
+		assert.Equal(pb.Hardware_blade, t0b2.Item.Type)
+		assert.Equal(int64(2), t0b2.Item.Id)
+		assert.Equal(int64(0), t0b2.Item.Port)
 
 		// There should be exactly two blades at indices 1 and 2.
 		//
 		b1, ok := r.Blades[1]
-		require.True(t, ok)
+		require.True(ok)
 
-		assert.True(t, b1.Details.Enabled)
-		assert.Equal(t, pb.Condition_operational, b1.Details.Condition)
+		assert.True(b1.Details.Enabled)
+		assert.Equal(pb.Condition_operational, b1.Details.Condition)
 
-		assert.Equal(t, int64(16), b1.Capacity.Cores)
-		assert.Equal(t, int64(16834), b1.Capacity.MemoryInMb)
-		assert.Equal(t, int64(240), b1.Capacity.DiskInGb)
-		assert.Equal(t, int64(2048), b1.Capacity.NetworkBandwidthInMbps)
-		assert.Equal(t, "X64", b1.Capacity.Arch)
+		assert.Equal(int64(16),    b1.Capacity.Cores)
+		assert.Equal(int64(16834), b1.Capacity.MemoryInMb)
+		assert.Equal(int64(240),   b1.Capacity.DiskInGb)
+		assert.Equal(int64(2048),  b1.Capacity.NetworkBandwidthInMbps)
+		assert.Equal("X64",        b1.Capacity.Arch)
 
 		b2, ok := r.Blades[2]
-		require.True(t, ok)
+		require.True(ok)
 
-		assert.True(t, b2.Details.Enabled)
-		assert.Equal(t, pb.Condition_operational, b2.Details.Condition)
+		assert.True(b2.Details.Enabled)
+		assert.Equal(pb.Condition_operational, b2.Details.Condition)
 
-		assert.Equal(t, int64(8), b2.Capacity.Cores)
-		assert.Equal(t, int64(16834), b2.Capacity.MemoryInMb)
-		assert.Equal(t, int64(120), b2.Capacity.DiskInGb)
-		assert.Equal(t, int64(2048), b2.Capacity.NetworkBandwidthInMbps)
-		assert.Equal(t, "X64", b2.Capacity.Arch)
+		assert.Equal(int64(8),     b2.Capacity.Cores)
+		assert.Equal(int64(16834), b2.Capacity.MemoryInMb)
+		assert.Equal(int64(120),   b2.Capacity.DiskInGb)
+		assert.Equal(int64(2048),  b2.Capacity.NetworkBandwidthInMbps)
+		assert.Equal("X64",        b2.Capacity.Arch)
 	}
 }
 
-func TestReadInventoryDefinitionFromFileBogusPath(t *testing.T) {
-	_ = utf.Open(t)
-	defer utf.Close()
-	viper.Reset()
+func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileBogusPath() {
+	assert := ts.Assert()
+	require := ts.Require()
 
 	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./missing/path")
-	require.Error(t, err)
-	assert.NotEqual(t, "%v", response)
+	require.Error(err)
+	assert.NotEqual("%v", response)
 }
 
 // TestInventoryUniqueRack test to check that zone always contain unique rack numbers
 //
-func TestIReadInventoryDefinitionFromFileUniqueRack(t *testing.T) {
-
-	_ = utf.Open(t)
-	defer utf.Close()
-	viper.Reset()
+func (ts *readerTestSuite) TestIReadInventoryDefinitionFromFileUniqueRack() {
+	assert := ts.Assert()
+	require := ts.Require()
 
 	_, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYaml")
-	require.Error(t, err)
-	assert.Equal(t, "Duplicate rack \"rack1\" detected", err.Error())
+	require.Error(err)
+	assert.Equal("Duplicate rack \"rack1\" detected", err.Error())
 }
 
-func TestReadInventoryDefinitionFromFileUniqueBlade(t *testing.T) {
-
-	_ = utf.Open(t)
-	defer utf.Close()
-	viper.Reset()
+func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileUniqueBlade() {
+	assert := ts.Assert()
+	require := ts.Require()
 
 	_, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYamlBlade")
-	require.Error(t, err)
-	assert.Equal(t, "Duplicate Blade 1 in Rack \"rack1\" detected", err.Error())
+	require.Error(err)
+	assert.Equal("Duplicate Blade 1 in Rack \"rack1\" detected", err.Error())
 }
 
-func TestReadInventoryDefinitionFromFileValidateBlade(t *testing.T) {
-
-	_ = utf.Open(t)
-	defer utf.Close()
-	viper.Reset()
+func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileValidateBlade() {
+	assert := ts.Assert()
+	require := ts.Require()
 
 	_, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYamlValidate")
-	require.Error(t, err)
-	assert.Equal(t,
-		"In rack \"rack1\": the field \"Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid",
-		err.Error())
+	require.Error(err)
+	assert.Equal("In rack \"rack1\": the field \"Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid",
+			err.Error())
+}
+
+func TestReaderTestSuite(t *testing.T) {
+	suite.Run(t, new(readerTestSuite))
 }

--- a/simulation/internal/clients/inventory/reader_test.go
+++ b/simulation/internal/clients/inventory/reader_test.go
@@ -42,7 +42,8 @@ func (ts *readerTestSuite) TestReadInventoryDefinition() {
 	require := ts.Require()
 
 	response, err := ReadInventoryDefinition(context.Background(), "./testdata/Basic")
-	require.Nil(err)
+	require.NoError(err)
+	require.NotNil(response)
 
 	require.Equal(2, len(response.Racks))
 
@@ -71,41 +72,36 @@ func (ts *readerTestSuite) TestReadInventoryDefinition() {
 }
 
 func (ts *readerTestSuite) TestReadInventoryBogusPath() {
-	assert := ts.Assert()
 	require := ts.Require()
 
 	response, err := ReadInventoryDefinition(context.Background(), "./missing/path")
-	require.NotNil(err)
-	assert.NotEqual("%v", response)
+	require.EqualError(err, "no inventory definition found at ./missing/path/inventory.yaml (yaml)")
+	require.Nil(response)
 }
 
 // TestInventoryUniqueRack test to check that zone always contain unique rack numbers
 func (ts *readerTestSuite) TestInventoryUniqueRack() {
-	assert := ts.Assert()
 	require := ts.Require()
 
-	_, err := ReadInventoryDefinition(context.Background(), "./testdata/BadYaml")
-	require.NotNil(err)
-	assert.Equal("Duplicate rack \"rack1\" detected", err.Error())
+	response, err := ReadInventoryDefinition(context.Background(), "./testdata/BadYaml")
+	require.EqualError(err, "Duplicate rack \"rack1\" detected")
+	require.Nil(response)
 }
 
 func (ts *readerTestSuite) TestInventoryUniqueBlade() {
-	assert := ts.Assert()
 	require := ts.Require()
 
-	_, err := ReadInventoryDefinition(context.Background(), "./testdata/BadYamlBlade")
-	require.NotNil(err)
-	assert.Equal("Duplicate Blade 1 in Rack \"rack1\" detected", err.Error())
+	response, err := ReadInventoryDefinition(context.Background(), "./testdata/BadYamlBlade")
+	require.EqualError(err, "Duplicate Blade 1 in Rack \"rack1\" detected")
+	require.Nil(response)
 }
 
 func (ts *readerTestSuite) TestInventoryValidateBlade() {
-	assert := ts.Assert()
 	require := ts.Require()
 
-	_, err := ReadInventoryDefinition(context.Background(), "./testdata/BadYamlValidate")
-	require.NotNil(err)
-	assert.Equal("In rack \"rack1\": the field \"Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid",
-				 err.Error())
+	response, err := ReadInventoryDefinition(context.Background(), "./testdata/BadYamlValidate")
+	require.EqualError(err, "In rack \"rack1\": the field \"Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid")
+	require.Nil(response)
 }
 
 func (ts *readerTestSuite) TestReadInventoryDefinitionFromFile() {
@@ -114,6 +110,7 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFile() {
 
 	zonemap, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/Basic")
 	require.NoError(err)
+	require.NotNil(zonemap)
 
 	// There should only be a single zone.
 	//
@@ -224,42 +221,37 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFile() {
 }
 
 func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileBogusPath() {
-	assert := ts.Assert()
 	require := ts.Require()
 
 	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./missing/path")
-	require.Error(err)
-	assert.NotEqual("%v", response)
+	require.EqualError(err, "no inventory definition found at ./missing/path/inventory.yaml (yaml)")
+	require.Nil(response)
 }
 
 // TestInventoryUniqueRack test to check that zone always contain unique rack numbers
 //
 func (ts *readerTestSuite) TestIReadInventoryDefinitionFromFileUniqueRack() {
-	assert := ts.Assert()
 	require := ts.Require()
 
-	_, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYaml")
-	require.Error(err)
-	assert.Equal("Duplicate rack \"rack1\" detected", err.Error())
+	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYaml")
+	require.EqualError(err, "Duplicate rack \"rack1\" detected")
+	require.Nil(response)
 }
 
 func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileUniqueBlade() {
-	assert := ts.Assert()
 	require := ts.Require()
 
-	_, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYamlBlade")
-	require.Error(err)
-	assert.Equal("Duplicate Blade 1 in Rack \"rack1\" detected", err.Error())
+	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYamlBlade")
+	require.EqualError(err, "Duplicate Blade 1 in Rack \"rack1\" detected")
+	require.Nil(response)
 }
 
 func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileValidateBlade() {
-	assert := ts.Assert()
 	require := ts.Require()
 
-	_, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYamlValidate")
-	require.Error(err)
-	assert.Equal("In rack \"rack1\": the field \"Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid",
-			err.Error())
+	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYamlValidate")
+	require.EqualError(err, "In rack \"rack1\": the field \"Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid")
+	require.Nil(response)
 }
 
 func TestReaderTestSuite(t *testing.T) {


### PR DESCRIPTION
In preparation for additional tests, convert inventory definitions tests to be based on the testify package, as are the existing reader tests.

Requires moving to a common core test suite to allow each sub-package (reader, definition) to make use of the same common test setup core. 

Since the flag package must only parse flags exactly once to avoid issues, need to separate the flag parsing into a guaranteed run at most once section.
