### PR TITLE
Active state persistence, part 1

### DIFF
--- a/pkg/protos/inventory/actual.proto
+++ b/pkg/protos/inventory/actual.proto
@@ -17,22 +17,179 @@ message Actual {
         faulted = 2;
     }
 
-    message Pdu {
+    // Cable represents the operational state of a simulated wire between a
+    // component and a blade.  The target blade and port is determined by the
+    // definition view, as it does not change.
+    message Cable {
+        // Determine if the cable is on (working) or off (disabled).
+        enum State {
+            invalid = 0;
+            on = 1;
+            off = 2;
+        }
+        State state = 1;
 
+        // This is true if the cable is faulted such that it cannot be
+        // controlled, and the on/off state is externally uncertain.
+        bool faulted = 2;
+    }
+
+    // MachineCore holds the common state needed by the core state machine
+    // infrastructure.
+    message MachineCore {
+
+        // This is the simulated time when the current state was entered.
+        int64 entered_at = 1;
+
+        // This is true if the state machine execution has completed.
+        bool terminal = 2;
+
+        // This is the guard time, used for handling of message overrun or
+        // other external state change.
+        int64 guard = 3;
+    }
+
+    message Pdu {
+        // This indicates whether this element in operational, or in some other
+        // lifecycle state.
         Condition condition = 1;
 
+        // this holds the simulated cables attached to this element.
+        map<int64, Cable> cables = 2;
+
+        // This defines the state machine states
+        enum State {
+            invalid = 0;
+
+            // This is the state where the PDU is powered on and working.
+            working = 1;
+
+            // This is the state where the PDU is powered off.
+            off = 2;
+
+            // This is the state where the PDU is unresponsive, but power may or
+            // may not still be on.
+            stuck = 3;
+        }
+        State sm_state = 3;
+
+        // This is the stored core state machine recovery state.
+        MachineCore core = 4;
     }
 
     message Tor {
-
+        // This indicates whether this element in operational, or in some other
+        // lifecycle state.
         Condition condition = 1;
 
+        // this holds the simulated cables attached to this element.
+        map<int64, Cable> cables = 2;
+
+        // This defines the state machine states
+        enum State {
+            invalid = 0;
+
+            working = 1;
+
+            // The TOR is faulted and unresponsive. Note that programmed cables
+            // may or may not continue to be programmed.
+            stuck = 2;
+        }
+        State sm_state = 3;
+
+        // This is the stored core state machine recovery state.
+        MachineCore core = 4;
     }
 
     message Blade {
-
+        // This indicates whether this element in operational, or in some other
+        // lifecycle state.
         Condition condition = 1;
 
+        // This defines the state machine states
+        enum State {
+            invalid = 0;
+
+            // This is the state where initialization of the state machine
+            // begins.
+            start = 1;
+
+            // This is the state when the blade has neither simulated power
+            // nor simulated network connectivity.
+            off_disconnected = 2;
+
+            // This is the state when the blade does not have power, but does
+            // have simulated network connectivity.
+            off_connected = 3;
+
+            // This is the state when the blade has simulated power, but does
+            // not have simulated network connectivity.
+            powered_disconnected = 4;
+
+            // This is the state when the blade has power and simulated network
+            // connectivity.  If auto-boot is enabled, this state will
+            // automatically transition to the booting state.
+            powered_connected = 5;
+
+            // This is the state when the blade is waiting for the simulated
+            // boot delay to complete.
+            booting = 6;
+
+            // This is the state when the blade is powered on, booted, and
+            // able to handle workload requests.
+            working = 7;
+
+            // This is the state when the blade is powered on and booted, but
+            // has not simulated network connectivity.  Existing workloads are
+            // informed the connectivity has been lost, but are otherwise
+            // undisturbed.
+            isolated = 8;
+
+            // This is a transitional state to clean up when the blade is
+            // finally shutting down.  This may involve notifying any active
+            // workloads that they have been forcibly stopped.
+            stopping = 9;
+
+            // This is a transitional state parallel to the stopping state, but
+            // where simulated network connectivity has been lost.
+            stopping_isolated = 10;
+
+            // This is the state when the blade has either had a processing
+            // fault, such as a timer failure, or an injected fault that leaves
+            // it in a position that requires an external reset/fix.
+            faulted = 11;
+        }
+        State sm_state = 2;
+
+        // This is the stored core state machine recovery state.
+        MachineCore core = 3;
+
+        bool state_expires = 4;
+        int64 expiration = 5;
+    }
+
+    // NB: Given the rack's rather different lifecycle needs, this is mostly
+    // latent at this time.
+    message Rack {
+        // This defines the state machine states
+        enum State {
+            invalid = 0;
+
+            // This is the state when the rack is awaiting the start simulation
+            // command.
+            awaiting_start = 1;
+
+            // This is the state during normal simulation operation.
+            working = 2;
+
+            // This is the state when the rack has processed a stop simulation
+            // command.
+            terminated = 3;
+        }
+        State sm_state = 1;
+
+        // This is the stored core state machine recovery state.
+        MachineCore core = 2;
     }
 }
 

