### PR TITLE
Add ability to read inventory definition using an extended syntax

### DIFF
--- a/simulation/internal/clients/inventory/reader.go
+++ b/simulation/internal/clients/inventory/reader.go
@@ -559,7 +559,7 @@ func toDefinitionRoot(xfrRoot *rootEx) (*pb.Definition_Root, error) {
 			Name: xfrRoot.Details.Name,
 			Notes: xfrRoot.Details.Notes,
 		},
-		Regions: make(map[string]*pb.Definition_Region),
+		Regions: make(map[string]*pb.Definition_Region, len(xfrRoot.Regions)),
 	}
 
 	// For each rack in the supplied configuration, create rack in the
@@ -573,10 +573,10 @@ func toDefinitionRoot(xfrRoot *rootEx) (*pb.Definition_Root, error) {
 			}
 		}
 		var (
-			ok		   bool
+			ok         bool
 			state      pb.State
 			condition  pb.Condition
-			hwType	   pb.Hardware_HwType
+			hwType     pb.Hardware_HwType
 			bootSource pb.BladeBootInfo_Method
 		)
 
@@ -595,7 +595,7 @@ func toDefinitionRoot(xfrRoot *rootEx) (*pb.Definition_Root, error) {
 				Location: xfrRegion.Details.Location,
 				Notes:    xfrRegion.Details.Notes,
 			},
-			Zones:   make(map[string]*pb.Definition_Zone),
+			Zones:   make(map[string]*pb.Definition_Zone, len(xfrRegion.Zones)),
 		}
 	
 		// Iterate over the set of zones in the supplied configuration
@@ -626,7 +626,7 @@ func toDefinitionRoot(xfrRoot *rootEx) (*pb.Definition_Root, error) {
 					Location: xfrZone.Details.Location,
 					Notes:    xfrZone.Details.Notes,
 				},
-				Racks: make(map[string]*pb.Definition_Rack),
+				Racks: make(map[string]*pb.Definition_Rack, len(xfrZone.Racks)),
 			}
 
 			// Iterate over the set of racks in the supplied configuration
@@ -659,9 +659,9 @@ func toDefinitionRoot(xfrRoot *rootEx) (*pb.Definition_Root, error) {
 						Location:  xfrRack.Details.Location,
 						Notes:     xfrRack.Details.Notes,
 					},
-					Pdus:   make(map[int64]*pb.Definition_Pdu),
-					Tors:   make(map[int64]*pb.Definition_Tor),
-					Blades: make(map[int64]*pb.Definition_Blade),
+					Pdus:   make(map[int64]*pb.Definition_Pdu, len(xfrRack.Pdus)),
+					Tors:   make(map[int64]*pb.Definition_Tor, len(xfrRack.Tors)),
+					Blades: make(map[int64]*pb.Definition_Blade, len(xfrRack.Blades)),
 				}
 
 				// A rack contains sub-components for Pdus, Tors and Blades with
@@ -699,7 +699,7 @@ func toDefinitionRoot(xfrRoot *rootEx) (*pb.Definition_Root, error) {
 							Condition: condition,
 							Enabled:   xfrPdu.Details.Enabled,
 						},
-						Ports: make(map[int64]*pb.PowerPort),
+						Ports: make(map[int64]*pb.PowerPort, len(xfrPdu.Ports)),
 					}
 
 					// Iterate over the set of power ports in the supplied
@@ -779,7 +779,7 @@ func toDefinitionRoot(xfrRoot *rootEx) (*pb.Definition_Root, error) {
 							Condition: condition,
 							Enabled:   xfrTor.Details.Enabled,
 						},
-						Ports: make(map[int64]*pb.NetworkPort),
+						Ports: make(map[int64]*pb.NetworkPort, len(xfrTor.Ports)),
 					}
 
 					// Iterate over the set of network ports in the supplied
@@ -906,9 +906,9 @@ func toDefinitionRoot(xfrRoot *rootEx) (*pb.Definition_Root, error) {
 			return nil, errors.ErrRegionValidationFailure{
 				Region: xfrRegion.Name,
 				Err:  err,
+			}
 		}
 	}
-}
 
 	return root, nil
 }

--- a/simulation/internal/clients/inventory/reader.go
+++ b/simulation/internal/clients/inventory/reader.go
@@ -5,6 +5,7 @@ package inventory
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/viper"
 
@@ -48,6 +49,118 @@ type tor struct {
 }
 
 type pdu struct {
+}
+
+type rootEx struct {
+	Details rootExDetails
+	Regions []regionEx
+}
+
+type rootExDetails struct {
+	Name  string
+	Notes string
+}
+
+type regionEx struct {
+	Name    string
+	Details regionExDetails
+	Zones   []zoneEx	
+}
+
+type regionExDetails struct {
+	State    string
+	Location string
+	Notes    string
+}
+
+type zoneEx struct {
+	Name    string
+	Details zoneExDetails
+	Racks   []rackEx
+}
+
+type zoneExDetails struct {
+	Enabled  bool
+	State    string
+	Location string
+	Notes    string
+}
+
+type rackEx struct {
+	Name    string
+	Details rackExDetails
+	Pdus    []pduEx
+	Tors    []torEx
+	Blades  []bladeEx
+}
+
+type rackExDetails struct {
+	Enabled   bool
+	Condition string
+	Location  string
+	Notes     string
+}
+
+type portEx struct {
+	Index int64
+	Wired bool
+	Item  portExTarget
+}
+
+type portExTarget struct {
+	Type string
+	ID   int64
+	Port int64
+}
+
+type pduEx struct {
+	Index   int64
+	Details pduExDetails
+	Ports   []portEx
+}
+
+type pduExDetails struct {
+	Enabled  bool
+	Condition string	
+}
+
+type torEx struct {
+	Index   int64
+	Details pduExDetails
+	Ports   []portEx
+}
+
+type torExDetails struct {
+	Enabled  bool
+	Condition string	
+}
+
+type bladeEx struct {
+	Index         int64
+	Details       bladeExDetails
+	Capacity      bladeExCapacity
+	BootInfo      bladeExBootinfo
+	BootOnPowerOn bool
+}
+
+type bladeExDetails struct {
+	Enabled  bool
+	Condition string	
+}
+
+type bladeExCapacity struct {
+	Arch                   string
+	Cores                  int64
+	DiskInGb               int64
+	MemoryInMb             int64
+	NetworkBandwidthInMbps int64
+}
+
+type bladeExBootinfo struct {
+	Source     string
+	Image      string
+	Version    string
+	Parameters string
 }
 
 // --- Intermediate binary format
