### PR TITLE
Move session management constants to cloudchamber.yaml

### DIFF
--- a/simulation/configs/cloudchamber.yaml
+++ b/simulation/configs/cloudchamber.yaml
@@ -107,3 +107,9 @@ webServer:
 
   # .. and its password (a really bad pattern here, but we'll use it for now)
   systemAccountPassword: adminPassword
+
+  # number of seconds that a session is idle before being automatically closed.
+  sessionInactivity: 3600
+
+  # maximum number of simultaneous active sessions allowed.
+  activeSessionLimit: 100

--- a/simulation/internal/clients/inventory/testdata/cloudchamber.yaml
+++ b/simulation/internal/clients/inventory/testdata/cloudchamber.yaml
@@ -104,3 +104,6 @@ webServer:
 
   # .. and its password (a really bad pattern here, but we'll use it for now)
   systemAccountPassword: adminPassword
+
+  sessionInactivity: 3600
+  activeSessionLimit: 100

--- a/simulation/internal/clients/store/testdata/cloudchamber.yaml
+++ b/simulation/internal/clients/store/testdata/cloudchamber.yaml
@@ -104,3 +104,6 @@ webServer:
 
   # .. and its password (a really bad pattern here, but we'll use it for now)
   systemAccountPassword: adminPassword
+
+  sessionInactivity: 3600
+  activeSessionLimit: 100