--- a/pkg/protos/services/requests.proto
+++ b/pkg/protos/services/requests.proto
@@ -104,6 +104,43 @@ message StatusResponse {
 
 // --- Stepper specific messages
 
+// +++ Stepper persisted state
+
+// StepperState contains the state machine internal state necessary to restore
+// the current simulated time on restart.
+// NB: This is currently mostly latent - only the state machine state values are
+// provided, in order to support the changes in the common state machine
+// internals.
+message StepperState {
+    enum State {
+        // This is the state when no legal policy is in force.
+        invalid = 0;
+
+        // This is the state prior to initialization.
+        awaiting_start = 1;
+
+        // This state manages the policy where the simulated time is either
+        // manually stepped forward, or, if a Delay operation is called, it jumps
+        // forward to immediately complete any waiter.
+        no_wait = 2;
+
+        // This is the state where simulated time only moves forward due to
+        // specific Step operations.
+        manual = 3;
+
+        // This is the state where simulated time moves forward by one tick per
+        // the designated real time interval (e.g. 1 tick / second).
+        measured = 4;
+
+        // An internal fault has occurred.  This is a terminal state.
+        faulted = 5;
+    }
+
+    State sm_state = 1;
+}
+
+// --- Stepper persisted state
+
 // +++ trace sink specific messages
 
 // Specify the trace entry to append to the trace sink's store

--- a/simulation/internal/services/inventory/blade.go
+++ b/simulation/internal/services/inventory/blade.go
@@ -2,7 +2,6 @@ package inventory
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 
 	"github.com/golang/protobuf/proto"
@@ -264,7 +263,7 @@ func bootingTimerExpiry(ctx context.Context, machine *sm.SM, m sm.Envelope) bool
 
 // bootingOnLeave ensures that any active boot delay timer is canceled before
 // proceeding to a non-booting state.
-func bootingOnLeave(ctx context.Context, machine *sm.SM, nextState fmt.Stringer) {
+func bootingOnLeave(ctx context.Context, machine *sm.SM, nextState sm.StateIndex) {
 	if nextState != pb.Actual_Blade_booting {
 		cancelTimer(ctx, machine, "boot")
 	}
@@ -279,7 +278,7 @@ func stoppingTimerExpiry(ctx context.Context, machine *sm.SM, m sm.Envelope) boo
 
 // stoppingOnLeave ensures that any active time is canceled before proceeding
 // to a non-stopping state.
-func stoppingOnLeave(ctx context.Context, machine *sm.SM, nextState fmt.Stringer) {
+func stoppingOnLeave(ctx context.Context, machine *sm.SM, nextState sm.StateIndex) {
 	if nextState != pb.Actual_Blade_stopping &&
 		nextState != pb.Actual_Blade_stopping_isolated {
 		cancelTimer(ctx, machine, "shutdown")

--- a/simulation/internal/services/inventory/blade.go
+++ b/simulation/internal/services/inventory/blade.go
@@ -2,7 +2,10 @@ package inventory
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
+
+	"github.com/golang/protobuf/proto"
 
 	"github.com/Jim3Things/CloudChamber/simulation/internal/common"
 	"github.com/Jim3Things/CloudChamber/simulation/internal/services/inventory/messages"
@@ -55,58 +58,9 @@ type blade struct {
 	// matchTimerExpiry is the blade supplied ID embedded in the timer expired
 	// message.
 	matchTimerExpiry int
+
+	expiration int64
 }
-
-const (
-	// bladeStart is the state where initialization of the state machine
-	// begins.
-	bladeStart = "start"
-
-	// bladeOffDiscon is current when the blade has neither simulated
-	// power or simulated network connectivity.
-	bladeOffDiscon = "off-disconnected"
-
-	// bladeOffConn is current when the blade has no simulated power,
-	// but does have simulated network connectivity.
-	bladeOffConn = "off-connected"
-
-	// bladePoweredDiscon is current when the blade has simulated power,
-	// but no simulated network connectivity.
-	bladePoweredDiscon = "powered-disconnected"
-
-	// bladePoweredConn is current when the blade has power and simulated
-	// network connectivity.  If auto-boot is enabled, this state will
-	// automatically transition to the following booting state.
-	bladePoweredConn = "powered-connected"
-
-	// bladeBooting is current when the blade is waiting for the simulated
-	// boot delay to complete.
-	bladeBooting = "booting"
-
-	// bladeWorking is current when the blade is powered on, booted, and
-	// able to handle workload requests.
-	bladeWorking = "working"
-
-	// bladeIsolated is current when the blade is powered on and booted,
-	// but has not simulated network connectivity.  Existing workloads are
-	// informed the connectivity has been lost, but are otherwise undisturbed.
-	bladeIsolated = "isolated"
-
-	// bladeStopping is a transitional state to clean up when the blade is
-	// finally shutting down.  This may involve notifying any active workloads
-	// that they have been forcibly stopped.
-	bladeStopping = "stopping"
-
-	// bladeStoppingIsolated is a transitional state parallel to the
-	// bladeStopping, but where simulated network connectivity has been
-	// lost.
-	bladeStoppingIsolated = "stopping-isolated"
-
-	// bladeFaulted is current when the blade has either had a processing
-	// fault, such as a timer failure, or an injected fault that leaves it in
-	// a position that requires an external reset/fix.
-	bladeFaulted = "faulted"
-)
 
 func newBlade(def *pb.BladeCapacity, r *Rack, id int64) *blade {
 	b := &blade{
@@ -134,112 +88,112 @@ func newBlade(def *pb.BladeCapacity, r *Rack, id int64) *blade {
 
 	b.sm = sm.NewSM(b,
 		sm.WithFirstState(
-			bladeStart,
+			pb.Actual_Blade_start,
 			startedOnEnter,
 			[]sm.ActionEntry{},
 			sm.UnexpectedMessage,
 			sm.NullLeave),
 
 		sm.WithState(
-			bladeOffDiscon,
+			pb.Actual_Blade_off_disconnected,
 			sm.NullEnter,
 			[]sm.ActionEntry{
-				{messages.TagSetConnection, setConnection, bladeOffConn, sm.Stay},
-				{messages.TagSetPower, setPower, bladePoweredDiscon, sm.Stay},
+				{messages.TagSetConnection, setConnection, pb.Actual_Blade_off_connected, sm.Stay},
+				{messages.TagSetPower, setPower, pb.Actual_Blade_powered_disconnected, sm.Stay},
 			},
 			sm.UnexpectedMessage,
 			sm.NullLeave),
 
 		sm.WithState(
-			bladeOffConn,
+			pb.Actual_Blade_off_connected,
 			sm.NullEnter,
 			[]sm.ActionEntry{
 				{messages.TagGetStatus, sm.Ignore, sm.Stay, sm.Stay},
-				{messages.TagSetConnection, setConnection, sm.Stay, bladeOffDiscon},
-				{messages.TagSetPower, setPower, bladePoweredConn, sm.Stay},
+				{messages.TagSetConnection, setConnection, sm.Stay, pb.Actual_Blade_off_disconnected},
+				{messages.TagSetPower, setPower, pb.Actual_Blade_powered_connected, sm.Stay},
 			},
 			sm.UnexpectedMessage,
 			sm.NullLeave),
 
 		sm.WithState(
-			bladePoweredDiscon,
+			pb.Actual_Blade_powered_disconnected,
 			sm.NullEnter,
 			[]sm.ActionEntry{
-				{messages.TagSetConnection, setConnection, bladePoweredConn, sm.Stay},
-				{messages.TagSetPower, setPower, sm.Stay, bladePoweredDiscon},
+				{messages.TagSetConnection, setConnection, pb.Actual_Blade_powered_connected, sm.Stay},
+				{messages.TagSetPower, setPower, sm.Stay, pb.Actual_Blade_powered_disconnected},
 			},
 			sm.UnexpectedMessage,
 			sm.NullLeave),
 
 		sm.WithState(
-			bladePoweredConn,
+			pb.Actual_Blade_powered_connected,
 			poweredConnOnEnter,
 			[]sm.ActionEntry{
 				{messages.TagGetStatus, bladeGetStatus, sm.Stay, sm.Stay},
-				{messages.TagSetConnection, setConnection, sm.Stay, bladePoweredDiscon},
-				{messages.TagSetPower, setPower, sm.Stay, bladeOffConn},
+				{messages.TagSetConnection, setConnection, sm.Stay, pb.Actual_Blade_powered_disconnected},
+				{messages.TagSetPower, setPower, sm.Stay, pb.Actual_Blade_off_connected},
 			},
 			sm.UnexpectedMessage,
 			sm.NullLeave),
 
 		sm.WithState(
-			bladeBooting,
+			pb.Actual_Blade_booting,
 			bootingOnEnter,
 			[]sm.ActionEntry{
 				{messages.TagGetStatus, bladeGetStatus, sm.Stay, sm.Stay},
-				{messages.TagSetConnection, setConnection, sm.Stay, bladePoweredDiscon},
-				{messages.TagSetPower, setPower, sm.Stay, bladeOffConn},
-				{messages.TagTimerExpiry, bootingTimerExpiry, bladeWorking, sm.Stay},
+				{messages.TagSetConnection, setConnection, sm.Stay, pb.Actual_Blade_powered_disconnected},
+				{messages.TagSetPower, setPower, sm.Stay, pb.Actual_Blade_off_connected},
+				{messages.TagTimerExpiry, bootingTimerExpiry, pb.Actual_Blade_working, sm.Stay},
 			},
 			sm.UnexpectedMessage,
 			bootingOnLeave),
 
 		sm.WithState(
-			bladeWorking,
+			pb.Actual_Blade_working,
 			sm.NullEnter,
 			[]sm.ActionEntry{
 				{messages.TagGetStatus, bladeGetStatus, sm.Stay, sm.Stay},
-				{messages.TagSetConnection, setConnection, sm.Stay, bladeIsolated},
-				{messages.TagSetPower, setPower, sm.Stay, bladeOffConn},
+				{messages.TagSetConnection, setConnection, sm.Stay, pb.Actual_Blade_isolated},
+				{messages.TagSetPower, setPower, sm.Stay, pb.Actual_Blade_off_connected},
 			},
 			sm.UnexpectedMessage,
 			sm.NullLeave),
 
 		sm.WithState(
-			bladeIsolated,
+			pb.Actual_Blade_isolated,
 			sm.NullEnter,
 			[]sm.ActionEntry{
-				{messages.TagSetConnection, setConnection, bladeWorking, sm.Stay},
-				{messages.TagSetPower, setPower, sm.Stay, bladeOffConn},
+				{messages.TagSetConnection, setConnection, pb.Actual_Blade_working, sm.Stay},
+				{messages.TagSetPower, setPower, sm.Stay, pb.Actual_Blade_off_connected},
 			},
 			sm.UnexpectedMessage,
 			sm.NullLeave),
 
 		sm.WithState(
-			bladeStopping,
+			pb.Actual_Blade_stopping,
 			sm.NullEnter,
 			[]sm.ActionEntry{
 				{messages.TagGetStatus, bladeGetStatus, sm.Stay, sm.Stay},
-				{messages.TagSetConnection, setConnection, sm.Stay, bladeStoppingIsolated},
-				{messages.TagSetPower, setPower, sm.Stay, bladeOffConn},
-				{messages.TagTimerExpiry, stoppingTimerExpiry, bladeOffConn, sm.Stay},
+				{messages.TagSetConnection, setConnection, sm.Stay, pb.Actual_Blade_stopping_isolated},
+				{messages.TagSetPower, setPower, sm.Stay, pb.Actual_Blade_off_connected},
+				{messages.TagTimerExpiry, stoppingTimerExpiry, pb.Actual_Blade_off_connected, sm.Stay},
 			},
 			sm.UnexpectedMessage,
 			stoppingOnLeave),
 
 		sm.WithState(
-			bladeStoppingIsolated,
+			pb.Actual_Blade_stopping_isolated,
 			sm.NullEnter,
 			[]sm.ActionEntry{
-				{messages.TagSetConnection, setConnection, bladeStopping, sm.Stay},
-				{messages.TagSetPower, setPower, sm.Stay, bladeOffDiscon},
-				{messages.TagTimerExpiry, stoppingTimerExpiry, bladeOffDiscon, sm.Stay},
+				{messages.TagSetConnection, setConnection, pb.Actual_Blade_stopping, sm.Stay},
+				{messages.TagSetPower, setPower, sm.Stay, pb.Actual_Blade_off_disconnected},
+				{messages.TagTimerExpiry, stoppingTimerExpiry, pb.Actual_Blade_off_disconnected, sm.Stay},
 			},
 			sm.UnexpectedMessage,
 			stoppingOnLeave),
 
 		sm.WithState(
-			bladeFaulted,
+			pb.Actual_Blade_faulted,
 			faultedEnter,
 			[]sm.ActionEntry{},
 			messages.DropMessage,
@@ -247,6 +201,25 @@ func newBlade(def *pb.BladeCapacity, r *Rack, id int64) *blade {
 	)
 
 	return b
+}
+
+// Save returns a protobuf instance containing the information needed to later
+// restore this state machine instance to the logical equivalence of its current
+// state.
+func (b *blade) Save() (proto.Message, error) {
+	cur, entered, terminal, guard := b.sm.Savable()
+
+	return &pb.Actual_Blade{
+		Condition:    pb.Actual_operational,
+		SmState:      cur.(pb.Actual_Blade_State),
+		StateExpires: b.hasActiveTimer,
+		Expiration:   b.expiration,
+		Core: &pb.Actual_MachineCore{
+			EnteredAt: entered,
+			Terminal:  terminal,
+			Guard:     guard,
+		},
+	}, nil
 }
 
 func (b *blade) Receive(ctx context.Context, msg sm.Envelope) {
@@ -262,7 +235,7 @@ func (b *blade) me() *messages.MessageTarget {
 // startedOnEnter initializes the simulation state and transitions to the
 // off and disconnected state.
 func startedOnEnter(ctx context.Context, machine *sm.SM) error {
-	return machine.ChangeState(ctx, bladeOffDiscon)
+	return machine.ChangeState(ctx, pb.Actual_Blade_off_disconnected)
 }
 
 // poweredConnOnEnter checks if automatic booting is enabled.  If it is, the
@@ -271,7 +244,7 @@ func poweredConnOnEnter(ctx context.Context, machine *sm.SM) error {
 	b := machine.Parent.(*blade)
 
 	if b.bootOnPower {
-		return machine.ChangeState(ctx, bladeBooting)
+		return machine.ChangeState(ctx, pb.Actual_Blade_booting)
 	}
 
 	return nil
@@ -291,8 +264,8 @@ func bootingTimerExpiry(ctx context.Context, machine *sm.SM, m sm.Envelope) bool
 
 // bootingOnLeave ensures that any active boot delay timer is canceled before
 // proceeding to a non-booting state.
-func bootingOnLeave(ctx context.Context, machine *sm.SM, nextState string) {
-	if nextState != bladeBooting {
+func bootingOnLeave(ctx context.Context, machine *sm.SM, nextState fmt.Stringer) {
+	if nextState != pb.Actual_Blade_booting {
 		cancelTimer(ctx, machine, "boot")
 	}
 }
@@ -306,8 +279,9 @@ func stoppingTimerExpiry(ctx context.Context, machine *sm.SM, m sm.Envelope) boo
 
 // stoppingOnLeave ensures that any active time is canceled before proceeding
 // to a non-stopping state.
-func stoppingOnLeave(ctx context.Context, machine *sm.SM, nextState string) {
-	if nextState != bladeStopping && nextState != bladeStoppingIsolated {
+func stoppingOnLeave(ctx context.Context, machine *sm.SM, nextState fmt.Stringer) {
+	if nextState != pb.Actual_Blade_stopping &&
+		nextState != pb.Actual_Blade_stopping_isolated {
 		cancelTimer(ctx, machine, "shutdown")
 	}
 }
@@ -329,7 +303,7 @@ func bladeGetStatus(ctx context.Context, machine *sm.SM, m sm.Envelope) bool {
 
 	status := &messages.BladeStatus{
 		StatusBody: messages.StatusBody{
-			State:     b.sm.CurrentIndex,
+			State:     b.sm.CurrentIndex.String(),
 			EnteredAt: b.sm.EnteredAt,
 		},
 		Capacity:  b.capacity.Clone(),
@@ -410,6 +384,7 @@ func setTimer(ctx context.Context, machine *sm.SM, delay int64) error {
 
 		b.hasActiveTimer = true
 		b.matchTimerExpiry = timerId
+		b.expiration = occursAt + delay
 	}
 
 	return nil

--- a/simulation/internal/services/inventory/cable.go
+++ b/simulation/internal/services/inventory/cable.go
@@ -3,6 +3,7 @@ package inventory
 import (
 	"github.com/Jim3Things/CloudChamber/simulation/internal/common"
 	"github.com/Jim3Things/CloudChamber/simulation/pkg/errors"
+	pb "github.com/Jim3Things/CloudChamber/simulation/pkg/protos/inventory"
 )
 
 // cable describes the active state of a connecting cable from the one element
@@ -85,4 +86,17 @@ func (c *cable) force(offOn bool, guard int64, at int64) (bool, error) {
 
 	c.on = offOn
 	return c.on != startState, nil
+}
+
+// save returns the protobuf structure that contains the cable state.
+func (c *cable) save() *pb.Actual_Cable {
+	on := pb.Actual_Cable_off
+	if c.on {
+		on = pb.Actual_Cable_on
+	}
+
+	return &pb.Actual_Cable{
+		State:   on,
+		Faulted: c.faulted,
+	}
 }

--- a/simulation/internal/services/inventory/messages/RepairActionState.go
+++ b/simulation/internal/services/inventory/messages/RepairActionState.go
@@ -9,7 +9,7 @@ import (
 // RepairActionState is the abstract definition that all inventory state
 // machines must implement.
 type RepairActionState interface {
-	sm.SmState
+	sm.State
 
 	// Power is the function that responds to a setPower message.
 	Power(ctx context.Context, sm *sm.SM, msg *SetPower)

--- a/simulation/internal/services/inventory/rack_test.go
+++ b/simulation/internal/services/inventory/rack_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Jim3Things/CloudChamber/simulation/internal/sm"
 	"github.com/Jim3Things/CloudChamber/simulation/internal/tracing"
 	"github.com/Jim3Things/CloudChamber/simulation/pkg/errors"
+	pb "github.com/Jim3Things/CloudChamber/simulation/pkg/protos/inventory"
 )
 
 type RackTestSuite struct {
@@ -55,19 +56,19 @@ func (ts *RackTestSuite) TestStartStopRack() {
 	r := newRack(ctx, ts.rackName(), rackDef, ts.timers)
 	require.NotNil(r)
 	assert.Equal(len(rackDef.Blades), len(r.blades))
-	assert.Equal(rackAwaitingStartState, r.sm.CurrentIndex)
+	assert.Equal(pb.Actual_Rack_awaiting_start, r.sm.CurrentIndex)
 
 	err := r.start(ctx)
 	assert.NoError(err)
 
 	require.Eventually(func() bool {
-		return r.sm.CurrentIndex == rackWorkingState
+		return r.sm.CurrentIndex == pb.Actual_Rack_working
 	}, time.Second, 10*time.Millisecond,
 		"state is %v", r.sm.CurrentIndex)
 
 	r.stop(ctx)
 	require.Eventually(func() bool {
-		return r.sm.CurrentIndex == rackTerminalState
+		return r.sm.CurrentIndex == pb.Actual_Rack_terminated
 	}, time.Second, 10*time.Millisecond,
 		"state is %v", r.sm.CurrentIndex)
 
@@ -90,13 +91,13 @@ func (ts *RackTestSuite) TestStartStartStopRack() {
 	r := newRack(ctx, ts.rackName(), rackDef, ts.timers)
 	require.NotNil(r)
 	assert.Equal(len(rackDef.Blades), len(r.blades))
-	assert.Equal(rackAwaitingStartState, r.sm.CurrentIndex)
+	assert.Equal(pb.Actual_Rack_awaiting_start, r.sm.CurrentIndex)
 
 	err := r.start(ctx)
 	assert.NoError(err)
 
 	require.Eventually(func() bool {
-		return r.sm.CurrentIndex == rackWorkingState
+		return r.sm.CurrentIndex == pb.Actual_Rack_working
 	}, time.Second, 10*time.Millisecond,
 		"state is %v", r.sm.CurrentIndex)
 
@@ -104,11 +105,11 @@ func (ts *RackTestSuite) TestStartStartStopRack() {
 	assert.Error(err)
 	assert.Equal(errors.ErrAlreadyStarted, err)
 
-	assert.Equal(rackWorkingState, r.sm.CurrentIndex)
+	assert.Equal(pb.Actual_Rack_working, r.sm.CurrentIndex)
 
 	r.stop(ctx)
 	require.Eventually(func() bool {
-		return r.sm.CurrentIndex == rackTerminalState
+		return r.sm.CurrentIndex == pb.Actual_Rack_terminated
 	}, time.Second, 10*time.Millisecond,
 		"state is %v", r.sm.CurrentIndex)
 
@@ -131,24 +132,24 @@ func (ts *RackTestSuite) TestStartStopStopRack() {
 	r := newRack(ctx, ts.rackName(), rackDef, ts.timers)
 	require.NotNil(r)
 	assert.Equal(len(rackDef.Blades), len(r.blades))
-	assert.Equal(rackAwaitingStartState, r.sm.CurrentIndex)
+	assert.Equal(pb.Actual_Rack_awaiting_start, r.sm.CurrentIndex)
 
 	err := r.start(ctx)
 	assert.NoError(err)
 
 	require.Eventually(func() bool {
-		return r.sm.CurrentIndex == rackWorkingState
+		return r.sm.CurrentIndex == pb.Actual_Rack_working
 	}, time.Second, 10*time.Millisecond,
 		"state is %v", r.sm.CurrentIndex)
 
 	r.stop(ctx)
 	require.Eventually(func() bool {
-		return r.sm.CurrentIndex == rackTerminalState
+		return r.sm.CurrentIndex == pb.Actual_Rack_terminated
 	}, time.Second, 10*time.Millisecond,
 		"state is %v", r.sm.CurrentIndex)
 
 	r.stop(ctx)
-	assert.Equal(rackTerminalState, r.sm.CurrentIndex)
+	assert.Equal(pb.Actual_Rack_terminated, r.sm.CurrentIndex)
 
 	span.End()
 }
@@ -169,10 +170,10 @@ func (ts *RackTestSuite) TestStopNoStartRack() {
 	r := newRack(ctx, ts.rackName(), rackDef, ts.timers)
 	require.NotNil(r)
 	assert.Equal(len(rackDef.Blades), len(r.blades))
-	assert.Equal(rackAwaitingStartState, r.sm.CurrentIndex)
+	assert.Equal(pb.Actual_Rack_awaiting_start, r.sm.CurrentIndex)
 
 	r.stop(ctx)
-	assert.Equal(rackTerminalState, r.sm.CurrentIndex)
+	assert.Equal(pb.Actual_Rack_terminated, r.sm.CurrentIndex)
 
 	span.End()
 }
@@ -193,13 +194,13 @@ func (ts *RackTestSuite) TestPowerOnPdu() {
 	r := newRack(ctx, ts.rackName(), rackDef, ts.timers)
 	require.NotNil(r)
 	assert.Equal(len(rackDef.Blades), len(r.blades))
-	assert.Equal(rackAwaitingStartState, r.sm.CurrentIndex)
+	assert.Equal(pb.Actual_Rack_awaiting_start, r.sm.CurrentIndex)
 
 	err := r.start(ctx)
 	assert.NoError(err)
 
 	require.Eventually(func() bool {
-		return r.sm.CurrentIndex == rackWorkingState
+		return r.sm.CurrentIndex == pb.Actual_Rack_working
 	}, time.Second, 10*time.Millisecond,
 		"state is %v", r.sm.CurrentIndex)
 
@@ -225,10 +226,10 @@ func (ts *RackTestSuite) TestPowerOnPdu() {
 		assert.False(c.on)
 	}
 
-	assert.Equal(pduWorkingState, r.pdu.sm.CurrentIndex)
+	assert.Equal(pb.Actual_Pdu_working, r.pdu.sm.CurrentIndex)
 
 	r.stop(ctx)
-	assert.Equal(rackTerminalState, r.sm.CurrentIndex)
+	assert.Equal(pb.Actual_Rack_terminated, r.sm.CurrentIndex)
 
 	span.End()
 }

--- a/simulation/internal/services/inventory/testSuiteCore.go
+++ b/simulation/internal/services/inventory/testSuiteCore.go
@@ -139,7 +139,7 @@ func (ts *testSuiteCore) bootBlade(ctx context.Context, r *Rack, id int64) conte
 	require.NoError(res.Err)
 
 	return ts.advanceToStateChange(ctx, 10, func() bool {
-		return bladeWorking == r.blades[id].sm.CurrentIndex
+		return pb.Actual_Blade_working == r.blades[id].sm.CurrentIndex
 	})
 }
 

--- a/simulation/internal/services/stepper/stepper.go
+++ b/simulation/internal/services/stepper/stepper.go
@@ -4,6 +4,7 @@ package stepper
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -15,32 +16,10 @@ import (
 	"github.com/Jim3Things/CloudChamber/simulation/internal/sm"
 	"github.com/Jim3Things/CloudChamber/simulation/internal/tracing"
 	"github.com/Jim3Things/CloudChamber/simulation/pkg/errors"
+	pb "github.com/Jim3Things/CloudChamber/simulation/pkg/protos/services"
 )
 
 const (
-	// awaitingStart is the state prior to initializing the state machine.
-	awaitingStart = "AwaitingStart"
-
-	// invalidState is the state used when no legal policy is in force.
-	invalidState = "Invalid"
-
-	// noWaitState manages the policy where the simulated time is either
-	// manually stepped forward, or, if a Delay operation is called, it jumps
-	// forward to immediately complete any waiter.
-	noWaitState = "NoWait"
-
-	// manualState manages the policy where simulated time only moves forward
-	// due to specific Step operations.
-	manualState = "Manual"
-
-	// measuredState manages the policy where simulated time moves forward by
-	// one tick per a designated real time interval (e.g. 1 tick / second)
-	measuredState = "Measured"
-
-	// faultedState is the state the machine transitions to when an internal
-	// error has occurred.  It is a terminal state.
-	faultedState = "Faulted"
-
 	// queueDepth is the number of incoming messages that may be queued up
 	// before the sender is forced to wait.
 	queueDepth = 100
@@ -84,22 +63,22 @@ func newStepper(startingPolicy int) *stepper {
 
 	s.sm = sm.NewSM(s,
 		sm.WithFirstState(
-			awaitingStart,
+			pb.StepperState_awaiting_start,
 			sm.NullEnter,
 			[]sm.ActionEntry{
-				{sm.TagStartSM, doStart, sm.Stay, faultedState},
+				{sm.TagStartSM, doStart, sm.Stay, pb.StepperState_faulted},
 			},
 			sm.UnexpectedMessage,
 			sm.NullLeave),
 
 		sm.WithState(
-			invalidState,
+			pb.StepperState_invalid,
 			invalidStateEnter,
 			[]sm.ActionEntry{
-				{messages.TagNoWaitPolicy, policy, noWaitState, sm.Stay},
-				{messages.TagMeasuredPolicy, measuredPolicy, measuredState, sm.Stay},
-				{messages.TagManualPolicy, policy, manualState, sm.Stay},
-				{messages.TagReset, reset, invalidState, sm.Stay},
+				{messages.TagNoWaitPolicy, policy, pb.StepperState_no_wait, sm.Stay},
+				{messages.TagMeasuredPolicy, measuredPolicy, pb.StepperState_measured, sm.Stay},
+				{messages.TagManualPolicy, policy, pb.StepperState_manual, sm.Stay},
+				{messages.TagReset, reset, pb.StepperState_invalid, sm.Stay},
 				{messages.TagGetStatus, getStatus, sm.Stay, sm.Stay},
 				{messages.TagAutoStep, sm.Ignore, sm.Stay, sm.Stay},
 			},
@@ -107,13 +86,13 @@ func newStepper(startingPolicy int) *stepper {
 			sm.NullLeave),
 
 		sm.WithState(
-			noWaitState,
+			pb.StepperState_no_wait,
 			noWaitEnter,
 			[]sm.ActionEntry{
-				{messages.TagNoWaitPolicy, policy, noWaitState, sm.Stay},
-				{messages.TagMeasuredPolicy, measuredPolicy, measuredState, sm.Stay},
-				{messages.TagManualPolicy, policy, manualState, sm.Stay},
-				{messages.TagReset, reset, invalidState, sm.Stay},
+				{messages.TagNoWaitPolicy, policy, pb.StepperState_no_wait, sm.Stay},
+				{messages.TagMeasuredPolicy, measuredPolicy, pb.StepperState_measured, sm.Stay},
+				{messages.TagManualPolicy, policy, pb.StepperState_manual, sm.Stay},
+				{messages.TagReset, reset, pb.StepperState_invalid, sm.Stay},
 				{messages.TagGetStatus, getStatus, sm.Stay, sm.Stay},
 				{messages.TagStep, step, sm.Stay, sm.Stay},
 				{messages.TagNow, now, sm.Stay, sm.Stay},
@@ -124,13 +103,13 @@ func newStepper(startingPolicy int) *stepper {
 			sm.NullLeave),
 
 		sm.WithState(
-			manualState,
+			pb.StepperState_manual,
 			sm.NullEnter,
 			[]sm.ActionEntry{
-				{messages.TagNoWaitPolicy, policy, noWaitState, sm.Stay},
-				{messages.TagMeasuredPolicy, measuredPolicy, measuredState, sm.Stay},
-				{messages.TagManualPolicy, policy, manualState, sm.Stay},
-				{messages.TagReset, reset, invalidState, sm.Stay},
+				{messages.TagNoWaitPolicy, policy, pb.StepperState_no_wait, sm.Stay},
+				{messages.TagMeasuredPolicy, measuredPolicy, pb.StepperState_measured, sm.Stay},
+				{messages.TagManualPolicy, policy, pb.StepperState_manual, sm.Stay},
+				{messages.TagReset, reset, pb.StepperState_invalid, sm.Stay},
 				{messages.TagGetStatus, getStatus, sm.Stay, sm.Stay},
 				{messages.TagStep, step, sm.Stay, sm.Stay},
 				{messages.TagNow, now, sm.Stay, sm.Stay},
@@ -141,13 +120,13 @@ func newStepper(startingPolicy int) *stepper {
 			sm.NullLeave),
 
 		sm.WithState(
-			measuredState,
+			pb.StepperState_measured,
 			measuredEnter,
 			[]sm.ActionEntry{
-				{messages.TagNoWaitPolicy, policy, noWaitState, sm.Stay},
-				{messages.TagMeasuredPolicy, measuredPolicy, measuredState, sm.Stay},
-				{messages.TagManualPolicy, policy, manualState, sm.Stay},
-				{messages.TagReset, reset, invalidState, sm.Stay},
+				{messages.TagNoWaitPolicy, policy, pb.StepperState_no_wait, sm.Stay},
+				{messages.TagMeasuredPolicy, measuredPolicy, pb.StepperState_measured, sm.Stay},
+				{messages.TagManualPolicy, policy, pb.StepperState_manual, sm.Stay},
+				{messages.TagReset, reset, pb.StepperState_invalid, sm.Stay},
 				{messages.TagGetStatus, getStatus, sm.Stay, sm.Stay},
 				{messages.TagNow, now, sm.Stay, sm.Stay},
 				{messages.TagDelay, delay, sm.Stay, sm.Stay},
@@ -157,7 +136,7 @@ func newStepper(startingPolicy int) *stepper {
 			measuredLeave),
 
 		sm.WithState(
-			faultedState,
+			pb.StepperState_faulted,
 			sm.TerminalEnter,
 			[]sm.ActionEntry{},
 			sm.UnexpectedMessage,
@@ -181,7 +160,7 @@ func (s *stepper) start(ctx context.Context) error {
 
 	// Only start the state machine once.  If it has already been started
 	// then ignore this call.
-	if s.sm.CurrentIndex == awaitingStart {
+	if s.sm.CurrentIndex == pb.StepperState_awaiting_start {
 		go s.simulate()
 
 		repl := make(chan *sm.Response)
@@ -300,7 +279,7 @@ func measuredEnter(ctx context.Context, machine *sm.SM) error {
 
 // measuredLeave cancels the recurring timer and the associated background
 // goroutine.
-func measuredLeave(_ context.Context, machine *sm.SM, _ string) {
+func measuredLeave(_ context.Context, machine *sm.SM, _ fmt.Stringer) {
 	s := machine.Parent.(*stepper)
 
 	s.stopTicker <- true
@@ -325,16 +304,16 @@ func doStart(ctx context.Context, machine *sm.SM, msg sm.Envelope) bool {
 
 	switch s.firstPolicy {
 	case messages.PolicyInvalid:
-		err = machine.ChangeState(ctx, invalidState)
+		err = machine.ChangeState(ctx, pb.StepperState_invalid)
 
 	case messages.PolicyMeasured:
-		err = machine.ChangeState(ctx, measuredState)
+		err = machine.ChangeState(ctx, pb.StepperState_measured)
 
 	case messages.PolicyManual:
-		err = machine.ChangeState(ctx, manualState)
+		err = machine.ChangeState(ctx, pb.StepperState_manual)
 
 	case messages.PolicyNoWait:
-		err = machine.ChangeState(ctx, noWaitState)
+		err = machine.ChangeState(ctx, pb.StepperState_no_wait)
 
 	default:
 		err = &errors.ErrInvalidEnum{
@@ -600,15 +579,15 @@ func checkForExpiry(ctx context.Context, machine *sm.SM) {
 
 // convertFromState translates the current state into a policy enum value that
 // can be used in the GetStatus response message.
-func convertFromState(state string) int {
+func convertFromState(state fmt.Stringer) int {
 	switch state {
-	case manualState:
+	case pb.StepperState_manual:
 		return messages.PolicyManual
 
-	case measuredState:
+	case pb.StepperState_measured:
 		return messages.PolicyMeasured
 
-	case noWaitState:
+	case pb.StepperState_no_wait:
 		return messages.PolicyNoWait
 
 	default:

--- a/simulation/internal/services/stepper/stepper.go
+++ b/simulation/internal/services/stepper/stepper.go
@@ -4,7 +4,6 @@ package stepper
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -279,7 +278,7 @@ func measuredEnter(ctx context.Context, machine *sm.SM) error {
 
 // measuredLeave cancels the recurring timer and the associated background
 // goroutine.
-func measuredLeave(_ context.Context, machine *sm.SM, _ fmt.Stringer) {
+func measuredLeave(_ context.Context, machine *sm.SM, _ sm.StateIndex) {
 	s := machine.Parent.(*stepper)
 
 	s.stopTicker <- true
@@ -579,7 +578,7 @@ func checkForExpiry(ctx context.Context, machine *sm.SM) {
 
 // convertFromState translates the current state into a policy enum value that
 // can be used in the GetStatus response message.
-func convertFromState(state fmt.Stringer) int {
+func convertFromState(state sm.StateIndex) int {
 	switch state {
 	case pb.StepperState_manual:
 		return messages.PolicyManual

--- a/simulation/internal/sm/actionState.go
+++ b/simulation/internal/sm/actionState.go
@@ -2,15 +2,10 @@ package sm
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Jim3Things/CloudChamber/simulation/internal/common"
 	"github.com/Jim3Things/CloudChamber/simulation/internal/tracing"
-)
-
-const (
-	// Stay is used in an ActionEntry as shorthand to indicate that there is
-	// no state transition to process.
-	Stay = ""
 )
 
 var (
@@ -19,6 +14,10 @@ var (
 
 	// NullLeave defines a state exit function that does nothing.
 	NullLeave LeaveFunc = nil
+
+	// Stay is used in an ActionEntry as shorthand to indicate that there is
+	// no state transition to process.
+	Stay fmt.Stringer = nil
 )
 
 // ActionState is the common definition for how to process incoming requests
@@ -50,7 +49,7 @@ type EnterFunc func(ctx context.Context, machine *SM) error
 // parameter contains the state ID for the state being transitioned to.  This
 // allows for special processing when, for instance, the transition is from
 // the current state back into the current state.
-type LeaveFunc func(ctx context.Context, machine *SM, nextState string)
+type LeaveFunc func(ctx context.Context, machine *SM, nextState fmt.Stringer)
 
 // ActionFunc is the signature definition for a message processing function
 // listed in an ActionEntry.
@@ -65,10 +64,10 @@ type ActionEntry struct {
 	Action ActionFunc
 
 	// TrueState is the state ID to change to if Action returns true.
-	TrueState string
+	TrueState fmt.Stringer
 
 	// FalseState is the state ID to change to if Action returns false.
-	FalseState string
+	FalseState fmt.Stringer
 }
 
 // NewActionState creates a new ActionState instance with the supplied match
@@ -100,7 +99,7 @@ func (s *ActionState) Receive(ctx context.Context, machine *SM, msg Envelope) {
 	}
 }
 
-func (s *ActionState) Leave(ctx context.Context, sm *SM, nextState string) {
+func (s *ActionState) Leave(ctx context.Context, sm *SM, nextState fmt.Stringer) {
 	if s.OnLeave != nil {
 		s.OnLeave(ctx, sm, nextState)
 	}

--- a/simulation/internal/sm/actionState.go
+++ b/simulation/internal/sm/actionState.go
@@ -2,7 +2,6 @@ package sm
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/Jim3Things/CloudChamber/simulation/internal/common"
 	"github.com/Jim3Things/CloudChamber/simulation/internal/tracing"
@@ -17,7 +16,7 @@ var (
 
 	// Stay is used in an ActionEntry as shorthand to indicate that there is
 	// no state transition to process.
-	Stay fmt.Stringer = nil
+	Stay StateIndex = nil
 )
 
 // ActionState is the common definition for how to process incoming requests
@@ -49,7 +48,7 @@ type EnterFunc func(ctx context.Context, machine *SM) error
 // parameter contains the state ID for the state being transitioned to.  This
 // allows for special processing when, for instance, the transition is from
 // the current state back into the current state.
-type LeaveFunc func(ctx context.Context, machine *SM, nextState fmt.Stringer)
+type LeaveFunc func(ctx context.Context, machine *SM, nextState StateIndex)
 
 // ActionFunc is the signature definition for a message processing function
 // listed in an ActionEntry.
@@ -64,10 +63,10 @@ type ActionEntry struct {
 	Action ActionFunc
 
 	// TrueState is the state ID to change to if Action returns true.
-	TrueState fmt.Stringer
+	TrueState StateIndex
 
 	// FalseState is the state ID to change to if Action returns false.
-	FalseState fmt.Stringer
+	FalseState StateIndex
 }
 
 // NewActionState creates a new ActionState instance with the supplied match
@@ -99,7 +98,7 @@ func (s *ActionState) Receive(ctx context.Context, machine *SM, msg Envelope) {
 	}
 }
 
-func (s *ActionState) Leave(ctx context.Context, sm *SM, nextState fmt.Stringer) {
+func (s *ActionState) Leave(ctx context.Context, sm *SM, nextState StateIndex) {
 	if s.OnLeave != nil {
 		s.OnLeave(ctx, sm, nextState)
 	}

--- a/simulation/internal/sm/messages.go
+++ b/simulation/internal/sm/messages.go
@@ -54,7 +54,7 @@ func UnexpectedMessageResponse(machine *SM, occursAt int64, body interface{}) *R
 	return &Response{
 		Err: &errors.ErrUnexpectedMessage{
 			Msg:   fmt.Sprintf("%v", body),
-			State: machine.CurrentIndex,
+			State: machine.CurrentIndex.String(),
 		},
 		At:  occursAt,
 		Msg: nil,

--- a/simulation/internal/sm/sm.go
+++ b/simulation/internal/sm/sm.go
@@ -11,6 +11,8 @@ import (
 	pb "github.com/Jim3Things/CloudChamber/simulation/pkg/protos/inventory"
 )
 
+// StateIndex denotes that the value is used as an index into the state machine
+// action states.
 type StateIndex interface {
 	fmt.Stringer
 }

--- a/simulation/internal/sm/state.go
+++ b/simulation/internal/sm/state.go
@@ -2,7 +2,6 @@ package sm
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/Jim3Things/CloudChamber/simulation/internal/common"
 )
@@ -18,7 +17,7 @@ type State interface {
 	Receive(ctx context.Context, machine *SM, msg Envelope)
 
 	// Leave is called when a state transition moves away from this state
-	Leave(ctx context.Context, sm *SM, nextState fmt.Stringer)
+	Leave(ctx context.Context, sm *SM, nextState StateIndex)
 }
 
 // NullState is the default implementation of an SM state

--- a/simulation/internal/sm/state.go
+++ b/simulation/internal/sm/state.go
@@ -2,12 +2,13 @@ package sm
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Jim3Things/CloudChamber/simulation/internal/common"
 )
 
-// SmState defines the methods used for state actions and transitions.
-type SmState interface {
+// State defines the methods used for state actions and transitions.
+type State interface {
 
 	// Enter is called when a state transition moves to this state
 	Enter(ctx context.Context, sm *SM) error
@@ -17,7 +18,7 @@ type SmState interface {
 	Receive(ctx context.Context, machine *SM, msg Envelope)
 
 	// Leave is called when a state transition moves away from this state
-	Leave(ctx context.Context, sm *SM, nextState string)
+	Leave(ctx context.Context, sm *SM, nextState fmt.Stringer)
 }
 
 // NullState is the default implementation of an SM state


### PR DESCRIPTION
This adds the save-to-a-protobuf part of the state machine. Restore, and actual connection to the store are later.

Rack and stepper are mostly latent support to be filled in later.