@@ -333,4 +446,469 @@ func toDefinitionRegionInternal(xfr *zone) (*pb.Definition_Region, error) {
 	region.Zones[DefaultZone] = zone
 
 	return region, nil
+}
+
+// ReadInventoryDefinitionFromFileEx imports the inventory from
+// an external YAML file and transforms it into the
+// internal Cloud chamber binary format.
+//
+func ReadInventoryDefinitionFromFileEx(ctx context.Context, path string) (*pb.Definition_Root, error) {
+	ctx, span := tracing.StartSpan(ctx,
+		tracing.WithName("Read inventory definition from file"),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
+		tracing.AsInternal())
+	defer span.End()
+
+	viper.SetConfigName(defaultDefinitionFile)
+	viper.AddConfigPath(path)
+	viper.SetConfigType(defaultConfigType)
+
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			err = fmt.Errorf("no inventory definition found at %s/%s (%s)",
+				path,
+				defaultDefinitionFile,
+				defaultConfigType)
+		} else {
+			err = fmt.Errorf("fatal error reading definition file: %s", err)
+		}
+
+		return nil, tracing.Error(ctx, err)
+	}
+
+	// First we are going to put it into intermediate format
+	xfr := &rootEx{}
+	if err := viper.UnmarshalExact(xfr); err != nil {
+		return nil, tracing.Error(ctx, "unable to decode into struct, %v", err)
+	}
+
+	// Now convert it into its final form
+	root, err := toDefinitionRoot(xfr)
+	if err != nil {
+		return nil, tracing.Error(ctx, err)
+	}
+
+	tracing.Info(ctx, "Inventory definition Read: \n%v", root)
+
+	return root, nil
+}
+
+var conditionmMap = map[string]pb.Condition{
+	"not_in_service": pb.Condition_not_in_service,
+    "operational":    pb.Condition_operational,
+    "burn_in":        pb.Condition_burn_in,
+    "out_for_repair": pb.Condition_out_for_repair,
+    "retiring":       pb.Condition_retiring,
+    "retired":        pb.Condition_retired,
+}
+
+var stateMap = map[string]pb.State{
+	"out_of_service":  pb.State_out_of_service,
+	"in_service":      pb.State_in_service,
+	"commissioning":   pb.State_commissioning,
+	"assumed_failed":  pb.State_assumed_failed,
+	"decommissioning": pb.State_decommissioning,
+	"decommissioned":  pb.State_decommissioned,
+}
+
+func getConditionFromString(c string) (pb.Condition, bool) {
+	cond, ok := conditionmMap[strings.ToLower(c)]
+
+	return cond, ok
+}
+
+func getStateFromString(s string) (pb.State, bool) {
+	state, ok := stateMap[strings.ToLower(s)]
+
+	return state, ok
+}
+
+var methodMap = map[string]pb.BladeBootInfo_Method{
+	"local": pb.BladeBootInfo_local,
+	"network": pb.BladeBootInfo_network,
+}
+
+func getBootMethodFromString(s string) (pb.BladeBootInfo_Method, bool) {
+	method, ok := methodMap[strings.ToLower(s)]
+
+	return method, ok
+}
+
+var hwTypeMap = map[string]pb.Hardware_HwType{
+	"unknown": pb.Hardware_unknown,
+	"pdu": 	   pb.Hardware_pdu,
+	"tor":     pb.Hardware_tor,
+	"blade":   pb.Hardware_blade,
+}
+
+func getHwTypeFromString(t string) (pb.Hardware_HwType, bool) {
+	hwType, ok := hwTypeMap[strings.ToLower(t)]
+
+	return hwType, ok
+}
+
+// toDefinitionRoot converts intermediate values to the final format
+// One important difference is that the intermediate is array based.
+// The final format is map based using specific fields in array
+// entries as the map keys
+//
+func toDefinitionRoot(xfrRoot *rootEx) (*pb.Definition_Root, error) {
+
+	root := &pb.Definition_Root{
+		Details: &pb.RootDetails{
+			Name: xfrRoot.Details.Name,
+			Notes: xfrRoot.Details.Notes,
+		},
+		Regions: make(map[string]*pb.Definition_Region),
+	}
+
+	// For each rack in the supplied configuration, create rack in the
+	// zone. Each rack has some details, a set of PDUs, a set of TORs,
+	// and a set of blades.
+	//
+	for _, xfrRegion := range xfrRoot.Regions {
+		if _, ok := root.Regions[xfrRegion.Name]; ok {
+			return nil, errors.ErrConfigRegionDuplicate{
+				Region: xfrRegion.Name,
+			}
+		}
+		var (
+			ok		   bool
+			state      pb.State
+			condition  pb.Condition
+			hwType	   pb.Hardware_HwType
+			bootSource pb.BladeBootInfo_Method
+		)
+
+		// Create a region and populate it from the supplied configuration
+		//
+		if state, ok = getStateFromString(xfrRegion.Details.State); !ok {
+			return nil, errors.ErrConfigRegionBadState{
+				Region: xfrRegion.Name,
+				State:  xfrRegion.Details.State,
+			}
+		}
+
+		region := &pb.Definition_Region{
+			Details: &pb.RegionDetails{
+				State:    state,
+				Location: xfrRegion.Details.Location,
+				Notes:    xfrRegion.Details.Notes,
+			},
+			Zones:   make(map[string]*pb.Definition_Zone),
+		}
+	
+		// Iterate over the set of zones in the supplied configuration
+		// and add an entry in the internal structs for that zone.
+		//
+		for _, xfrZone := range xfrRegion.Zones {
+			if _, ok = region.Zones[xfrZone.Name]; ok {
+				return nil, errors.ErrConfigZoneDuplicate{
+					Region: xfrRegion.Name,
+					Zone:   xfrZone.Name,
+				}
+			}
+
+			// Create a zone and populate it from the supplied configuration
+			//
+			if state, ok = getStateFromString(xfrZone.Details.State); !ok {
+				return nil, errors.ErrConfigZoneBadState{
+					Region: xfrRegion.Name,
+					Zone:   xfrZone.Name,
+					State:  xfrZone.Details.State,
+				}
+			}
+
+			zone := &pb.Definition_Zone{
+				Details: &pb.ZoneDetails{
+					State:    state,
+					Enabled:  xfrZone.Details.Enabled,
+					Location: xfrZone.Details.Location,
+					Notes:    xfrZone.Details.Notes,
+				},
+				Racks: make(map[string]*pb.Definition_Rack),
+			}
+
+			// Iterate over the set of racks in the supplied configuration
+			// and add an entry in the internal structs for that rack.
+			//
+			for _, xfrRack := range xfrZone.Racks {
+				if _, ok := zone.Racks[xfrRack.Name]; ok {
+					return nil, errors.ErrConfigRackDuplicate{
+						Region: xfrRegion.Name,
+						Zone:   xfrZone.Name,
+						Rack:   xfrRack.Name,
+					}
+				}
+
+				// Create a rack and populate it from the supplied configuration
+				//
+				if condition, ok = getConditionFromString(xfrRack.Details.Condition); !ok {
+					return nil, errors.ErrConfigRackBadCondition{
+						Region:    xfrRegion.Name,
+						Zone:      xfrZone.Name,
+						Rack:      xfrRack.Name,
+						Condition: xfrRack.Details.Condition,
+					}
+				}
+
+				rack := &pb.Definition_Rack{
+					Details: &pb.RackDetails{
+						Condition: condition,
+						Enabled:   xfrRack.Details.Enabled,
+						Location:  xfrRack.Details.Location,
+						Notes:     xfrRack.Details.Notes,
+					},
+					Pdus:   make(map[int64]*pb.Definition_Pdu),
+					Tors:   make(map[int64]*pb.Definition_Tor),
+					Blades: make(map[int64]*pb.Definition_Blade),
+				}
+
+				// A rack contains sub-components for Pdus, Tors and Blades with
+				// it being possible to have multiple instances of each.
+				//
+				// Step 1 - Iterate over the set of pdus in the supplied
+				// configuration and add an entry in the internal structs
+				// for that pdu.
+				//
+				for _, xfrPdu := range xfrRack.Pdus {
+
+					if _, ok := rack.Pdus[xfrPdu.Index]; ok {
+						return nil, errors.ErrConfigPduDuplicate{
+							Region:    xfrRegion.Name,
+							Zone:      xfrZone.Name,
+							Rack:      xfrRack.Name,
+							Pdu:       xfrPdu.Index,
+						}
+					}
+
+					// Create a pdu and populate it from the supplied configuration
+					//
+					if condition, ok = getConditionFromString(xfrPdu.Details.Condition); !ok {
+						return nil, errors.ErrConfigPduBadCondition{
+							Region:    xfrRegion.Name,
+							Zone:      xfrZone.Name,
+							Rack:      xfrRack.Name,
+							Pdu:       xfrPdu.Index,
+							Condition: xfrPdu.Details.Condition,
+						}
+					}
+
+					pdu := &pb.Definition_Pdu{
+						Details: &pb.PduDetails{
+							Condition: condition,
+							Enabled:   xfrPdu.Details.Enabled,
+						},
+						Ports: make(map[int64]*pb.PowerPort),
+					}
+
+					// Iterate over the set of power ports in the supplied
+					// configuration and add an entry in the internal structs
+					// for that port.
+					//
+					for _, xfrPort := range xfrPdu.Ports {
+
+						if _, ok := pdu.Ports[xfrPort.Index]; ok {
+							return nil, errors.ErrConfigPowerPortDuplicate{
+								Region: xfrRegion.Name,
+								Zone:   xfrZone.Name,
+								Rack:   xfrRack.Name,
+								Pdu:    xfrPdu.Index,
+								Port:	xfrPort.Index,
+							}
+						}
+
+						// Create a power port and populate it from the supplied
+						// configuration
+						//
+						if hwType, ok = getHwTypeFromString(xfrPort.Item.Type); !ok {
+							return nil, errors.ErrConfigPduHwTypeInvalid{
+								Region: xfrRegion.Name,
+								Zone:   xfrZone.Name,
+								Rack:   xfrRack.Name,
+								Pdu:    xfrPdu.Index,
+								Port:   xfrPort.Index,
+								Type:	xfrPort.Item.Type,
+							}
+						}
+
+						// Create a power port and populate it from the supplied configuration
+						//
+						pdu.Ports[xfrPort.Index] = &pb.PowerPort{
+							Wired: xfrPort.Wired,
+							Item: &pb.Hardware{
+								Type: hwType,
+								Id:   xfrPort.Item.ID,
+								Port: xfrPort.Item.Port,
+							},
+						}
+					}
+
+					rack.Pdus[xfrPdu.Index] = pdu
+				}
+
+				// Step 2 - Iterate over the set of tors in the supplied
+				// configuration and add an entry in the internal structs
+				// for that tor.
+				//
+				for _, xfrTor := range xfrRack.Tors {
+
+					if _, ok := rack.Tors[xfrTor.Index]; ok {
+						return nil, errors.ErrConfigTorDuplicate{
+							Region:    xfrRegion.Name,
+							Zone:      xfrZone.Name,
+							Rack:      xfrRack.Name,
+							Tor:       xfrTor.Index,
+						}
+					}
+
+					// Create a pdu and populate it from the supplied configuration
+					//
+					if condition, ok = getConditionFromString(xfrTor.Details.Condition); !ok {
+						return nil, errors.ErrConfigTorBadCondition{
+							Region:    xfrRegion.Name,
+							Zone:      xfrZone.Name,
+							Rack:      xfrRack.Name,
+							Tor:       xfrTor.Index,
+							Condition: xfrTor.Details.Condition,
+						}
+					}
+
+					tor := &pb.Definition_Tor{
+						Details: &pb.TorDetails{
+							Condition: condition,
+							Enabled:   xfrTor.Details.Enabled,
+						},
+						Ports: make(map[int64]*pb.NetworkPort),
+					}
+
+					// Iterate over the set of network ports in the supplied
+					// configuration and add an entry in the internal structs
+					// for that port.
+					//
+					for _, xfrPort := range xfrTor.Ports {
+
+						if _, ok := tor.Ports[xfrPort.Index]; ok {
+							return nil, errors.ErrConfigNetworkPortDuplicate{
+								Region: xfrRegion.Name,
+								Zone:   xfrZone.Name,
+								Rack:   xfrRack.Name,
+								Tor:    xfrTor.Index,
+								Port:	xfrPort.Index,
+							}
+						}
+
+						// Create a power port and populate it from the supplied
+						// configuration
+						//
+						if hwType, ok = getHwTypeFromString(xfrPort.Item.Type); !ok {
+							return nil, errors.ErrConfigTorHwTypeInvalid{
+								Region: xfrRegion.Name,
+								Zone:   xfrZone.Name,
+								Rack:   xfrRack.Name,
+								Tor:    xfrTor.Index,
+								Port:   xfrPort.Index,
+								Type:	xfrPort.Item.Type,
+							}
+						}
+
+						// Create a power port and populate it from the supplied configuration
+						//
+						tor.Ports[xfrPort.Index] = &pb.NetworkPort{
+							Wired: xfrPort.Wired,
+							Item: &pb.Hardware{
+								Type: hwType,
+								Id:   xfrPort.Item.ID,
+								Port: xfrPort.Item.Port,
+							},
+						}
+					}
+
+					rack.Tors[xfrTor.Index] = tor
+				}
+
+				// Step 3 - Iterate over the set of blades in the supplied
+				// configuration and add an entry in the internal structs
+				// for that blade.
+				//
+				for _, xfrBlade := range xfrRack.Blades {
+
+					// If we already have a blade definition at the index
+					// for the blade, it MUST be a duplicate, which we do
+					// not allow, so fail describing where we found the
+					// issue.
+					//
+					if _, ok := rack.Blades[xfrBlade.Index]; ok {
+						return nil, errors.ErrConfigBladeDuplicate{
+							Region: xfrRegion.Name,
+							Zone:   xfrZone.Name,
+							Rack:   xfrRack.Name,
+							Blade:  xfrBlade.Index,
+						}
+					}
+
+					// Create a blade and populate it from the supplied
+					// configuration
+					//
+					if condition, ok = getConditionFromString(xfrBlade.Details.Condition); !ok {
+						return nil, errors.ErrConfigBladeBadCondition{
+							Region:    xfrRegion.Name,
+							Zone:      xfrZone.Name,
+							Rack:      xfrRack.Name,
+							Blade:     xfrBlade.Index,
+							Condition: xfrBlade.Details.Condition,
+						}
+					}
+
+					if bootSource, ok = getBootMethodFromString(xfrBlade.BootInfo.Source); !ok {
+						return nil, errors.ErrConfigBladeBadBootSource{
+							Region:     xfrRegion.Name,
+							Zone:       xfrZone.Name,
+							Rack:       xfrRack.Name,
+							Blade:      xfrBlade.Index,
+							BootSource: xfrBlade.BootInfo.Source,
+						}
+					}
+
+					blade := &pb.Definition_Blade{
+						Details: &pb.BladeDetails{
+							Condition: condition,
+							Enabled:   xfrBlade.Details.Enabled,
+						},
+						Capacity: &pb.BladeCapacity{
+							Cores:                  xfrBlade.Capacity.Cores,
+							MemoryInMb:             xfrBlade.Capacity.MemoryInMb,
+							DiskInGb:               xfrBlade.Capacity.DiskInGb,
+							NetworkBandwidthInMbps: xfrBlade.Capacity.NetworkBandwidthInMbps,
+							Arch:                   xfrBlade.Capacity.Arch,
+						},
+						BootInfo: &pb.BladeBootInfo{
+							Source: bootSource,
+							Image: xfrBlade.BootInfo.Image,
+							Version: xfrBlade.BootInfo.Version,
+							Parameters: xfrBlade.BootInfo.Parameters,
+						},
+						BootOnPowerOn: xfrBlade.BootOnPowerOn,
+					}
+
+					rack.Blades[xfrBlade.Index] = blade
+				}
+
+				zone.Racks[xfrRack.Name] = rack
+			}
+
+			region.Zones[xfrZone.Name] = zone
+		}
+
+		root.Regions[xfrRegion.Name] = region
+
+		if err := region.Validate(""); err != nil {
+			return nil, errors.ErrRegionValidationFailure{
+				Region: xfrRegion.Name,
+				Err:  err,
+		}
+	}
+}
+
+	return root, nil
 }

