### PR TITLE
Add ability to use anchors and aliases in inventory YAML config files

### DIFF
--- a/simulation/internal/clients/inventory/definition_test.go
+++ b/simulation/internal/clients/inventory/definition_test.go
@@ -2864,6 +2864,13 @@ func (ts *definitionTestSuite) TestReadInventoryDefinitionFromFileExStandard() {
 	require.NoError(err)
 }
 
+func (ts *definitionTestSuite) TestReadInventoryDefinitionFromFileExReference() {
+	require := ts.Require()
+
+	_, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/reference")
+	require.NoError(err)
+}
+
 func (ts *definitionTestSuite) TestLoadInventoryIntoStore() {
 	require := ts.Require()
 

--- a/simulation/internal/clients/inventory/reader.go
+++ b/simulation/internal/clients/inventory/reader.go
@@ -52,9 +52,66 @@ type pdu struct {
 }
 
 type rootEx struct {
-	Details rootExDetails
-	Regions []regionEx
+	ZoneTypes   []catZone
+	RackTypes   []catRack
+	PduTypes    []catPdu
+	TorTypes    []catTor
+	BladeTypes  []catBlade
+	Details     rootExDetails
+	Regions     []regionEx
 }
+
+// ++++++++++
+//
+// The folowing catXxx structs are used as throwaway data fields to enable
+// the Viper package to both read and process a yaml configuration file
+// while making use of anchors and aliases to limit the amount of repitition
+// within the file.
+//
+// The values held in this set of structs after unmarshalling the contents of
+// the configuration file have no value and should just be discarded.
+//
+// NOTE: Cannot extend the scheme to include complete regions to be defined
+//       with an achor and used as an alias as the file read function returns
+//       an error for "excessive aliasing"
+//
+type catZone struct {
+	Name    string
+	Details zoneExDetails
+	Racks   []rackEx
+}
+
+type catRack struct {
+	Name    string
+	Details rackExDetails
+	Pdus    []pduEx
+	Tors    []torEx
+	Blades  []bladeEx
+}
+type catPdu struct {
+	Details pduExDetails
+	Ports   []portEx
+}
+
+type catTor struct {
+	Details torExDetails
+	Ports   []portEx
+}
+
+type catBlade struct {
+	Details       bladeExDetails
+	Capacity      bladeExCapacity
+	BootInfo      bladeExBootinfo
+	BootOnPowerOn bool
+}
+
+type catPort struct {
+	Wired bool
+	Item  portExTarget
+}
+
+// ----------
+
 
 type rootExDetails struct {
 	Name  string
@@ -126,7 +183,7 @@ type pduExDetails struct {
 
 type torEx struct {
 	Index   int64
-	Details pduExDetails
+	Details torExDetails
 	Ports   []portEx
 }
 

--- a/simulation/internal/clients/inventory/testdata/Reference/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/Reference/inventory.yaml
@@ -1,0 +1,160 @@
+BladeTypeS:
+  - &bladeType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: network
+      Image: region1_standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
+      Cores: 16
+      MemoryInMb: 16834
+      DiskInGb: 240 
+      NetworkBandwidthInMbps: 2048
+      Arch: "X64"
+
+  - &bladeType2
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: network
+      Image: region1_standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
+      Cores: 32
+      MemoryInMb: 16834
+      DiskInGb: 120
+      NetworkBandwidthInMbps: 2048
+      Arch: "X64"
+
+TorTypes:
+  - &torType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   pdu, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 1}}
+      - {Index:  3, Wired: true, Item: {Type: blade, Id:  3, Port: 1}}
+      - {Index:  4, Wired: true, Item: {Type: blade, Id:  4, Port: 1}}
+      - {Index:  5, Wired: true, Item: {Type: blade, Id:  5, Port: 1}}
+      - {Index:  6, Wired: true, Item: {Type: blade, Id:  6, Port: 1}}
+      - {Index:  7, Wired: true, Item: {Type: blade, Id:  7, Port: 1}}
+      - {Index:  8, Wired: true, Item: {Type: blade, Id:  8, Port: 1}}
+
+PduTypes:
+  - &pduType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   tor, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 1}}
+      - {Index:  3, Wired: true, Item: {Type: blade, Id:  3, Port: 1}}
+      - {Index:  4, Wired: true, Item: {Type: blade, Id:  4, Port: 1}}
+      - {Index:  5, Wired: true, Item: {Type: blade, Id:  5, Port: 1}}
+      - {Index:  6, Wired: true, Item: {Type: blade, Id:  6, Port: 1}}
+      - {Index:  7, Wired: true, Item: {Type: blade, Id:  7, Port: 1}}
+      - {Index:  8, Wired: true, Item: {Type: blade, Id:  8, Port: 1}}
+
+
+RackTypes:
+  - &rackType1
+    Details:
+      Enabled: true
+      Condition: Operational
+      Location: "Pacific NW, row 1, rack 1"
+      Notes: "rack definition, 1 pdu, 1 tor, 8 blades"
+    Blades:
+      - Index: 1
+        <<: *bladeType1
+      - Index: 2
+        <<: *bladeType2
+      - Index: 3
+        <<: *bladeType2
+      - Index: 4
+        <<: *bladeType2
+      - Index: 5
+        <<: *bladeType2
+      - Index: 6
+        <<: *bladeType2
+      - Index: 7
+        <<: *bladeType2
+      - Index: 8
+        <<: *bladeType2
+    Tors:
+      - Index: 0
+        <<: *torType1
+    Pdus:
+      - Index: 0
+        <<: *pduType1
+
+
+ZoneTypes:
+  - &zoneType1
+    Details:
+      Enabled: true
+      State: In_Service
+      Location: "Pacific NW, row 1"
+      Notes: "Simple zone definition"
+    Racks:
+      - Name: rack1
+        <<: *rackType1
+      - Name: rack2
+        <<: *rackType1
+      - Name: rack3
+        <<: *rackType1
+      - Name: rack4
+        <<: *rackType1
+      - Name: rack5
+        <<: *rackType1
+      - Name: rack6
+        <<: *rackType1
+      - Name: rack7
+        <<: *rackType1
+      - Name: rack8
+        <<: *rackType1
+
+
+# Start of layout
+#
+Details:
+  Name: "Reference Test Inventory"
+  Notes: "Test configuration comprising 2 regions, each with 4 zones, each zone having 8 racks, with each rack having a single pdu, a single tor and 8 blades."
+Regions:
+  - Name: region1
+    Details:
+      State: In_Service
+      Location: "Pacific NW"
+      Notes: "Test Region 1"
+    Zones:
+      - Name: zone1
+        <<: *zoneType1
+      - Name: zone2
+        <<: *zoneType1
+      - Name: zone3
+        <<: *zoneType1
+      - Name: zone4
+        <<: *zoneType1
+  - Name: region2
+    Details:
+      State: In_Service
+      Location: "Pacific NW"
+      Notes: "Test Region 2"
+    Zones:
+      - Name: zone1
+        <<: *zoneType1
+      - Name: zone2
+        <<: *zoneType1
+      - Name: zone3
+        <<: *zoneType1
+      - Name: zone4
+        <<: *zoneType1


### PR DESCRIPTION
There is inherently a lot of repetition in the inventory yaml file which can lead to large, hard to read and almost impossible to edit files describing the inventory. By using YAML anchors and aliases this amount of repetition can be dramatically reduced.

Improve inventory readability by using flow notation for the individual port descriptions for both Pdu and Tor definitions.