--- a/simulation/internal/config/settings.go
+++ b/simulation/internal/config/settings.go
@@ -34,11 +34,11 @@ const (
 	simSupportDefaultPort      = 8083
 	simSupportDefaultTraceFile = ".\\sim_support_trace.txt"
 
-	webServerDefaultPort      = 8084
-	webServerFEDefaultPort    = 8080
-	webServerDefaultTraceFile = ".\\web_server_trace.txt"
-	defaultHost               = ""
-	webServerDefaultInactivity = 3600
+	webServerDefaultPort         = 8084
+	webServerFEDefaultPort       = 8080
+	webServerDefaultTraceFile    = ".\\web_server_trace.txt"
+	defaultHost                  = ""
+	webServerDefaultInactivity   = 3600
 	webServerDefaultSessionLimit = 100
 
 	stepperDefaultPolicy = ""
@@ -137,7 +137,7 @@ type WebServerType struct {
 	// .. and that account's password
 	SystemAccountPassword string
 
-	SessionInactivity int
+	SessionInactivity  int
 	ActiveSessionLimit int
 
 	// External http endpoint
@@ -199,8 +199,8 @@ func newGlobalConfig() *GlobalConfig {
 			RootFilePath:          defaultRootFilePath,
 			SystemAccount:         defaultSystemAccount,
 			SystemAccountPassword: defaultSystemPassword,
-			SessionInactivity: webServerDefaultInactivity,
-			ActiveSessionLimit: webServerDefaultSessionLimit,
+			SessionInactivity:     webServerDefaultInactivity,
+			ActiveSessionLimit:    webServerDefaultSessionLimit,
 			FE: Endpoint{
 				Hostname: defaultHost,
 				Port:     webServerFEDefaultPort,

--- a/simulation/internal/config/settings.go
+++ b/simulation/internal/config/settings.go
@@ -38,6 +38,8 @@ const (
 	webServerFEDefaultPort    = 8080
 	webServerDefaultTraceFile = ".\\web_server_trace.txt"
 	defaultHost               = ""
+	webServerDefaultInactivity = 3600
+	webServerDefaultSessionLimit = 100
 
 	stepperDefaultPolicy = ""
 
@@ -135,6 +137,9 @@ type WebServerType struct {
 	// .. and that account's password
 	SystemAccountPassword string
 
+	SessionInactivity int
+	ActiveSessionLimit int
+
 	// External http endpoint
 	FE Endpoint
 
@@ -194,6 +199,8 @@ func newGlobalConfig() *GlobalConfig {
 			RootFilePath:          defaultRootFilePath,
 			SystemAccount:         defaultSystemAccount,
 			SystemAccountPassword: defaultSystemPassword,
+			SessionInactivity: webServerDefaultInactivity,
+			ActiveSessionLimit: webServerDefaultSessionLimit,
 			FE: Endpoint{
 				Hostname: defaultHost,
 				Port:     webServerFEDefaultPort,
@@ -288,6 +295,8 @@ func (data *GlobalConfig) String() string {
 			"  RootFilePath: %s\n"+
 			"  SystemAccount: %s\n"+
 			"  SystemAccountPassword: %s\n"+
+			"  SessionInactivity: %d\n"+
+			"  ActiveSessionLimit: %d\n"+
 			"Store:"+
 			"  ConnectTimeout: %v\n"+
 			"  RequestTimeout: %v\n"+
@@ -312,6 +321,8 @@ func (data *GlobalConfig) String() string {
 		data.WebServer.RootFilePath,
 		data.WebServer.SystemAccount,
 		data.WebServer.SystemAccountPassword,
+		data.WebServer.SessionInactivity,
+		data.WebServer.ActiveSessionLimit,
 		data.Store.ConnectTimeout,
 		data.Store.RequestTimeout,
 		data.Store.TraceLevel,

--- a/simulation/internal/services/frontend/frontend.go
+++ b/simulation/internal/services/frontend/frontend.go
@@ -50,6 +50,8 @@ type Server struct {
 	cookieStore *sessions.CookieStore
 
 	startTime time.Time
+
+	sessions managedSessions
 }
 
 var (
@@ -195,6 +197,9 @@ func initService(cfg *config.GlobalConfig) error {
 	server.cookieStore.Options.Secure = false
 	server.cookieStore.Options.HttpOnly = false
 
+	server.sessions = newSessionTable(
+		cfg.WebServer.ActiveSessionLimit,
+		time.Duration(cfg.WebServer.SessionInactivity)*time.Second)
 	server.startTime = time.Now()
 
 	if err := initHandlers(); err != nil {

--- a/simulation/internal/services/frontend/inventory.go
+++ b/simulation/internal/services/frontend/inventory.go
@@ -55,7 +55,7 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 	err := doSessionHeader(
 		ctx, w, r,
 		func(_ context.Context, session *sessions.Session) error {
-			return ensureEstablishedSession(session)
+			return server.sessions.ensureEstablishedSession(session)
 		})
 
 	if err != nil {
@@ -115,7 +115,7 @@ func handlerRackRead(w http.ResponseWriter, r *http.Request) {
 	err := doSessionHeader(
 		ctx, w, r,
 		func(_ context.Context, session *sessions.Session) error {
-			return ensureEstablishedSession(session)
+			return server.sessions.ensureEstablishedSession(session)
 		})
 
 	if err != nil {
@@ -149,7 +149,7 @@ func handlerBladesList(w http.ResponseWriter, r *http.Request) {
 	err := doSessionHeader(
 		ctx, w, r,
 		func(_ context.Context, session *sessions.Session) error {
-			return ensureEstablishedSession(session)
+			return server.sessions.ensureEstablishedSession(session)
 		})
 
 	if err != nil {
@@ -189,7 +189,7 @@ func handlerBladeRead(w http.ResponseWriter, r *http.Request) {
 	err := doSessionHeader(
 		ctx, w, r,
 		func(_ context.Context, session *sessions.Session) error {
-			return ensureEstablishedSession(session)
+			return server.sessions.ensureEstablishedSession(session)
 		})
 
 	if err != nil {

--- a/simulation/internal/services/frontend/logs.go
+++ b/simulation/internal/services/frontend/logs.go
@@ -36,7 +36,7 @@ func handlerLogsGetAfter(w http.ResponseWriter, r *http.Request) {
 	err := doSessionHeader(
 		ctx, w, r,
 		func(ctx context.Context, session *sessions.Session) error {
-			return ensureEstablishedSession(session)
+			return server.sessions.ensureEstablishedSession(session)
 		})
 
 	if err != nil {
@@ -84,7 +84,7 @@ func handlerLogsGetPolicy(w http.ResponseWriter, r *http.Request) {
 	err := doSessionHeader(
 		ctx, w, r,
 		func(ctx context.Context, session *sessions.Session) error {
-			return ensureEstablishedSession(session)
+			return server.sessions.ensureEstablishedSession(session)
 		})
 
 	if err != nil {

--- a/simulation/internal/services/frontend/ping.go
+++ b/simulation/internal/services/frontend/ping.go
@@ -40,8 +40,8 @@ func handlerPing(w http.ResponseWriter, r *http.Request) {
 			// We get the cloud chamber session state.  We can ignore the ok
 			// flag, as we only look at it if the next call succeeds, which
 			// can only happen if there is a session...
-			ccSession, _ = getSession(session)
-			return ensureEstablishedSession(session)
+			ccSession, _ = server.sessions.getSession(session)
+			return server.sessions.ensureEstablishedSession(session)
 		})
 
 	if err != nil {

--- a/simulation/internal/services/frontend/session_manager_test.go
+++ b/simulation/internal/services/frontend/session_manager_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/Jim3Things/CloudChamber/simulation/internal/tracing/exporters"
 )
 
+const (
+	expirationTimeout = time.Hour
+	sessionLimit      = 100
+)
+
 type SessionManagerTestSuite struct {
 	suite.Suite
 
@@ -26,7 +31,7 @@ func (ts *SessionManagerTestSuite) SetupSuite() {
 func (ts *SessionManagerTestSuite) SetupTest() {
 	_ = ts.utf.Open(ts.T())
 
-	ts.sessions = newSessionTable(100, expirationTimeout).(*sessionTable)
+	ts.sessions = newSessionTable(sessionLimit, expirationTimeout).(*sessionTable)
 }
 
 func (ts *SessionManagerTestSuite) TearDownTest() {

--- a/simulation/internal/services/frontend/stepper.go
+++ b/simulation/internal/services/frontend/stepper.go
@@ -44,7 +44,7 @@ func handleGetStatus(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	err := doSessionHeader(ctx, w, r, func(_ context.Context, session *sessions.Session) error {
-		return ensureEstablishedSession(session)
+		return server.sessions.ensureEstablishedSession(session)
 	})
 
 	if err != nil {
@@ -79,7 +79,7 @@ func handleAdvance(w http.ResponseWriter, r *http.Request) {
 	var count int
 
 	err := doSessionHeader(ctx, w, r, func(_ context.Context, session *sessions.Session) error {
-		return ensureEstablishedSession(session)
+		return server.sessions.ensureEstablishedSession(session)
 	})
 
 	if err != nil {
@@ -138,7 +138,7 @@ func handleSetMode(w http.ResponseWriter, r *http.Request) {
 	var policy pb.StepperPolicy
 
 	err := doSessionHeader(ctx, w, r, func(_ context.Context, session *sessions.Session) error {
-		return ensureEstablishedSession(session)
+		return server.sessions.ensureEstablishedSession(session)
 	})
 
 	if err != nil {
@@ -217,7 +217,7 @@ func handleWaitFor(w http.ResponseWriter, r *http.Request) {
 		ctx, w, r,
 		func(_ context.Context, session *sessions.Session) error {
 
-			if err := ensureEstablishedSession(session); err != nil {
+			if err := server.sessions.ensureEstablishedSession(session); err != nil {
 				return err
 			}
 
@@ -259,7 +259,7 @@ func handleGetNow(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	err := doSessionHeader(ctx, w, r, func(_ context.Context, session *sessions.Session) error {
-		return ensureEstablishedSession(session)
+		return server.sessions.ensureEstablishedSession(session)
 	})
 
 	if err != nil {

--- a/simulation/internal/services/frontend/testdata/cloudchamber.yaml
+++ b/simulation/internal/services/frontend/testdata/cloudchamber.yaml
@@ -107,3 +107,6 @@ webServer:
 
   # .. and its password (a really bad pattern here, but we'll use it for now)
   systemAccountPassword: AdminPassword
+
+  sessionInactivity: 3600
+  activeSessionLimit: 100


### PR DESCRIPTION
The constants that determine the inactivity time and maximum simultaneous session limit are moved to the yaml file.

This also prompted fully encapsulating the session manager into a struct/interface, and having the instance be part of the frontend server instance.