--- a/simulation/internal/clients/inventory/reader_test.go
+++ b/simulation/internal/clients/inventory/reader_test.go
@@ -433,30 +433,6 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionExtended() {
 			}
 		}
 	}
-	// require.Equal(2, len(response.Racks))
-
-	// r, ok := response.Racks["rack1"]
-	// require.True(ok)
-	// assert.Equal(2, len(r.Blades))
-
-	// b, ok := r.Blades[1]
-	// require.True(ok)
-	// assert.Equal(int64(16), b.Cores)
-	// assert.Equal(int64(16834), b.MemoryInMb)
-	// assert.Equal(int64(240), b.DiskInGb)
-	// assert.Equal(int64(2048), b.NetworkBandwidthInMbps)
-	// assert.Equal("X64", b.Arch)
-
-	// s, ok := response.Racks["rack2"]
-	// require.True(ok)
-	// assert.Equal(2, len(s.Blades))
-
-	// c, ok := r.Blades[2]
-	// require.True(ok)
-	// assert.Equal(int64(8), c.Cores)
-	// assert.Equal(int64(16834), c.MemoryInMb)
-	// assert.Equal(int64(120), c.DiskInGb)
-	// assert.Equal(int64(2048), c.NetworkBandwidthInMbps)
 }
 
 func TestReaderTestSuite(t *testing.T) {

--- a/simulation/internal/clients/inventory/reader_test.go
+++ b/simulation/internal/clients/inventory/reader_test.go
@@ -250,7 +250,7 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileValidateBlade() {
 	require := ts.Require()
 
 	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYamlValidate")
-	require.EqualError(err, "In rack \"rack1\": the field \"Blade[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid")
+	require.EqualError(err, "In rack \"rack1\": the field \"Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid")
 	require.Nil(response)
 }
 

--- a/simulation/internal/clients/inventory/reader_test.go
+++ b/simulation/internal/clients/inventory/reader_test.go
@@ -250,8 +250,213 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileValidateBlade() {
 	require := ts.Require()
 
 	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYamlValidate")
-	require.EqualError(err, "In rack \"rack1\": the field \"Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid")
+	require.EqualError(err, "In rack \"rack1\": the field \"Blade[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid")
 	require.Nil(response)
+}
+
+func (ts *readerTestSuite) TestReadInventoryDefinitionExtended() {
+	assert := ts.Assert()
+	require := ts.Require()
+
+	root, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/Extended")
+	require.NoError(err)
+	require.NotNil(root)
+
+	// There should only be a single region.
+	//
+	regionExpectedCount := 1
+	regionExpectedName  := "Region1"
+
+	assert.Equal(regionExpectedCount, len(root.Regions))
+
+	for regionName, region := range root.Regions {
+
+		if !assert.Equal(regionName, regionExpectedName, "Found unexpected region: %s", regionName) {
+			continue
+		}
+
+		assert.Equal(pb.State_in_service, region.Details.State)
+		assert.Equal("Pacific NW", region.Details.Location)
+		assert.Equal("Test Region", region.Details.Notes)
+
+		// There should only be a single zone.
+		//
+		zoneExpectedCount := 1
+		zoneExpectedName := "zone1"
+
+		assert.Equal(zoneExpectedCount, len(region.Zones))
+
+		for zoneName, zone := range region.Zones {
+
+			if !assert.Equal(zoneName, zoneExpectedName, "Found unexpected zone: %s", zoneName) {
+				continue
+			}
+
+			assert.True(zone.Details.Enabled)
+			assert.Equal(pb.State_in_service, zone.Details.State)
+			assert.Equal("Pacific NW, row 1", zone.Details.Location)
+			assert.Equal("Simple zone definition", zone.Details.Notes)
+
+			// There should only be a single rack.
+			//
+			rackExpectedCount := 1
+			rackExpectedName := "rack1"
+
+			assert.Equal(rackExpectedCount, len(zone.Racks))
+
+			for rackName, rack := range zone.Racks {
+
+				if !assert.Equal(rackName, rackExpectedName, "Found unexpected rack: %s", rackName) {
+					continue
+				}
+		
+				assert.True(rack.Details.Enabled)
+				assert.Equal(pb.Condition_operational, rack.Details.Condition)
+				assert.Equal("Pacific NW, row 1, rack 1", rack.Details.Location)
+				assert.Equal("Simple rack definition" , rack.Details.Notes)
+
+				// There should be a single PDU at index 0
+				//
+				assert.Equal(1, len(rack.Pdus))
+
+				p0, ok := rack.Pdus[0]
+				require.True(ok)
+
+				// The PDU should have a wired port for the tor and two ports
+				// for one of the blades, and a single port for the other blade.
+				//
+				assert.Equal(4, len(p0.Ports))
+
+				p0b1, ok := p0.Ports[1]
+				require.True(ok)
+
+				assert.True(p0b1.Wired)
+				assert.Equal(pb.Hardware_blade, p0b1.Item.Type)
+				assert.Equal(int64(1), p0b1.Item.Id)
+				assert.Equal(int64(0), p0b1.Item.Port)
+
+				p0b2, ok := p0.Ports[2]
+				require.True(ok)
+
+				assert.True(p0b2.Wired)
+				assert.Equal(pb.Hardware_blade, p0b2.Item.Type)
+				assert.Equal(int64(1), p0b2.Item.Id)
+				assert.Equal(int64(1), p0b2.Item.Port)
+
+				p0b3, ok := p0.Ports[3]
+				require.True(ok)
+
+				assert.True(p0b3.Wired)
+				assert.Equal(pb.Hardware_tor, p0b3.Item.Type)
+				assert.Equal(int64(0), p0b3.Item.Id)
+				assert.Equal(int64(1), p0b3.Item.Port)
+
+				p0b4, ok := p0.Ports[4]
+				require.True(ok)
+
+				assert.True(p0b4.Wired)
+				assert.Equal(pb.Hardware_blade, p0b4.Item.Type)
+				assert.Equal(int64(2), p0b4.Item.Id)
+				assert.Equal(int64(4), p0b4.Item.Port)
+
+				// There should be a single TOR at index 0
+				//
+				assert.Equal(1, len(rack.Tors))
+
+				t0, ok := rack.Tors[0]
+				require.True(ok)
+
+				// The TOR should have a wired port for the pdu and two ports
+				// for one of the blades, and a single port for the other blade.
+				//
+				assert.Equal(4, len(t0.Ports))
+
+				t0b1, ok := t0.Ports[1]
+				require.True(ok)
+
+				assert.True(t0b1.Wired)
+				assert.Equal(pb.Hardware_blade, t0b1.Item.Type)
+				assert.Equal(int64(1), t0b1.Item.Id)
+				assert.Equal(int64(0), t0b1.Item.Port)
+
+				t0b2, ok := t0.Ports[2]
+				require.True(ok)
+
+				assert.True(t0b2.Wired)
+				assert.Equal(pb.Hardware_blade, t0b2.Item.Type)
+				assert.Equal(int64(1), t0b2.Item.Id)
+				assert.Equal(int64(1), t0b2.Item.Port)
+
+				t0b3, ok := t0.Ports[3]
+				require.True(ok)
+
+				assert.True(t0b3.Wired)
+				assert.Equal(pb.Hardware_pdu, t0b3.Item.Type)
+				assert.Equal(int64(0), t0b3.Item.Id)
+				assert.Equal(int64(1), t0b3.Item.Port)
+
+				t0b4, ok := t0.Ports[4]
+				require.True(ok)
+
+				assert.True(t0b4.Wired)
+				assert.Equal(pb.Hardware_blade, t0b4.Item.Type)
+				assert.Equal(int64(2), t0b4.Item.Id)
+				assert.Equal(int64(3), t0b4.Item.Port)
+
+				// There should be exactly two blades at indices 1 and 2
+				//
+				assert.Equal(2, len(rack.Blades))
+
+				b1, ok := rack.Blades[1]
+				require.True(ok)
+
+				assert.True(b1.Details.Enabled)
+				assert.Equal(pb.Condition_operational, b1.Details.Condition)
+
+				assert.Equal(int64(16),    b1.Capacity.Cores)
+				assert.Equal(int64(16834), b1.Capacity.MemoryInMb)
+				assert.Equal(int64(240),   b1.Capacity.DiskInGb)
+				assert.Equal(int64(2048),  b1.Capacity.NetworkBandwidthInMbps)
+				assert.Equal("X64",        b1.Capacity.Arch)
+
+				b2, ok := rack.Blades[2]
+				require.True(ok)
+
+				assert.True(b2.Details.Enabled)
+				assert.Equal(pb.Condition_operational, b2.Details.Condition)
+
+				assert.Equal(int64(24),    b2.Capacity.Cores)
+				assert.Equal(int64(32768), b2.Capacity.MemoryInMb)
+				assert.Equal(int64(480),   b2.Capacity.DiskInGb)
+				assert.Equal(int64(4096),  b2.Capacity.NetworkBandwidthInMbps)
+				assert.Equal("X64",        b2.Capacity.Arch)
+			}
+		}
+	}
+	// require.Equal(2, len(response.Racks))
+
+	// r, ok := response.Racks["rack1"]
+	// require.True(ok)
+	// assert.Equal(2, len(r.Blades))
+
+	// b, ok := r.Blades[1]
+	// require.True(ok)
+	// assert.Equal(int64(16), b.Cores)
+	// assert.Equal(int64(16834), b.MemoryInMb)
+	// assert.Equal(int64(240), b.DiskInGb)
+	// assert.Equal(int64(2048), b.NetworkBandwidthInMbps)
+	// assert.Equal("X64", b.Arch)
+
+	// s, ok := response.Racks["rack2"]
+	// require.True(ok)
+	// assert.Equal(2, len(s.Blades))
+
+	// c, ok := r.Blades[2]
+	// require.True(ok)
+	// assert.Equal(int64(8), c.Cores)
+	// assert.Equal(int64(16834), c.MemoryInMb)
+	// assert.Equal(int64(120), c.DiskInGb)
+	// assert.Equal(int64(2048), c.NetworkBandwidthInMbps)
 }
 
 func TestReaderTestSuite(t *testing.T) {

--- a/simulation/internal/clients/inventory/testdata/Extended/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/Extended/inventory.yaml
@@ -28,25 +28,25 @@ Regions:
                   Condition: Operational
                 Ports:
                   - Index: 1
-                    Wired: 1
+                    Wired: true
                     Item:
                       Type: blade
                       Id: 1
                       Port: 0
                   - Index: 2
-                    Wired: 1
+                    Wired: true
                     Item: 
                       Type: blade
                       Id: 1
                       Port: 1
                   - Index: 3
-                    Wired: 1
+                    Wired: true
                     Item: 
                       Type: tor
                       Id: 0
                       Port: 1
                   - Index: 4
-                    Wired: 1
+                    Wired: true
                     Item:
                       Type: blade
                       Id: 2
@@ -58,25 +58,25 @@ Regions:
                   Condition: Operational
                 Ports:
                   - Index: 1
-                    Wired: 1
+                    Wired: true
                     Item: 
                       Type: blade
                       Id: 1
                       Port: 0
                   - Index: 2
-                    Wired: 1
+                    Wired: true
                     Item: 
                       Type: blade
                       Id: 1
                       Port: 1
                   - Index: 3
-                    Wired: 1
+                    Wired: true
                     Item: 
                       Type: pdu
                       Id: 0
                       Port: 1
                   - Index: 4
-                    Wired: 1
+                    Wired: true
                     Item: 
                       Type: blade
                       Id: 2
@@ -84,7 +84,7 @@ Regions:
             Blades:
               - Index: 1
                 Details:
-                  Enabled: 1
+                  Enabled: true
                   Condition: Operational
                 Capacity:
                   Cores: 16
@@ -100,7 +100,7 @@ Regions:
                 BootOnPowerOn: true
               - Index: 2
                 Details:
-                  Enabled: 1
+                  Enabled: true
                   Condition: Operational
                 Capacity:
                   Cores: 24

--- a/simulation/internal/clients/inventory/testdata/Extended/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/Extended/inventory.yaml
@@ -1,0 +1,116 @@
+Details:
+  Name: "test configuration"
+  Notes: "Test configuration with a basic set of components"
+Regions:
+  - Name: Region1
+    Details:
+      State: In_Service
+      Location: "Pacific NW"
+      Notes: "Test Region"
+    Zones:
+      - Name: zone1
+        Details:
+          Enabled: true
+          State: In_Service
+          Location: "Pacific NW, row 1"
+          Notes: "Simple zone definition"
+        Racks:
+          - Name: rack1
+            Details:
+              Enabled: true
+              Condition: Operational
+              Location: "Pacific NW, row 1, rack 1"
+              Notes: "Simple rack definition"
+            Pdus:
+              - Index: 0
+                Details:
+                  Enabled: true
+                  Condition: Operational
+                Ports:
+                  - Index: 1
+                    Wired: 1
+                    Item:
+                      Type: blade
+                      Id: 1
+                      Port: 0
+                  - Index: 2
+                    Wired: 1
+                    Item: 
+                      Type: blade
+                      Id: 1
+                      Port: 1
+                  - Index: 3
+                    Wired: 1
+                    Item: 
+                      Type: tor
+                      Id: 0
+                      Port: 1
+                  - Index: 4
+                    Wired: 1
+                    Item:
+                      Type: blade
+                      Id: 2
+                      Port: 4
+            Tors:
+              - Index: 0
+                Details:
+                  Enabled: true
+                  Condition: Operational
+                Ports:
+                  - Index: 1
+                    Wired: 1
+                    Item: 
+                      Type: blade
+                      Id: 1
+                      Port: 0
+                  - Index: 2
+                    Wired: 1
+                    Item: 
+                      Type: blade
+                      Id: 1
+                      Port: 1
+                  - Index: 3
+                    Wired: 1
+                    Item: 
+                      Type: pdu
+                      Id: 0
+                      Port: 1
+                  - Index: 4
+                    Wired: 1
+                    Item: 
+                      Type: blade
+                      Id: 2
+                      Port: 3
+            Blades:
+              - Index: 1
+                Details:
+                  Enabled: 1
+                  Condition: Operational
+                Capacity:
+                  Cores: 16
+                  MemoryInMb: 16834
+                  DiskInGb: 240 
+                  NetworkBandwidthInMbps: 2048
+                  Arch: "X64"
+                BootInfo:
+                  Source: network
+                  Image: standard.vhdx
+                  Version: latest
+                  Parameters: -param1=v1
+                BootOnPowerOn: true
+              - Index: 2
+                Details:
+                  Enabled: 1
+                  Condition: Operational
+                Capacity:
+                  Cores: 24
+                  MemoryInMb: 32768
+                  DiskInGb: 480 
+                  NetworkBandwidthInMbps: 4096
+                  Arch: "X64"
+                BootInfo:
+                  Source: network
+                  Image: standard.vhdx
+                  Version: latest
+                  Parameters: -param1=v2
+                BootOnPowerOn: true

--- a/simulation/internal/services/frontend/DBInventory.go
+++ b/simulation/internal/services/frontend/DBInventory.go
@@ -682,7 +682,7 @@ func (m *DBInventory) CreatePdu(
 	pdu *pb.Definition_Pdu,
 	options ...InventoryOption) (int64, error) {
 
-	if err := pdu.Verify(); err != nil {
+	if err := pdu.Validate("", 0); err != nil {
 		return InvalidRev, err
 	}
 
@@ -726,7 +726,7 @@ func (m *DBInventory) CreateTor(
 	tor *pb.Definition_Tor,
 	options ...InventoryOption) (int64, error) {
 
-	if err := tor.Verify(); err != nil {
+	if err := tor.Validate("", 0); err != nil {
 		return InvalidRev, err
 	}
 

--- a/simulation/pkg/errors/errors.go
+++ b/simulation/pkg/errors/errors.go
@@ -316,6 +316,283 @@ func (edb ErrDuplicateBlade) Error() string {
 	return fmt.Sprintf("Duplicate Blade %d in Rack %q detected", edb.Blade, edb.Rack)
 }
 
+// ErrDuplicateRegion indicates duplicates region names found
+type ErrDuplicateRegion string
+
+func (e ErrDuplicateRegion) Error() string {
+	return fmt.Sprintf("Duplicate region %q detected", string(e))
+}
+
+// ErrConfigRegionDuplicate indicates duplicate region names found
+//
+type ErrConfigRegionDuplicate struct {
+	Region string
+}
+
+func (e ErrConfigRegionDuplicate) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration detected duplicate Region %s",
+		e.Region)
+}
+
+// ErrConfigRegionBadState indicates the state for the region was unrecognized
+//
+type ErrConfigRegionBadState struct {
+	Region string
+	State  string
+}
+
+func (e ErrConfigRegionBadState) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration detected invalid state %q for region %q",
+		e.State,
+		e.Region)
+}
+
+// ErrConfigZoneDuplicate indicates duplicate zone names found
+//
+type ErrConfigZoneDuplicate struct {
+	Region string
+	Zone   string
+}
+
+func (e ErrConfigZoneDuplicate) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration detected duplicate Zone %q in %s",
+		e.Zone,
+		regionAddress(e.Region))
+}
+
+// ErrConfigZoneBadState indicates the state for the zone was unrecognized
+//
+type ErrConfigZoneBadState struct {
+	Region string
+	Zone   string
+	State  string
+}
+
+func (e ErrConfigZoneBadState) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration detected invalid state %q for %s",
+	 	e.State,
+		zoneAddress(e.Zone, e.Region))
+}
+
+// ErrConfigRackDuplicate indicates duplicate rack names found
+//
+type ErrConfigRackDuplicate struct {
+	Region string
+	Zone   string
+	Rack   string
+}
+
+func (e ErrConfigRackDuplicate) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration detected duplicate Rack %s in %s",
+		e.Rack,
+		zoneAddress(e.Region, e.Zone))
+}
+
+// ErrConfigRackBadCondition indicates the condition for the rack was unrecognized
+//
+type ErrConfigRackBadCondition struct {
+	Region    string
+	Zone      string
+	Rack      string
+	Condition string
+}
+
+func (e ErrConfigRackBadCondition) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration detected invalid condition %q for %s",
+	 	e.Condition,
+		rackAddress(e.Zone, e.Region, e.Rack))
+}
+
+// ErrConfigPduDuplicate indicates duplicate pdu indexes found
+type ErrConfigPduDuplicate struct {
+	Region string
+	Zone   string
+	Rack   string
+	Pdu    int64
+}
+
+func (e ErrConfigPduDuplicate) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration detected duplicate Pdu %d in %s",
+		e.Pdu,
+		pduAddress(e.Region, e.Zone, e.Rack, e.Pdu))
+}
+
+// ErrConfigPduBadCondition indicates the condition for the pdu was unrecognized
+//
+type ErrConfigPduBadCondition struct {
+	Region    string
+	Zone      string
+	Rack      string
+	Pdu       int64
+	Condition string
+}
+
+func (e ErrConfigPduBadCondition) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration detected invalid condition %q for %s",
+	 	e.Condition,
+		pduAddress(e.Zone, e.Region, e.Rack, e.Pdu))
+}
+
+// ErrConfigTorDuplicate indicates duplicate tor indexes found
+type ErrConfigTorDuplicate struct {
+	Region string
+	Zone   string
+	Rack   string
+	Tor    int64
+}
+
+func (e ErrConfigTorDuplicate) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration detected duplicate Tor %d in %s",
+		e.Tor,
+		torAddress(e.Region, e.Zone, e.Rack, e.Tor))
+}
+
+// ErrConfigTorBadCondition indicates the condition for the tor was unrecognized
+//
+type ErrConfigTorBadCondition struct {
+	Region    string
+	Zone      string
+	Rack      string
+	Tor       int64
+	Condition string
+}
+
+func (e ErrConfigTorBadCondition) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration file detected invalid condition %q for %s",
+	 	e.Condition,
+		torAddress(e.Region, e.Zone, e.Rack, e.Tor))
+}
+
+// ErrConfigBladeDuplicate indicates duplicate tor indexes found
+//
+type ErrConfigBladeDuplicate struct {
+	Region string
+	Zone   string
+	Rack   string
+	Blade  int64
+}
+
+func (e ErrConfigBladeDuplicate) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration detected duplicate Blade %d in %s",
+		e.Blade,
+		bladeAddress(e.Region, e.Zone, e.Rack, e.Blade))
+}
+
+// ErrConfigBladeBadCondition indicates the state for the zone was unrecognized
+//
+type ErrConfigBladeBadCondition struct {
+	Region    string
+	Zone      string
+	Rack      string
+	Blade     int64
+	Condition string
+}
+
+func (e ErrConfigBladeBadCondition) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration file has invalid condition %q for %s",
+	 	e.Condition,
+		bladeAddress(e.Zone, e.Region, e.Rack, e.Blade))
+}
+
+// ErrConfigPowerPortDuplicate indicates duplicate pdu port indexes found
+//
+type ErrConfigPowerPortDuplicate struct {
+	Region string
+	Zone   string
+	Rack   string
+	Pdu    int64
+	Port   int64
+}
+
+func (e ErrConfigPowerPortDuplicate) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration detected duplicate power port %d in %s",
+		e.Port,
+		pduAddress(e.Region, e.Zone, e.Rack, e.Pdu))
+}
+
+// ErrConfigNetworkPortDuplicate indicates duplicate tor port indexes found
+//
+type ErrConfigNetworkPortDuplicate struct {
+	Region string
+	Zone   string
+	Rack   string
+	Tor    int64
+	Port   int64
+}
+
+func (e ErrConfigNetworkPortDuplicate) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration detected duplicate network port %d in %s",
+		e.Port,
+		torAddress(e.Region, e.Zone, e.Rack, e.Tor))
+}
+
+// ErrConfigPduHwTypeInvalid indicates invalid hw type connected to a pdu port
+//
+type ErrConfigPduHwTypeInvalid struct {
+	Region string
+	Zone   string
+	Rack   string
+	Pdu    int64
+	Port   int64
+	Type   string
+}
+
+func (e ErrConfigPduHwTypeInvalid) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration detected invalid hardware type %q at %s",
+		e.Type,
+		powerPortAddress(e.Region, e.Zone, e.Rack, e.Pdu, e.Port))
+}
+
+// ErrConfigTorHwTypeInvalid indicates invalid hw type connected to a tor port
+//
+type ErrConfigTorHwTypeInvalid struct {
+	Region string
+	Zone   string
+	Rack   string
+	Tor    int64
+	Port   int64
+	Type   string
+}
+
+func (e ErrConfigTorHwTypeInvalid) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration detected invalid hardware type %q at %s",
+		e.Type,
+		networkPortAddress(e.Region, e.Zone, e.Rack, e.Tor, e.Port))
+}
+
+// ErrConfigBladeBadBootSource indicates invalid hw type connected to a tor port
+//
+type ErrConfigBladeBadBootSource struct {
+	Region     string
+	Zone       string
+	Rack       string
+	Blade      int64
+	BootSource string
+}
+
+func (e ErrConfigBladeBadBootSource) Error() string {
+	return fmt.Sprintf(
+		"CloudChamber: Configuration detected invalid boot source %q at %s",
+		e.BootSource,
+		bladeAddress(e.Region, e.Zone, e.Rack, e.Blade))
+}
+
 // ErrRackValidationFailure indicates validation failure in the attributes associated
 // with a rack.
 type ErrRackValidationFailure struct {
@@ -325,6 +602,17 @@ type ErrRackValidationFailure struct {
 
 func (evf ErrRackValidationFailure) Error() string {
 	return fmt.Sprintf("In rack %q: %v", evf.Rack, evf.Err)
+}
+
+// ErrRegionValidationFailure indicates validation failure in the attributes associated
+// with a rack.
+type ErrRegionValidationFailure struct {
+	Region string
+	Err    error
+}
+
+func (e ErrRegionValidationFailure) Error() string {
+	return fmt.Sprintf("In rack %q: %v", e.Region, e.Err)
 }
 
 // ErrUserAlreadyExists indicates the attempt to create a new user account
@@ -805,6 +1093,22 @@ func (e ErrMustBeGTE) Error() string {
 		e.Actual)
 }
 
+// ErrMustBeLTE signals that the specified field must be less than or equal
+// to a designated value.
+type ErrMustBeLTE struct {
+	Field    string
+	Actual   int64
+	Required int64
+}
+
+func (e ErrMustBeLTE) Error() string {
+	return fmt.Sprintf(
+		"the field %q must be less than or equal to %d.  It is %d, which is invalid",
+		e.Field,
+		e.Required,
+		e.Actual)
+}
+
 // ErrInvalidEnum signals that the specified field does not contain a valid
 // enum value.
 type ErrInvalidEnum struct {
@@ -1192,7 +1496,7 @@ func (epna ErrPortsNotAvailable) Error() string {
 }
 
 // ErrCapacityNotAvailable indicates the requested capacity information for
-// the item have not yet been establiehed.
+// the item has not yet been establiehed.
 //
 type ErrCapacityNotAvailable string
 

--- a/simulation/pkg/errors/formatters.go
+++ b/simulation/pkg/errors/formatters.go
@@ -42,3 +42,11 @@ func torAddress(region string, zone string, rack string, tor int64) string {
 func torAddressName(region string, zone string, rack string, tor string) string {
 	return fmt.Sprintf("tor %q in region %q, zone %q, rack %q", tor, region, zone, rack)
 }
+
+func powerPortAddress(region string, zone string, rack string, pdu int64, port int64) string {
+	return fmt.Sprintf("port %d in region %q, zone %q, rack %q, pdu %d", port, region, zone, rack, pdu)
+}
+
+func networkPortAddress(region string, zone string, rack string, tor int64, port int64) string {
+	return fmt.Sprintf("port %d in region %q, zone %q, rack %q, tor %d", port, region, zone, rack, tor)
+}

--- a/simulation/pkg/protos/inventory/capacity.Validate.go
+++ b/simulation/pkg/protos/inventory/capacity.Validate.go
@@ -8,44 +8,99 @@ import (
 	"github.com/Jim3Things/CloudChamber/simulation/pkg/errors"
 )
 
+const (
+	minCors                   = int64(1)
+	maxCors                   = int64(16384)
+	minMemoryInMb             = int64(1)
+	maxMemoryInMb             = int64(16 * 1024 * 1024) // 16TB
+	minDiskInGb               = int64(1)
+	maxDiskInGb               = int64(1024 * 1024 * 1024) // 1PB
+	minNetworkBandwidthInMbps = int64(1)
+	maxNetworkBandwidthInMbps = int64(1024 * 1024) // 1Tbps
+)
+
 // Validate is a function to ensure that the blade capacity values are legal.
 // Note that since BladeCapacity is always used as a subfield, the Validate
 // function takes a prefix to use on the field name in order to place the
 // error correctly.
 func (x *BladeCapacity) Validate(prefix string) error {
-	// A blade must have at least one core
-	if x.Cores < 1 {
+	// A blade must have at least the minimum number of cores...
+	//
+	if x.Cores < minCors {
 		return errors.ErrMustBeGTE{
 			Field:    fmt.Sprintf("%sCores", prefix),
 			Actual:   x.Cores,
-			Required: 1,
+			Required: minCors,
 		}
 	}
 
-	// .. and it must have some memory
-	if x.MemoryInMb < 1 {
+	// ... but no more than the maximum number of cores
+	//
+	if x.Cores > maxCors {
+		return errors.ErrMustBeLTE{
+			Field:    fmt.Sprintf("%sCores", prefix),
+			Actual:   x.Cores,
+			Required: maxCors,
+		}
+	}
+
+	// And it must have some memory...
+	//
+	if x.MemoryInMb < minMemoryInMb {
 		return errors.ErrMustBeGTE{
 			Field:    fmt.Sprintf("%sMemoryInMb", prefix),
 			Actual:   x.MemoryInMb,
-			Required: 1,
+			Required: minMemoryInMb,
 		}
 	}
 
-	// .. and some disk space
-	if x.DiskInGb < 1 {
+	//...but no more than some sensible upper amount
+	//
+	if x.MemoryInMb > maxMemoryInMb {
+		return errors.ErrMustBeLTE{
+			Field:    fmt.Sprintf("%sMemoryInMb", prefix),
+			Actual:   x.MemoryInMb,
+			Required: maxMemoryInMb,
+		}
+	}
+
+	// And some disk space...
+	//
+	if x.DiskInGb < minDiskInGb {
 		return errors.ErrMustBeGTE{
 			Field:    fmt.Sprintf("%sDiskInGb", prefix),
 			Actual:   x.DiskInGb,
-			Required: 1,
+			Required: minDiskInGb,
 		}
 	}
 
-	// .. and a network bandwidth allowance
-	if x.NetworkBandwidthInMbps < 1 {
+	// ...but no more than some sensible upper amount
+	//
+	if x.DiskInGb > maxDiskInGb {
+		return errors.ErrMustBeGTE{
+			Field:    fmt.Sprintf("%sDiskInGb", prefix),
+			Actual:   x.DiskInGb,
+			Required: maxDiskInGb,
+		}
+	}
+
+	// And a network bandwidth allowance...
+	//
+	if x.NetworkBandwidthInMbps < minNetworkBandwidthInMbps {
 		return errors.ErrMustBeGTE{
 			Field:    fmt.Sprintf("%sNetworkBandwidthInMbps", prefix),
 			Actual:   x.NetworkBandwidthInMbps,
-			Required: 1,
+			Required: minNetworkBandwidthInMbps,
+		}
+	}
+
+	// ...but no more than some sensible upper amount
+	//
+	if x.NetworkBandwidthInMbps > maxNetworkBandwidthInMbps {
+		return errors.ErrMustBeLTE{
+			Field:    fmt.Sprintf("%sNetworkBandwidthInMbps", prefix),
+			Actual:   x.NetworkBandwidthInMbps,
+			Required: maxNetworkBandwidthInMbps,
 		}
 	}
 

--- a/simulation/pkg/protos/inventory/definition.Validate.go
+++ b/simulation/pkg/protos/inventory/definition.Validate.go
@@ -298,7 +298,7 @@ func (x *Definition_Rack) Validate(prefix string) error {
 	// Check that there is one Pdu port for each blade
 	//
 	for k, v := range x.Pdus {
-		if err := v.Validate(fmt.Sprintf("%sPdu[%d].", prefix, k), countBlades); err != nil {
+		if err := v.Validate(fmt.Sprintf("%sPdus[%d].", prefix, k), countBlades); err != nil {
 			return err
 		}
 	}
@@ -306,7 +306,7 @@ func (x *Definition_Rack) Validate(prefix string) error {
 	// Check that there is one Tor port for each blade
 	//
 	for k, v := range x.Tors {
-		if err := v.Validate(fmt.Sprintf("%sTor[%d].", prefix, k), countBlades); err != nil {
+		if err := v.Validate(fmt.Sprintf("%sTors[%d].", prefix, k), countBlades); err != nil {
 			return err
 		}
 	}
@@ -314,7 +314,7 @@ func (x *Definition_Rack) Validate(prefix string) error {
 	// .. And then validate that each blade is valid
 	//
 	for k, v := range x.Blades {
-		if err := v.Validate(fmt.Sprintf("%sBlade[%d].", prefix, k)); err != nil {
+		if err := v.Validate(fmt.Sprintf("%sBlades[%d].", prefix, k)); err != nil {
 			return err
 		}
 	}
@@ -342,7 +342,7 @@ func (x *Definition_Zone) Validate(prefix string) error {
 	// .. And then validate that each rack is valid
 	//
 	for k, v := range x.Racks {
-		if err := v.Validate(fmt.Sprintf("%sRack[%s].", prefix, k)); err != nil {
+		if err := v.Validate(fmt.Sprintf("%sRacks[%s].", prefix, k)); err != nil {
 			return err
 		}
 	}
@@ -370,7 +370,7 @@ func (x *Definition_Region) Validate(prefix string) error {
 	// .. And then validate that each rack is valid
 	//
 	for k, v := range x.Zones {
-		if err := v.Validate(fmt.Sprintf("%sZone[%s].", prefix, k)); err != nil {
+		if err := v.Validate(fmt.Sprintf("%sZones[%s].", prefix, k)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Add the ability to load the inventory from a file using an extended syntax to cater for regions, zones and ports with an explicit wiring designation.

This syntax supersedes the current format and will shortly replace it in a forthcoming PR.

Remove superfluous x.Verify methods and replace calls with updated x.Validate() methods