### PR TITLE
Replace all uses of earlier inventory yaml format with extended version (Closes #228, closes #235)

### DIFF
--- a/simulation/internal/clients/inventory/definition_test.go
+++ b/simulation/internal/clients/inventory/definition_test.go
@@ -2865,28 +2865,28 @@ func (ts *definitionTestSuite) TestReadInventoryFromStore() {
 func (ts *definitionTestSuite) TestReadInventoryDefinitionFromFileExBasic() {
 	require := ts.Require()
 
-	_, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/basic")
+	_, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/basic")
 	require.NoError(err)
 }
 
 func (ts *definitionTestSuite) TestReadInventoryDefinitionFromFileExExtended() {
 	require := ts.Require()
 
-	_, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/extended")
+	_, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/extended")
 	require.NoError(err)
 }
 
 func (ts *definitionTestSuite) TestReadInventoryDefinitionFromFileExStandard() {
 	require := ts.Require()
 
-	_, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/standard")
+	_, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/standard")
 	require.NoError(err)
 }
 
 func (ts *definitionTestSuite) TestReadInventoryDefinitionFromFileExReference() {
 	require := ts.Require()
 
-	_, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/reference")
+	_, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/reference")
 	require.NoError(err)
 }
 
@@ -2901,7 +2901,7 @@ func (ts *definitionTestSuite) TestLoadInventoryIntoStore() {
 	err = ts.inventory.deleteInventoryDefinitionFromStore(ctx, root)
 	require.NoError(err)
 
-	root, err = ReadInventoryDefinitionFromFileEx(ctx, "./testdata/extended")
+	root, err = ReadInventoryDefinitionFromFile(ctx, "./testdata/extended")
 	require.NoError(err)
 	require.NotNil(root)
 

--- a/simulation/internal/clients/inventory/inventory.go
+++ b/simulation/internal/clients/inventory/inventory.go
@@ -1025,7 +1025,6 @@ type Inventory struct {
 	Store              *store.Store
 	RootSummary        *RootSummary
 	DefaultZoneSummary *ZoneSummary
-	summaryInfoValid   bool
 }
 
 // NewInventory is a helper routine to construct an empty Inventory structure

--- a/simulation/internal/clients/inventory/inventory.go
+++ b/simulation/internal/clients/inventory/inventory.go
@@ -1089,7 +1089,7 @@ func (m *Inventory) UpdateInventoryDefinition(ctx context.Context, path string) 
 	// into the store looking to see if there are any material changes between
 	// what is already in the store and what is now found in the file.
 	//
-	rootFile, err := ReadInventoryDefinitionFromFileEx(ctx, path)
+	rootFile, err := ReadInventoryDefinitionFromFile(ctx, path)
 	if err != nil {
 		return err
 	}

--- a/simulation/internal/clients/inventory/reader.go
+++ b/simulation/internal/clients/inventory/reader.go
@@ -22,45 +22,6 @@ const (
 
 // +++ Intermediate binary format
 
-// This mirrors the external zone format except the keys
-// are fields of array
-
-type zone struct {
-	Racks []rack
-}
-
-type rack struct {
-	Name   string
-	Blades []blade
-	Tor    tor
-	Pdu    pdu
-}
-
-type blade struct {
-	Index                  int64
-	Arch                   string
-	Cores                  int64
-	DiskInGb               int64
-	MemoryInMb             int64
-	NetworkBandwidthInMbps int64
-}
-
-type tor struct {
-}
-
-type pdu struct {
-}
-
-type rootEx struct {
-	ZoneTypes   []catZone
-	RackTypes   []catRack
-	PduTypes    []catPdu
-	TorTypes    []catTor
-	BladeTypes  []catBlade
-	Details     rootExDetails
-	Regions     []regionEx
-}
-
 // ++++++++++
 //
 // The folowing catXxx structs are used as throwaway data fields to enable
@@ -112,6 +73,21 @@ type catPort struct {
 
 // ----------
 
+
+// This struct is used to load the inventory definition file in a
+// temporary format prior to converting to something the rest of
+// the system understand and using that to update the persisted
+//inventory in the store.
+//
+type rootEx struct {
+	ZoneTypes   []catZone
+	RackTypes   []catRack
+	PduTypes    []catPdu
+	TorTypes    []catTor
+	BladeTypes  []catBlade
+	Details     rootExDetails
+	Regions     []regionEx
+}
 
 type rootExDetails struct {
 	Name  string
@@ -222,288 +198,6 @@ type bladeExBootinfo struct {
 
 // --- Intermediate binary format
 
-// ReadInventoryDefinition imports the inventory from
-// external YAML file and transforms it into the
-// internal Cloud chamber binary format.
-func ReadInventoryDefinition(ctx context.Context, path string) (*pb.External_Zone, error) {
-	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithName("Read inventory definition from file"),
-		tracing.WithContextValue(timestamp.EnsureTickInContext),
-		tracing.AsInternal())
-	defer span.End()
-
-	viper.SetConfigName(defaultDefinitionFile)
-	viper.AddConfigPath(path)
-	viper.SetConfigType(defaultConfigType)
-
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			err = fmt.Errorf("no inventory definition found at %s/%s (%s)",
-				path,
-				defaultDefinitionFile,
-				defaultConfigType)
-		} else {
-			err = fmt.Errorf("fatal error reading definition file: %s", err)
-		}
-
-		return nil, tracing.Error(ctx, err)
-	}
-
-	// First we are going to put it into intermediate format
-	xfr := &zone{}
-	if err := viper.UnmarshalExact(xfr); err != nil {
-		return nil, tracing.Error(ctx, "unable to decode into struct, %v", err)
-	}
-
-	// Now convert it into its final form
-	cfg, err := toExternalZone(xfr)
-	if err != nil {
-		return nil, tracing.Error(ctx, err)
-	}
-
-	tracing.Info(ctx, "Inventory definition Read: \n%v", cfg)
-
-	return cfg, nil
-}
-
-// toExternalZone converts intermediate values to the final format
-// One important difference is that the intermediate is array based.
-// The final format is map based using specific fields in array
-// entries as the map keys
-func toExternalZone(xfr *zone) (*pb.External_Zone, error) {
-	cfg := &pb.External_Zone{
-		Racks: make(map[string]*pb.External_Rack),
-	}
-
-	for _, r := range xfr.Racks {
-		if _, ok := cfg.Racks[r.Name]; ok {
-			return nil, errors.ErrDuplicateRack(r.Name)
-		}
-
-		cfg.Racks[r.Name] = &pb.External_Rack{
-			Tor:    &pb.External_Tor{},
-			Pdu:    &pb.External_Pdu{},
-			Blades: make(map[int64]*pb.BladeCapacity),
-		}
-
-		for _, b := range r.Blades {
-			if _, ok := cfg.Racks[r.Name].Blades[b.Index]; ok {
-				return nil, errors.ErrDuplicateBlade{
-					Blade: b.Index,
-					Rack:  r.Name,
-				}
-			}
-
-			cfg.Racks[r.Name].Blades[b.Index] = &pb.BladeCapacity{
-				Cores:                  b.Cores,
-				MemoryInMb:             b.MemoryInMb,
-				DiskInGb:               b.DiskInGb,
-				NetworkBandwidthInMbps: b.NetworkBandwidthInMbps,
-				Arch:                   b.Arch,
-			}
-		}
-
-		if err := cfg.Racks[r.Name].Validate(); err != nil {
-			return nil, errors.ErrRackValidationFailure{
-				Rack: r.Name,
-				Err:  err,
-			}
-		}
-	}
-
-	return cfg, nil
-}
-
-// ReadInventoryDefinitionFromFile imports the inventory from
-// an external YAML file and transforms it into the
-// internal Cloud chamber binary format.
-//
-func ReadInventoryDefinitionFromFile(ctx context.Context, path string) (*pb.Definition_Region, error) {
-	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithName("Read inventory definition from file"),
-		tracing.WithContextValue(timestamp.EnsureTickInContext),
-		tracing.AsInternal())
-	defer span.End()
-
-	viper.SetConfigName(defaultDefinitionFile)
-	viper.AddConfigPath(path)
-	viper.SetConfigType(defaultConfigType)
-
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			err = fmt.Errorf("no inventory definition found at %s/%s (%s)",
-				path,
-				defaultDefinitionFile,
-				defaultConfigType)
-		} else {
-			err = fmt.Errorf("fatal error reading definition file: %s", err)
-		}
-
-		return nil, tracing.Error(ctx, err)
-	}
-
-	// First we are going to put it into intermediate format
-	xfr := &zone{}
-	if err := viper.UnmarshalExact(xfr); err != nil {
-		return nil, tracing.Error(ctx, "unable to decode into struct, %v", err)
-	}
-
-	// Now convert it into its final form
-	region, err := toDefinitionRegionInternal(xfr)
-	if err != nil {
-		return nil, tracing.Error(ctx, err)
-	}
-
-	tracing.Info(ctx, "Inventory definition Read: \n%v", region)
-
-	return region, nil
-}
-
-// toDefinitionRegionInternal converts intermediate values to the final format
-// One important difference is that the intermediate is array based.
-// The final format is map based using specific fields in array
-// entries as the map keys
-//
-func toDefinitionRegionInternal(xfr *zone) (*pb.Definition_Region, error) {
-
-	region := &pb.Definition_Region{
-		Details: &pb.RegionDetails{},
-		Zones:   make(map[string]*pb.Definition_Zone)}
-
-	// Since we only have a single zone at present, there is no loop
-	// here. But there will be eventually.
-	//
-	zone := &pb.Definition_Zone{
-		Details: &pb.ZoneDetails{
-			Enabled:  true,
-			State:    pb.State_in_service,
-			Location: "DC-PNW-0",
-			Notes:    "Base zone",
-		},
-		Racks: make(map[string]*pb.Definition_Rack),
-	}
-
-	// For each rack in the supplied configuration, create rack in the
-	// zone. Each rack has some details, a set of PDUs, a set of TORs,
-	// and a set of blades.
-	//
-	for _, r := range xfr.Racks {
-		if _, ok := zone.Racks[r.Name]; ok {
-			return nil, errors.ErrDuplicateRack(r.Name)
-		}
-
-		rack := &pb.Definition_Rack{
-			Details: &pb.RackDetails{
-				Enabled:   true,
-				Condition: pb.Condition_operational,
-				Location:  "DC-PNW-0-" + r.Name,
-				Notes:     "RackName: " + r.Name,
-			},
-			Pdus:   make(map[int64]*pb.Definition_Pdu),
-			Tors:   make(map[int64]*pb.Definition_Tor),
-			Blades: make(map[int64]*pb.Definition_Blade),
-		}
-
-		// Currently only have one each of Pdu and Tor per-rack.
-		//
-		// NOTE: At present, the Pdu and Tor are completely
-		// synthesized and not actually read from the definition
-		// file.
-		//
-		rack.Pdus[0] = &pb.Definition_Pdu{
-			Details: &pb.PduDetails{
-				Enabled:   true,
-				Condition: pb.Condition_operational,
-			},
-			Ports: make(map[int64]*pb.PowerPort),
-		}
-
-		rack.Tors[0] = &pb.Definition_Tor{
-			Details: &pb.TorDetails{
-				Enabled:   true,
-				Condition: pb.Condition_operational,
-			},
-			Ports: make(map[int64]*pb.NetworkPort),
-		}
-
-		// We do support more than a single blade for each rack
-		// so iterate over each of the blades in the supplied
-		// configuration.
-		//
-		for _, b := range r.Blades {
-
-			// If we already have a blade definition at the index
-			// for the blade, it MUST be a duplicate, which we do
-			// not allow, so fail describing where we found the
-			// issue.
-			//
-			if _, ok := rack.Blades[b.Index]; ok {
-				return nil, errors.ErrDuplicateBlade{
-					Blade: b.Index,
-					Rack:  r.Name,
-				}
-			}
-
-			// Add a blade definition based upon the supplied
-			// configuration.and add in the fields which do not
-			// (currently) have an existence in the configuration
-			// file.
-			//
-			rack.Blades[b.Index] = &pb.Definition_Blade{
-				Details: &pb.BladeDetails{
-					Enabled:   true,
-					Condition: pb.Condition_operational,
-				},
-				Capacity: &pb.BladeCapacity{
-					Cores:                  b.Cores,
-					MemoryInMb:             b.MemoryInMb,
-					DiskInGb:               b.DiskInGb,
-					NetworkBandwidthInMbps: b.NetworkBandwidthInMbps,
-					Arch:                   b.Arch,
-				},
-			}
-
-			// For the given blade index, add a matching connection
-			// in the PDU to allow power for the blade to be
-			// connected and controlled.
-			//
-			rack.Pdus[0].Ports[b.Index] = &pb.PowerPort{
-				Wired: true,
-				Item: &pb.Hardware{
-					Type: pb.Hardware_blade,
-					Id:   b.Index,
-					Port: 0,
-				},
-			}
-
-			// For the given blade index, add a matching connection
-			// in the TOR to allow a network for the blade to be
-			// connected and controlled.
-			//
-			rack.Tors[0].Ports[b.Index] = &pb.NetworkPort{
-				Wired: true,
-				Item: &pb.Hardware{
-					Type: pb.Hardware_blade,
-					Id:   b.Index,
-					Port: 0,
-				},
-			}
-		}
-
-		if err := rack.Validate(""); err != nil {
-			return nil, errors.ErrRackValidationFailure{
-				Rack: r.Name,
-				Err:  err,
-			}
-		}
-
-		zone.Racks[r.Name] = rack
-	}
-
-	region.Zones[DefaultZone] = zone
-
-	return region, nil
-}
 
 // ReadInventoryDefinitionFromFileEx imports the inventory from
 // an external YAML file and transforms it into the

--- a/simulation/internal/clients/inventory/reader.go
+++ b/simulation/internal/clients/inventory/reader.go
@@ -199,11 +199,11 @@ type bladeExBootinfo struct {
 // --- Intermediate binary format
 
 
-// ReadInventoryDefinitionFromFileEx imports the inventory from
+// ReadInventoryDefinitionFromFile imports the inventory from
 // an external YAML file and transforms it into the
 // internal Cloud chamber binary format.
 //
-func ReadInventoryDefinitionFromFileEx(ctx context.Context, path string) (*pb.Definition_Root, error) {
+func ReadInventoryDefinitionFromFile(ctx context.Context, path string) (*pb.Definition_Root, error) {
 	ctx, span := tracing.StartSpan(ctx,
 		tracing.WithName("Read inventory definition from file"),
 		tracing.WithContextValue(timestamp.EnsureTickInContext),
@@ -244,58 +244,28 @@ func ReadInventoryDefinitionFromFileEx(ctx context.Context, path string) (*pb.De
 	return root, nil
 }
 
-var conditionmMap = map[string]pb.Condition{
-	"not_in_service": pb.Condition_not_in_service,
-	"operational":    pb.Condition_operational,
-	"burn_in":        pb.Condition_burn_in,
-	"out_for_repair": pb.Condition_out_for_repair,
-	"retiring":       pb.Condition_retiring,
-	"retired":        pb.Condition_retired,
-}
-
-var stateMap = map[string]pb.State{
-	"out_of_service":  pb.State_out_of_service,
-	"in_service":      pb.State_in_service,
-	"commissioning":   pb.State_commissioning,
-	"assumed_failed":  pb.State_assumed_failed,
-	"decommissioning": pb.State_decommissioning,
-	"decommissioned":  pb.State_decommissioned,
-}
-
 func getConditionFromString(c string) (pb.Condition, bool) {
-	cond, ok := conditionmMap[strings.ToLower(c)]
+	cond, ok := pb.Condition_value[strings.ToLower(c)]
 
-	return cond, ok
+	return pb.Condition(cond), ok
 }
 
 func getStateFromString(s string) (pb.State, bool) {
-	state, ok := stateMap[strings.ToLower(s)]
+	state, ok := pb.State_value[strings.ToLower(s)]
 
-	return state, ok
-}
-
-var methodMap = map[string]pb.BladeBootInfo_Method{
-	"local": pb.BladeBootInfo_local,
-	"network": pb.BladeBootInfo_network,
+	return pb.State(state), ok
 }
 
 func getBootMethodFromString(s string) (pb.BladeBootInfo_Method, bool) {
-	method, ok := methodMap[strings.ToLower(s)]
+	method, ok := pb.BladeBootInfo_Method_value[strings.ToLower(s)]
 
-	return method, ok
-}
-
-var hwTypeMap = map[string]pb.Hardware_HwType{
-	"unknown": pb.Hardware_unknown,
-	"pdu": 	   pb.Hardware_pdu,
-	"tor":     pb.Hardware_tor,
-	"blade":   pb.Hardware_blade,
+	return pb.BladeBootInfo_Method(method), ok
 }
 
 func getHwTypeFromString(t string) (pb.Hardware_HwType, bool) {
-	hwType, ok := hwTypeMap[strings.ToLower(t)]
+	hwType, ok := pb.Hardware_HwType_value[strings.ToLower(t)]
 
-	return hwType, ok
+	return pb.Hardware_HwType(hwType), ok
 }
 
 // toDefinitionRoot converts intermediate values to the final format

--- a/simulation/internal/clients/inventory/reader.go
+++ b/simulation/internal/clients/inventory/reader.go
@@ -246,11 +246,11 @@ func ReadInventoryDefinitionFromFileEx(ctx context.Context, path string) (*pb.De
 
 var conditionmMap = map[string]pb.Condition{
 	"not_in_service": pb.Condition_not_in_service,
-    "operational":    pb.Condition_operational,
-    "burn_in":        pb.Condition_burn_in,
-    "out_for_repair": pb.Condition_out_for_repair,
-    "retiring":       pb.Condition_retiring,
-    "retired":        pb.Condition_retired,
+	"operational":    pb.Condition_operational,
+	"burn_in":        pb.Condition_burn_in,
+	"out_for_repair": pb.Condition_out_for_repair,
+	"retiring":       pb.Condition_retiring,
+	"retired":        pb.Condition_retired,
 }
 
 var stateMap = map[string]pb.State{

--- a/simulation/internal/clients/inventory/reader_test.go
+++ b/simulation/internal/clients/inventory/reader_test.go
@@ -165,7 +165,7 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFile() {
 		//
 		assert.Equal(3, len(p0.Ports))
 
-		p0b0, ok := p0.Ports[1]
+		p0b0, ok := p0.Ports[0]
 		require.True(ok)
 
 		assert.True(p0b0.Wired)
@@ -264,7 +264,7 @@ func (ts *readerTestSuite) TestIReadInventoryDefinitionFromFileUniqueRack() {
 	require := ts.Require()
 
 	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/BadYaml")
-	require.EqualError(err, "Duplicate rack \"rack1\" detected")
+	require.EqualError(err, "CloudChamber: Configuration detected duplicate Rack rack1 in zone \"zone1\" in region \"region1\"")
 	require.Nil(response)
 }
 
@@ -272,7 +272,7 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileUniqueBlade() {
 	require := ts.Require()
 
 	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/BadYamlBlade")
-	require.EqualError(err, "Duplicate Blade 1 in Rack \"rack1\" detected")
+	require.EqualError(err, "CloudChamber: Configuration detected duplicate Blade for blade 1 in region \"region1\", zone \"zone1\", rack \"rack1\"")
 	require.Nil(response)
 }
 
@@ -280,7 +280,7 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileValidateBlade() {
 	require := ts.Require()
 
 	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/BadYamlValidate")
-	require.EqualError(err, "In rack \"rack1\": the field \"Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid")
+	require.EqualError(err, "CloudChamber: in region \"region1\": the field \"Zones[zone1].Racks[rack1].Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid")
 	require.Nil(response)
 }
 

--- a/simulation/internal/clients/inventory/reader_test.go
+++ b/simulation/internal/clients/inventory/reader_test.go
@@ -41,82 +41,96 @@ func (ts *readerTestSuite) TestReadInventoryDefinition() {
 	assert := ts.Assert()
 	require := ts.Require()
 
-	response, err := ReadInventoryDefinition(context.Background(), "./testdata/Simple")
+	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/Simple")
 	require.NoError(err)
 	require.NotNil(response)
 
-	require.Equal(2, len(response.Racks))
+	require.Equal(1, len(response.Regions))
+	region1, ok := response.Regions["region1"]
+	require.True(ok)
+	assert.Equal(1, len(region1.Zones))
 
-	r, ok := response.Racks["rack1"]
+	zone1, ok := region1.Zones["zone1"]
+	require.True(ok)
+	require.Equal(2, len(zone1.Racks))
+
+	r, ok := zone1.Racks["rack1"]
 	require.True(ok)
 	assert.Equal(2, len(r.Blades))
 
 	b, ok := r.Blades[1]
 	require.True(ok)
-	assert.Equal(int64(16), b.Cores)
-	assert.Equal(int64(16384), b.MemoryInMb)
-	assert.Equal(int64(240), b.DiskInGb)
-	assert.Equal(int64(2048), b.NetworkBandwidthInMbps)
-	assert.Equal("X64", b.Arch)
+	require.NotNil(b.Capacity)
+	assert.Equal(int64(16), b.Capacity.Cores)
+	assert.Equal(int64(16384), b.Capacity.MemoryInMb)
+	assert.Equal(int64(240), b.Capacity.DiskInGb)
+	assert.Equal(int64(2048), b.Capacity.NetworkBandwidthInMbps)
+	assert.Equal("X64", b.Capacity.Arch)
 
-	s, ok := response.Racks["rack2"]
+	s, ok := zone1.Racks["rack2"]
 	require.True(ok)
 	assert.Equal(2, len(s.Blades))
 
 	c, ok := r.Blades[2]
 	require.True(ok)
-	assert.Equal(int64(8), c.Cores)
-	assert.Equal(int64(16384), c.MemoryInMb)
-	assert.Equal(int64(120), c.DiskInGb)
-	assert.Equal(int64(2048), c.NetworkBandwidthInMbps)
+	require.NotNil(b.Capacity)
+	assert.Equal(int64(8), c.Capacity.Cores)
+	assert.Equal(int64(16384), c.Capacity.MemoryInMb)
+	assert.Equal(int64(120), c.Capacity.DiskInGb)
+	assert.Equal(int64(2048), c.Capacity.NetworkBandwidthInMbps)
+	assert.Equal("X64", b.Capacity.Arch)
 }
 
-func (ts *readerTestSuite) TestReadInventoryBogusPath() {
-	require := ts.Require()
+// func (ts *readerTestSuite) TestReadInventoryBogusPath() {
+// 	require := ts.Require()
 
-	response, err := ReadInventoryDefinition(context.Background(), "./missing/path")
-	require.EqualError(err, "no inventory definition found at ./missing/path/inventory.yaml (yaml)")
-	require.Nil(response)
-}
+// 	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./missing/path")
+// 	require.EqualError(err, "no inventory definition found at ./missing/path/inventory.yaml (yaml)")
+// 	require.Nil(response)
+// }
 
-// TestInventoryUniqueRack test to check that zone always contain unique rack numbers
-func (ts *readerTestSuite) TestInventoryUniqueRack() {
-	require := ts.Require()
+// // TestInventoryUniqueRack test to check that zone always contain unique rack numbers
+// func (ts *readerTestSuite) TestInventoryUniqueRack() {
+// 	require := ts.Require()
 
-	response, err := ReadInventoryDefinition(context.Background(), "./testdata/BadYaml")
-	require.EqualError(err, "Duplicate rack \"rack1\" detected")
-	require.Nil(response)
-}
+// 	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/BadYaml")
+// 	require.EqualError(err, "Duplicate rack \"rack1\" detected")
+// 	require.Nil(response)
+// }
 
-func (ts *readerTestSuite) TestInventoryUniqueBlade() {
-	require := ts.Require()
+// func (ts *readerTestSuite) TestInventoryUniqueBlade() {
+// 	require := ts.Require()
 
-	response, err := ReadInventoryDefinition(context.Background(), "./testdata/BadYamlBlade")
-	require.EqualError(err, "Duplicate Blade 1 in Rack \"rack1\" detected")
-	require.Nil(response)
-}
+// 	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/BadYamlBlade")
+// 	require.EqualError(err, "Duplicate Blade 1 in Rack \"rack1\" detected")
+// 	require.Nil(response)
+// }
 
-func (ts *readerTestSuite) TestInventoryValidateBlade() {
-	require := ts.Require()
+// func (ts *readerTestSuite) TestInventoryValidateBlade() {
+// 	require := ts.Require()
 
-	response, err := ReadInventoryDefinition(context.Background(), "./testdata/BadYamlValidate")
-	require.EqualError(err, "In rack \"rack1\": the field \"Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid")
-	require.Nil(response)
-}
+// 	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/BadYamlValidate")
+// 	require.EqualError(err, "In rack \"rack1\": the field \"Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid")
+// 	require.Nil(response)
+// }
 
 func (ts *readerTestSuite) TestReadInventoryDefinitionFromFile() {
 	assert := ts.Assert()
 	require := ts.Require()
 
-	zonemap, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/Simple")
+	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/Simple")
 	require.NoError(err)
-	require.NotNil(zonemap)
+	require.NotNil(response)
+
+	require.Equal(1, len(response.Regions))
+	region, ok := response.Regions["region1"]
+	require.True(ok)
 
 	// There should only be a single zone.
 	//
-	require.Equal(1, len(zonemap.Zones))
+	require.Equal(1, len(region.Zones))
 
-	zone, ok := zonemap.Zones[DefaultZone]
+	zone, ok := region.Zones["zone1"]
 	require.True(ok)
 
 	assert.True(zone.Details.Enabled)
@@ -147,9 +161,17 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFile() {
 		p0, ok := r.Pdus[0]
 		require.True(ok)
 
-		// The PDU should have a wired port for each of the two expected blades.
+		// The PDU should have a wired port for each of the two expected blades and one for the tor.
 		//
-		assert.Equal(2, len(p0.Ports))
+		assert.Equal(3, len(p0.Ports))
+
+		p0b0, ok := p0.Ports[1]
+		require.True(ok)
+
+		assert.True(p0b0.Wired)
+		assert.Equal(pb.Hardware_tor, p0b0.Item.Type)
+		assert.Equal(int64(0), p0b0.Item.Id)
+		assert.Equal(int64(1), p0b0.Item.Port)
 
 		p0b1, ok := p0.Ports[1]
 		require.True(ok)
@@ -172,9 +194,17 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFile() {
 		t0, ok := r.Tors[0]
 		require.True(ok)
 
-		// The TOR should have a wired port for each of the two expected blades.
+		// The TOR should have a wired port for each of the two expected blades and one for the pdu.
 		//
-		assert.Equal(2, len(t0.Ports))
+		assert.Equal(3, len(t0.Ports))
+
+		t0b0, ok := t0.Ports[0]
+		require.True(ok)
+
+		assert.True(t0b0.Wired)
+		assert.Equal(pb.Hardware_pdu, t0b0.Item.Type)
+		assert.Equal(int64(0), t0b0.Item.Id)
+		assert.Equal(int64(1), t0b0.Item.Port)
 
 		t0b1, ok := t0.Ports[1]
 		require.True(ok)
@@ -223,7 +253,7 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFile() {
 func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileBogusPath() {
 	require := ts.Require()
 
-	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./missing/path")
+	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./missing/path")
 	require.EqualError(err, "no inventory definition found at ./missing/path/inventory.yaml (yaml)")
 	require.Nil(response)
 }
@@ -233,7 +263,7 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileBogusPath() {
 func (ts *readerTestSuite) TestIReadInventoryDefinitionFromFileUniqueRack() {
 	require := ts.Require()
 
-	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYaml")
+	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/BadYaml")
 	require.EqualError(err, "Duplicate rack \"rack1\" detected")
 	require.Nil(response)
 }
@@ -241,7 +271,7 @@ func (ts *readerTestSuite) TestIReadInventoryDefinitionFromFileUniqueRack() {
 func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileUniqueBlade() {
 	require := ts.Require()
 
-	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYamlBlade")
+	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/BadYamlBlade")
 	require.EqualError(err, "Duplicate Blade 1 in Rack \"rack1\" detected")
 	require.Nil(response)
 }
@@ -249,7 +279,7 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileUniqueBlade() {
 func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileValidateBlade() {
 	require := ts.Require()
 
-	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYamlValidate")
+	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/BadYamlValidate")
 	require.EqualError(err, "In rack \"rack1\": the field \"Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid")
 	require.Nil(response)
 }

--- a/simulation/internal/clients/inventory/reader_test.go
+++ b/simulation/internal/clients/inventory/reader_test.go
@@ -81,39 +81,6 @@ func (ts *readerTestSuite) TestReadInventoryDefinition() {
 	assert.Equal("X64", b.Capacity.Arch)
 }
 
-// func (ts *readerTestSuite) TestReadInventoryBogusPath() {
-// 	require := ts.Require()
-
-// 	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./missing/path")
-// 	require.EqualError(err, "no inventory definition found at ./missing/path/inventory.yaml (yaml)")
-// 	require.Nil(response)
-// }
-
-// // TestInventoryUniqueRack test to check that zone always contain unique rack numbers
-// func (ts *readerTestSuite) TestInventoryUniqueRack() {
-// 	require := ts.Require()
-
-// 	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/BadYaml")
-// 	require.EqualError(err, "Duplicate rack \"rack1\" detected")
-// 	require.Nil(response)
-// }
-
-// func (ts *readerTestSuite) TestInventoryUniqueBlade() {
-// 	require := ts.Require()
-
-// 	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/BadYamlBlade")
-// 	require.EqualError(err, "Duplicate Blade 1 in Rack \"rack1\" detected")
-// 	require.Nil(response)
-// }
-
-// func (ts *readerTestSuite) TestInventoryValidateBlade() {
-// 	require := ts.Require()
-
-// 	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/BadYamlValidate")
-// 	require.EqualError(err, "In rack \"rack1\": the field \"Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid")
-// 	require.Nil(response)
-// }
-
 func (ts *readerTestSuite) TestReadInventoryDefinitionFromFile() {
 	assert := ts.Assert()
 	require := ts.Require()

--- a/simulation/internal/clients/inventory/reader_test.go
+++ b/simulation/internal/clients/inventory/reader_test.go
@@ -41,7 +41,7 @@ func (ts *readerTestSuite) TestReadInventoryDefinition() {
 	assert := ts.Assert()
 	require := ts.Require()
 
-	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/Simple")
+	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/Simple")
 	require.NoError(err)
 	require.NotNil(response)
 
@@ -61,10 +61,10 @@ func (ts *readerTestSuite) TestReadInventoryDefinition() {
 	b, ok := r.Blades[1]
 	require.True(ok)
 	require.NotNil(b.Capacity)
-	assert.Equal(int64(16), b.Capacity.Cores)
-	assert.Equal(int64(16384), b.Capacity.MemoryInMb)
-	assert.Equal(int64(240), b.Capacity.DiskInGb)
-	assert.Equal(int64(2048), b.Capacity.NetworkBandwidthInMbps)
+	assert.EqualValues(16, b.Capacity.Cores)
+	assert.EqualValues(16384, b.Capacity.MemoryInMb)
+	assert.EqualValues(240, b.Capacity.DiskInGb)
+	assert.EqualValues(2048, b.Capacity.NetworkBandwidthInMbps)
 	assert.Equal("X64", b.Capacity.Arch)
 
 	s, ok := zone1.Racks["rack2"]
@@ -74,10 +74,10 @@ func (ts *readerTestSuite) TestReadInventoryDefinition() {
 	c, ok := r.Blades[2]
 	require.True(ok)
 	require.NotNil(b.Capacity)
-	assert.Equal(int64(8), c.Capacity.Cores)
-	assert.Equal(int64(16384), c.Capacity.MemoryInMb)
-	assert.Equal(int64(120), c.Capacity.DiskInGb)
-	assert.Equal(int64(2048), c.Capacity.NetworkBandwidthInMbps)
+	assert.EqualValues(8, c.Capacity.Cores)
+	assert.EqualValues(16384, c.Capacity.MemoryInMb)
+	assert.EqualValues(120, c.Capacity.DiskInGb)
+	assert.EqualValues(2048, c.Capacity.NetworkBandwidthInMbps)
 	assert.Equal("X64", b.Capacity.Arch)
 }
 
@@ -85,7 +85,7 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFile() {
 	assert := ts.Assert()
 	require := ts.Require()
 
-	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/Simple")
+	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/Simple")
 	require.NoError(err)
 	require.NotNil(response)
 
@@ -137,24 +137,24 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFile() {
 
 		assert.True(p0b0.Wired)
 		assert.Equal(pb.Hardware_tor, p0b0.Item.Type)
-		assert.Equal(int64(0), p0b0.Item.Id)
-		assert.Equal(int64(1), p0b0.Item.Port)
+		assert.EqualValues(0, p0b0.Item.Id)
+		assert.EqualValues(1, p0b0.Item.Port)
 
 		p0b1, ok := p0.Ports[1]
 		require.True(ok)
 
 		assert.True(p0b1.Wired)
 		assert.Equal(pb.Hardware_blade, p0b1.Item.Type)
-		assert.Equal(int64(1), p0b1.Item.Id)
-		assert.Equal(int64(0), p0b1.Item.Port)
+		assert.EqualValues(1, p0b1.Item.Id)
+		assert.EqualValues(0, p0b1.Item.Port)
 
 		p0b2, ok := p0.Ports[2]
 		require.True(ok)
 
 		assert.True(p0b2.Wired)
 		assert.Equal(pb.Hardware_blade, p0b2.Item.Type)
-		assert.Equal(int64(2), p0b2.Item.Id)
-		assert.Equal(int64(0), p0b2.Item.Port)
+		assert.EqualValues(2, p0b2.Item.Id)
+		assert.EqualValues(0, p0b2.Item.Port)
 
 		// There should be a single TOR at index 0
 		//
@@ -170,24 +170,24 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFile() {
 
 		assert.True(t0b0.Wired)
 		assert.Equal(pb.Hardware_pdu, t0b0.Item.Type)
-		assert.Equal(int64(0), t0b0.Item.Id)
-		assert.Equal(int64(1), t0b0.Item.Port)
+		assert.EqualValues(0, t0b0.Item.Id)
+		assert.EqualValues(1, t0b0.Item.Port)
 
 		t0b1, ok := t0.Ports[1]
 		require.True(ok)
 
 		assert.True(t0b1.Wired)
 		assert.Equal(pb.Hardware_blade, t0b1.Item.Type)
-		assert.Equal(int64(1), t0b1.Item.Id)
-		assert.Equal(int64(0), t0b1.Item.Port)
+		assert.EqualValues(1, t0b1.Item.Id)
+		assert.EqualValues(0, t0b1.Item.Port)
 
 		t0b2, ok := p0.Ports[2]
 		require.True(ok)
 
 		assert.True(t0b2.Wired)
 		assert.Equal(pb.Hardware_blade, t0b2.Item.Type)
-		assert.Equal(int64(2), t0b2.Item.Id)
-		assert.Equal(int64(0), t0b2.Item.Port)
+		assert.EqualValues(2, t0b2.Item.Id)
+		assert.EqualValues(0, t0b2.Item.Port)
 
 		// There should be exactly two blades at indices 1 and 2.
 		//
@@ -197,11 +197,11 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFile() {
 		assert.True(b1.Details.Enabled)
 		assert.Equal(pb.Condition_operational, b1.Details.Condition)
 
-		assert.Equal(int64(16),    b1.Capacity.Cores)
-		assert.Equal(int64(16384), b1.Capacity.MemoryInMb)
-		assert.Equal(int64(240),   b1.Capacity.DiskInGb)
-		assert.Equal(int64(2048),  b1.Capacity.NetworkBandwidthInMbps)
-		assert.Equal("X64",        b1.Capacity.Arch)
+		assert.EqualValues(16,    b1.Capacity.Cores)
+		assert.EqualValues(16384, b1.Capacity.MemoryInMb)
+		assert.EqualValues(240,   b1.Capacity.DiskInGb)
+		assert.EqualValues(2048,  b1.Capacity.NetworkBandwidthInMbps)
+		assert.Equal("X64",       b1.Capacity.Arch)
 
 		b2, ok := r.Blades[2]
 		require.True(ok)
@@ -209,18 +209,18 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFile() {
 		assert.True(b2.Details.Enabled)
 		assert.Equal(pb.Condition_operational, b2.Details.Condition)
 
-		assert.Equal(int64(8),     b2.Capacity.Cores)
-		assert.Equal(int64(16384), b2.Capacity.MemoryInMb)
-		assert.Equal(int64(120),   b2.Capacity.DiskInGb)
-		assert.Equal(int64(2048),  b2.Capacity.NetworkBandwidthInMbps)
-		assert.Equal("X64",        b2.Capacity.Arch)
+		assert.EqualValues(8,     b2.Capacity.Cores)
+		assert.EqualValues(16384, b2.Capacity.MemoryInMb)
+		assert.EqualValues(120,   b2.Capacity.DiskInGb)
+		assert.EqualValues(2048,  b2.Capacity.NetworkBandwidthInMbps)
+		assert.Equal("X64",       b2.Capacity.Arch)
 	}
 }
 
 func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileBogusPath() {
 	require := ts.Require()
 
-	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./missing/path")
+	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./missing/path")
 	require.EqualError(err, "no inventory definition found at ./missing/path/inventory.yaml (yaml)")
 	require.Nil(response)
 }
@@ -230,7 +230,7 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileBogusPath() {
 func (ts *readerTestSuite) TestIReadInventoryDefinitionFromFileUniqueRack() {
 	require := ts.Require()
 
-	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/BadYaml")
+	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYaml")
 	require.EqualError(err, "CloudChamber: Configuration detected duplicate Rack rack1 in zone \"zone1\" in region \"region1\"")
 	require.Nil(response)
 }
@@ -238,7 +238,7 @@ func (ts *readerTestSuite) TestIReadInventoryDefinitionFromFileUniqueRack() {
 func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileUniqueBlade() {
 	require := ts.Require()
 
-	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/BadYamlBlade")
+	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYamlBlade")
 	require.EqualError(err, "CloudChamber: Configuration detected duplicate Blade for blade 1 in region \"region1\", zone \"zone1\", rack \"rack1\"")
 	require.Nil(response)
 }
@@ -246,7 +246,7 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileUniqueBlade() {
 func (ts *readerTestSuite) TestReadInventoryDefinitionFromFileValidateBlade() {
 	require := ts.Require()
 
-	response, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/BadYamlValidate")
+	response, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/BadYamlValidate")
 	require.EqualError(err, "CloudChamber: in region \"region1\": the field \"Zones[zone1].Racks[rack1].Blades[2].Cores\" must be greater than or equal to 1.  It is 0, which is invalid")
 	require.Nil(response)
 }
@@ -255,7 +255,7 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionBasic() {
 	assert := ts.Assert()
 	require := ts.Require()
 
-	root, err := ReadInventoryDefinitionFromFileEx(context.Background(), "./testdata/Basic")
+	root, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/Basic")
 	require.NoError(err)
 	require.NotNil(root)
 
@@ -329,32 +329,32 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionBasic() {
 
 				assert.True(p0b1.Wired)
 				assert.Equal(pb.Hardware_blade, p0b1.Item.Type)
-				assert.Equal(int64(1), p0b1.Item.Id)
-				assert.Equal(int64(0), p0b1.Item.Port)
+				assert.EqualValues(1, p0b1.Item.Id)
+				assert.EqualValues(0, p0b1.Item.Port)
 
 				p0b2, ok := p0.Ports[2]
 				require.True(ok)
 
 				assert.True(p0b2.Wired)
 				assert.Equal(pb.Hardware_blade, p0b2.Item.Type)
-				assert.Equal(int64(1), p0b2.Item.Id)
-				assert.Equal(int64(1), p0b2.Item.Port)
+				assert.EqualValues(1, p0b2.Item.Id)
+				assert.EqualValues(1, p0b2.Item.Port)
 
 				p0b3, ok := p0.Ports[3]
 				require.True(ok)
 
 				assert.True(p0b3.Wired)
 				assert.Equal(pb.Hardware_tor, p0b3.Item.Type)
-				assert.Equal(int64(0), p0b3.Item.Id)
-				assert.Equal(int64(1), p0b3.Item.Port)
+				assert.EqualValues(0, p0b3.Item.Id)
+				assert.EqualValues(1, p0b3.Item.Port)
 
 				p0b4, ok := p0.Ports[4]
 				require.True(ok)
 
 				assert.True(p0b4.Wired)
 				assert.Equal(pb.Hardware_blade, p0b4.Item.Type)
-				assert.Equal(int64(2), p0b4.Item.Id)
-				assert.Equal(int64(4), p0b4.Item.Port)
+				assert.EqualValues(2, p0b4.Item.Id)
+				assert.EqualValues(4, p0b4.Item.Port)
 
 				// There should be a single TOR at index 0
 				//
@@ -373,32 +373,32 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionBasic() {
 
 				assert.True(t0b1.Wired)
 				assert.Equal(pb.Hardware_blade, t0b1.Item.Type)
-				assert.Equal(int64(1), t0b1.Item.Id)
-				assert.Equal(int64(0), t0b1.Item.Port)
+				assert.EqualValues(1, t0b1.Item.Id)
+				assert.EqualValues(0, t0b1.Item.Port)
 
 				t0b2, ok := t0.Ports[2]
 				require.True(ok)
 
 				assert.True(t0b2.Wired)
 				assert.Equal(pb.Hardware_blade, t0b2.Item.Type)
-				assert.Equal(int64(1), t0b2.Item.Id)
-				assert.Equal(int64(1), t0b2.Item.Port)
+				assert.EqualValues(1, t0b2.Item.Id)
+				assert.EqualValues(1, t0b2.Item.Port)
 
 				t0b3, ok := t0.Ports[3]
 				require.True(ok)
 
 				assert.True(t0b3.Wired)
 				assert.Equal(pb.Hardware_pdu, t0b3.Item.Type)
-				assert.Equal(int64(0), t0b3.Item.Id)
-				assert.Equal(int64(1), t0b3.Item.Port)
+				assert.EqualValues(0, t0b3.Item.Id)
+				assert.EqualValues(1, t0b3.Item.Port)
 
 				t0b4, ok := t0.Ports[4]
 				require.True(ok)
 
 				assert.True(t0b4.Wired)
 				assert.Equal(pb.Hardware_blade, t0b4.Item.Type)
-				assert.Equal(int64(2), t0b4.Item.Id)
-				assert.Equal(int64(3), t0b4.Item.Port)
+				assert.EqualValues(2, t0b4.Item.Id)
+				assert.EqualValues(3, t0b4.Item.Port)
 
 				// There should be exactly two blades at indices 1 and 2
 				//
@@ -410,11 +410,11 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionBasic() {
 				assert.True(b1.Details.Enabled)
 				assert.Equal(pb.Condition_operational, b1.Details.Condition)
 
-				assert.Equal(int64(16),    b1.Capacity.Cores)
-				assert.Equal(int64(16384), b1.Capacity.MemoryInMb)
-				assert.Equal(int64(240),   b1.Capacity.DiskInGb)
-				assert.Equal(int64(2048),  b1.Capacity.NetworkBandwidthInMbps)
-				assert.Equal("X64",        b1.Capacity.Arch)
+				assert.EqualValues(16,    b1.Capacity.Cores)
+				assert.EqualValues(16384, b1.Capacity.MemoryInMb)
+				assert.EqualValues(240,   b1.Capacity.DiskInGb)
+				assert.EqualValues(2048,  b1.Capacity.NetworkBandwidthInMbps)
+				assert.Equal("X64",       b1.Capacity.Arch)
 
 				b2, ok := rack.Blades[2]
 				require.True(ok)
@@ -422,11 +422,11 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionBasic() {
 				assert.True(b2.Details.Enabled)
 				assert.Equal(pb.Condition_operational, b2.Details.Condition)
 
-				assert.Equal(int64(24),    b2.Capacity.Cores)
-				assert.Equal(int64(32768), b2.Capacity.MemoryInMb)
-				assert.Equal(int64(480),   b2.Capacity.DiskInGb)
-				assert.Equal(int64(4096),  b2.Capacity.NetworkBandwidthInMbps)
-				assert.Equal("X64",        b2.Capacity.Arch)
+				assert.EqualValues(24,    b2.Capacity.Cores)
+				assert.EqualValues(32768, b2.Capacity.MemoryInMb)
+				assert.EqualValues(480,   b2.Capacity.DiskInGb)
+				assert.EqualValues(4096,  b2.Capacity.NetworkBandwidthInMbps)
+				assert.Equal("X64",       b2.Capacity.Arch)
 			}
 		}
 	}

--- a/simulation/internal/clients/inventory/testdata/BadYaml/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/BadYaml/inventory.yaml
@@ -1,34 +1,85 @@
-#defining a blade1 and blade2 for rack1
-Racks:
-  - Name: rack1
-    Blades:
-    - Index: 1
+# Simple test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades.
+#
+# Two racks, with a duplicated rack name.
+
+BladeTypeS:
+  - &bladeType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: local
+      Image: standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
       Cores: 16
       MemoryInMb: 16384
       DiskInGb: 240 
       NetworkBandwidthInMbps: 2048
       Arch: "X64"
-    - Index: 2
-      Cores: 8
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    Tor:
-    Pdu:
-  - Name: rack1
+
+TorTypes:
+  - &torType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   pdu, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 1}}
+
+PduTypes:
+  - &pduType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   tor, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 1}}
+
+RackTypes:
+  - &rackType1
+    Details:
+      Enabled: true
+      Condition: Operational
+      Location: "Pacific NW, row 1, rack 1"
+      Notes: "rack definition, 1 pdu, 1 tor, 2 blades"
     Blades:
-    - Index: 1
-      Cores: 16
-      MemoryInMb: 16384
-      DiskInGb: 240 
-      NetworkBandwidthInMbps: 2048
-      Arch: "X64"
-    - Index: 2
-      Cores: 8
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    Tor:
-    Pdu:
+      - Index: 1
+        <<: *bladeType1
+      - Index: 2
+        <<: *bladeType1
+    Tors:
+      - Index: 0
+        <<: *torType1
+    Pdus:
+      - Index: 0
+        <<: *pduType1
+
+
+# Start of layout
+#
+Details:
+  Name: "Simple Test Inventory"
+  Notes: "Test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades. Racks have duplicate names."
+Regions:
+  - Name: region1
+    Details:
+      State: In_Service
+      Location: "Pacific NW"
+      Notes: "Test Region 1"
+    Zones:
+      - Name: zone1
+        Details:
+          Enabled: true
+          State: In_Service
+          Location: "Pacific NW, row 1"
+          Notes: "Simple zone definition"
+        Racks:
+          - Name: rack1
+            <<: *rackType1
+          - Name: rack1
+            <<: *rackType1

--- a/simulation/internal/clients/inventory/testdata/BadYaml/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/BadYaml/inventory.yaml
@@ -2,7 +2,7 @@
 #
 # Two racks, with a duplicated rack name.
 
-BladeTypeS:
+BladeTypes:
   - &bladeType1
     Details:
       Enabled: true

--- a/simulation/internal/clients/inventory/testdata/BadYamlBlade/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/BadYamlBlade/inventory.yaml
@@ -1,34 +1,102 @@
-#defining a blade1 and blade2 for rack1
-Racks:
-  - Name: rack1
-    Blades:
-    - Index: 1
+# Simple test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades.
+#
+# Blades in rack1 have duplicate IDs.
+
+BladeTypeS:
+  - &bladeType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: local
+      Image: standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
       Cores: 16
       MemoryInMb: 16384
       DiskInGb: 240 
       NetworkBandwidthInMbps: 2048
       Arch: "X64"
-    - Index: 1
-      Cores: 8
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    Tor:
-    Pdu:
-  - Name: rack2
+
+TorTypes:
+  - &torType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   pdu, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 1}}
+
+PduTypes:
+  - &pduType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   tor, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 1}}
+
+RackTypes:
+  - &rackType1
+    Details:
+      Enabled: true
+      Condition: Operational
+      Location: "Pacific NW, row 1, rack 1"
+      Notes: "rack definition, 1 pdu, 1 tor, 2 blades"
     Blades:
-    - Index: 1
-      Cores: 16
-      MemoryInMb: 16384
-      DiskInGb: 240 
-      NetworkBandwidthInMbps: 2048
-      Arch: "X64"
-    - Index: 2
-      Cores: 8
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    Tor:
-    Pdu:
+      - Index: 1
+        <<: *bladeType1
+      - Index: 1
+        <<: *bladeType1
+    Tors:
+      - Index: 0
+        <<: *torType1
+    Pdus:
+      - Index: 0
+        <<: *pduType1
+  - &rackType2
+    Details:
+      Enabled: true
+      Condition: Operational
+      Location: "Pacific NW, row 1, rack 1"
+      Notes: "rack definition, 1 pdu, 1 tor, 2 blades"
+    Blades:
+      - Index: 1
+        <<: *bladeType1
+      - Index: 2
+        <<: *bladeType1
+    Tors:
+      - Index: 0
+        <<: *torType1
+    Pdus:
+      - Index: 0
+        <<: *pduType1
+
+
+# Start of layout
+#
+Details:
+  Name: "Simple Test Inventory"
+  Notes: "Test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades. Blades in rack1 have duplicate IDs."
+Regions:
+  - Name: region1
+    Details:
+      State: In_Service
+      Location: "Pacific NW"
+      Notes: "Test Region 1"
+    Zones:
+      - Name: zone1
+        Details:
+          Enabled: true
+          State: In_Service
+          Location: "Pacific NW, row 1"
+          Notes: "Simple zone definition"
+        Racks:
+          - Name: rack1
+            <<: *rackType1
+          - Name: rack2
+            <<: *rackType2

--- a/simulation/internal/clients/inventory/testdata/BadYamlValidate/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/BadYamlValidate/inventory.yaml
@@ -159,19 +159,19 @@ ZoneTypes:
       - Name: rack1
         <<: *rackType1
       - Name: rack2
-        <<: *rackType1
+        <<: *rackType2
       - Name: rack3
-        <<: *rackType1
+        <<: *rackType2
       - Name: rack4
-        <<: *rackType1
+        <<: *rackType2
       - Name: rack5
-        <<: *rackType1
+        <<: *rackType2
       - Name: rack6
-        <<: *rackType1
+        <<: *rackType2
       - Name: rack7
-        <<: *rackType1
+        <<: *rackType2
       - Name: rack8
-        <<: *rackType1
+        <<: *rackType2
 
 
 # Start of layout

--- a/simulation/internal/clients/inventory/testdata/BadYamlValidate/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/BadYamlValidate/inventory.yaml
@@ -1,417 +1,190 @@
-Racks:
-  - Name: rack1
-    Blades:
-    - Index: 1
+# Simple test configuration comprising 1 region, with 1 zone, with the zone having 8 racks, with each rack having a single pdu, a single tor and 8 blades.
+#
+# Region1, Zone1, Rack1, Blade2 has Cores field set to zero
+
+BladeTypeS:
+  - &bladeType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: network
+      Image: region1_standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
       Cores: 16
       MemoryInMb: 16384
       DiskInGb: 240 
       NetworkBandwidthInMbps: 2048
       Arch: "X64"
-    - Index: 2
+
+  - &bladeType2
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: network
+      Image: region1_standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
+      Cores: 32
+      MemoryInMb: 16384
+      DiskInGb: 120
+      NetworkBandwidthInMbps: 2048
+      Arch: "X64"
+
+  - &bladeType3
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: network
+      Image: region1_standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
       Cores: 0
       MemoryInMb: 16384
       DiskInGb: 120
       NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 3
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 4
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 5
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 6
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 7
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 8
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    Tor:
-    Pdu:
-  - Name: rack2
-    Blades:
-    - Index: 1
-      Cores: 16
-      MemoryInMb: 16384
-      DiskInGb: 240 
-      NetworkBandwidthInMbps: 2048
       Arch: "X64"
-    - Index: 2
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 3
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 4
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 5
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 6
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 7
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 8
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    Tor:
-    Pdu:
-  - Name: rack3
+
+TorTypes:
+  - &torType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   pdu, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 1}}
+      - {Index:  3, Wired: true, Item: {Type: blade, Id:  3, Port: 1}}
+      - {Index:  4, Wired: true, Item: {Type: blade, Id:  4, Port: 1}}
+      - {Index:  5, Wired: true, Item: {Type: blade, Id:  5, Port: 1}}
+      - {Index:  6, Wired: true, Item: {Type: blade, Id:  6, Port: 1}}
+      - {Index:  7, Wired: true, Item: {Type: blade, Id:  7, Port: 1}}
+      - {Index:  8, Wired: true, Item: {Type: blade, Id:  8, Port: 1}}
+
+PduTypes:
+  - &pduType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   tor, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 1}}
+      - {Index:  3, Wired: true, Item: {Type: blade, Id:  3, Port: 1}}
+      - {Index:  4, Wired: true, Item: {Type: blade, Id:  4, Port: 1}}
+      - {Index:  5, Wired: true, Item: {Type: blade, Id:  5, Port: 1}}
+      - {Index:  6, Wired: true, Item: {Type: blade, Id:  6, Port: 1}}
+      - {Index:  7, Wired: true, Item: {Type: blade, Id:  7, Port: 1}}
+      - {Index:  8, Wired: true, Item: {Type: blade, Id:  8, Port: 1}}
+
+
+RackTypes:
+  - &rackType1
+    Details:
+      Enabled: true
+      Condition: Operational
+      Location: "Pacific NW, row 1, rack 1"
+      Notes: "rack definition, 1 pdu, 1 tor, 8 blades"
     Blades:
-    - Index: 1
-      Cores: 16
-      MemoryInMb: 16384
-      DiskInGb: 240 
-      NetworkBandwidthInMbps: 2048
-      Arch: "X64"
-    - Index: 2
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 3
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 4
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 5
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 6
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 7
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 8
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    Tor:
-    Pdu:
-  - Name: rack4
+      - Index: 1
+        <<: *bladeType1
+      - Index: 2
+        <<: *bladeType3
+      - Index: 3
+        <<: *bladeType2
+      - Index: 4
+        <<: *bladeType2
+      - Index: 5
+        <<: *bladeType2
+      - Index: 6
+        <<: *bladeType2
+      - Index: 7
+        <<: *bladeType2
+      - Index: 8
+        <<: *bladeType2
+    Tors:
+      - Index: 0
+        <<: *torType1
+    Pdus:
+      - Index: 0
+        <<: *pduType1
+  - &rackType2
+    Details:
+      Enabled: true
+      Condition: Operational
+      Location: "Pacific NW, row 1, rack 1"
+      Notes: "rack definition, 1 pdu, 1 tor, 8 blades"
     Blades:
-    - Index: 1
-      Cores: 16
-      MemoryInMb: 16384
-      DiskInGb: 240 
-      NetworkBandwidthInMbps: 2048
-      Arch: "X64"
-    - Index: 2
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 3
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 4
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 5
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 6
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 7
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 8
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    Tor:
-    Pdu:
-  - Name: rack5
-    Blades:
-    - Index: 1
-      Cores: 16
-      MemoryInMb: 16384
-      DiskInGb: 240 
-      NetworkBandwidthInMbps: 2048
-      Arch: "X64"
-    - Index: 2
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 3
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 4
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 5
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 6
-      Cores: 0
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 7
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 8
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    Tor:
-    Pdu:
-  - Name: rack6
-    Blades:
-    - Index: 1
-      Cores: 16
-      MemoryInMb: 16384
-      DiskInGb: 240 
-      NetworkBandwidthInMbps: 2048
-      Arch: "X64"
-    - Index: 2
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 3
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 4
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 5
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 6
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 7
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 8
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    Tor:
-    Pdu:
-  - Name: rack7
-    Blades:
-    - Index: 1
-      Cores: 16
-      MemoryInMb: 16384
-      DiskInGb: 240 
-      NetworkBandwidthInMbps: 2048
-      Arch: "X64"
-    - Index: 2
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 3
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 4
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 5
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 6
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 7
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 8
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    Tor:
-    Pdu:
-  - Name: rack8
-    Blades:
-    - Index: 1
-      Cores: 16
-      MemoryInMb: 16384
-      DiskInGb: 240 
-      NetworkBandwidthInMbps: 2048
-      Arch: "X64"
-    - Index: 2
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 3
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 4
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 5
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 6
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 7
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    - Index: 8
-      Cores: 32
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    Tor:
-    Pdu:
+      - Index: 1
+        <<: *bladeType1
+      - Index: 2
+        <<: *bladeType2
+      - Index: 3
+        <<: *bladeType2
+      - Index: 4
+        <<: *bladeType2
+      - Index: 5
+        <<: *bladeType2
+      - Index: 6
+        <<: *bladeType2
+      - Index: 7
+        <<: *bladeType2
+      - Index: 8
+        <<: *bladeType2
+    Tors:
+      - Index: 0
+        <<: *torType1
+    Pdus:
+      - Index: 0
+        <<: *pduType1
+
+
+ZoneTypes:
+  - &zoneType1
+    Details:
+      Enabled: true
+      State: In_Service
+      Location: "Pacific NW, row 1"
+      Notes: "Simple zone definition"
+    Racks:
+      - Name: rack1
+        <<: *rackType1
+      - Name: rack2
+        <<: *rackType1
+      - Name: rack3
+        <<: *rackType1
+      - Name: rack4
+        <<: *rackType1
+      - Name: rack5
+        <<: *rackType1
+      - Name: rack6
+        <<: *rackType1
+      - Name: rack7
+        <<: *rackType1
+      - Name: rack8
+        <<: *rackType1
+
+
+# Start of layout
+#
+Details:
+  Name: "Reference Test Inventory"
+  Notes: "Test configuration comprising 2 regions, each with 4 zones, each zone having 8 racks, with each rack having a single pdu, a single tor and 8 blades."
+Regions:
+  - Name: region1
+    Details:
+      State: In_Service
+      Location: "Pacific NW"
+      Notes: "Test Region 1"
+    Zones:
+      - Name: zone1
+        <<: *zoneType1

--- a/simulation/internal/clients/inventory/testdata/Reference/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/Reference/inventory.yaml
@@ -11,7 +11,7 @@ BladeTypeS:
     BootOnPowerOn: true
     Capacity:
       Cores: 16
-      MemoryInMb: 16834
+      MemoryInMb: 16384
       DiskInGb: 240 
       NetworkBandwidthInMbps: 2048
       Arch: "X64"
@@ -28,7 +28,7 @@ BladeTypeS:
     BootOnPowerOn: true
     Capacity:
       Cores: 32
-      MemoryInMb: 16834
+      MemoryInMb: 16384
       DiskInGb: 120
       NetworkBandwidthInMbps: 2048
       Arch: "X64"

--- a/simulation/internal/clients/inventory/testdata/Simple/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/Simple/inventory.yaml
@@ -1,34 +1,92 @@
-#defining a blade1 and blade2 for rack1
-Racks:
-  - Name: rack1
-    Blades:
-    - Index: 1
+# Simple test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades.
+
+BladeTypeS:
+  - &bladeType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: local
+      Image: standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
       Cores: 16
       MemoryInMb: 16384
       DiskInGb: 240 
       NetworkBandwidthInMbps: 2048
       Arch: "X64"
-    - Index: 2
-      Cores: 8
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    Tor:
-    Pdu:
-  - Name: rack2
+
+TorTypes:
+  - &torType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   pdu, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 0}}
+
+PduTypes:
+  - &pduType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   tor, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 0}}
+
+RackTypes:
+  - &rackType1
+    Details:
+      Enabled: true
+      Condition: Operational
+      Location: "Pacific NW, row 1, rack 1"
+      Notes: "rack definition, 1 pdu, 1 tor, 2 blades"
     Blades:
-    - Index: 1
-      Cores: 16
-      MemoryInMb: 16384
-      DiskInGb: 240 
-      NetworkBandwidthInMbps: 2048
-      Arch: "X64"
-    - Index: 2
-      Cores: 8
-      MemoryInMb: 16384
-      DiskInGb: 120
-      NetworkBandwidthInMbps: 2048
-      Arch: X64
-    Tor:
-    Pdu:
+      - Index: 1
+        <<: *bladeType1
+      - Index: 2
+        <<: *bladeType1
+    Tors:
+      - Index: 0
+        <<: *torType1
+    Pdus:
+      - Index: 0
+        <<: *pduType1
+
+ZoneTypes:
+  - &zoneType1
+    Details:
+      Enabled: true
+      State: In_Service
+      Location: "DC-PNW-0"
+      Notes: "Base zone"
+    Racks:
+      - Name: rack1
+        <<: *rackType1
+        Details:
+          Location: "DC-PNW-0-rack1"
+          Notes: "RackName: rack1"
+      - Name: rack2
+        <<: *rackType1
+          Location: "DC-PNW-0-rack2"
+          Notes: "RackName: rack2"
+
+
+# Start of layout
+#
+Details:
+  Name: "Simple Test Inventory"
+  Notes: "Test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades."
+Regions:
+  - Name: region1
+    Details:
+      State: In_Service
+      Location: "Pacific NW"
+      Notes: "Test Region 1"
+    Zones:
+      - Name: zone1
+        <<: *zoneType1

--- a/simulation/internal/clients/inventory/testdata/Simple/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/Simple/inventory.yaml
@@ -17,6 +17,22 @@ BladeTypeS:
       DiskInGb: 240 
       NetworkBandwidthInMbps: 2048
       Arch: "X64"
+  - &bladeType2
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: local
+      Image: standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
+      Cores: 8
+      MemoryInMb: 16384
+      DiskInGb: 120
+      NetworkBandwidthInMbps: 2048
+      Arch: "X64"
 
 TorTypes:
   - &torType1
@@ -49,7 +65,7 @@ RackTypes:
       - Index: 1
         <<: *bladeType1
       - Index: 2
-        <<: *bladeType1
+        <<: *bladeType2
     Tors:
       - Index: 0
         <<: *torType1
@@ -68,10 +84,15 @@ ZoneTypes:
       - Name: rack1
         <<: *rackType1
         Details:
+          Enabled: true
+          Condition: Operational
           Location: "DC-PNW-0-rack1"
           Notes: "RackName: rack1"
       - Name: rack2
         <<: *rackType1
+        Details:
+          Enabled: true
+          Condition: Operational
           Location: "DC-PNW-0-rack2"
           Notes: "RackName: rack2"
 

--- a/simulation/internal/services/frontend/DBInventory.go
+++ b/simulation/internal/services/frontend/DBInventory.go
@@ -114,7 +114,7 @@ func (m *DBInventory) Start(ctx context.Context) error {
 			return err
 		}
 
-		if err := m.LoadInventoryActual(true); err != nil {
+		if err := m.LoadInventoryActual(ctx, true); err != nil {
 			return err
 		}
 

--- a/simulation/internal/services/frontend/DBInventoryActual.go
+++ b/simulation/internal/services/frontend/DBInventoryActual.go
@@ -64,13 +64,12 @@ type actualZone struct {
 // in-memory "actual" state. Eventually, we expect this to move to the store once
 // all the required store features are in place, primarily Watch().
 //
-func (m *DBInventory) LoadInventoryActual(force bool) error {
+func (m *DBInventory) LoadInventoryActual(ctx context.Context, force bool) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	ctx := context.Background()
-
-	if !m.actualLoaded || force  {
+	if !m.actualLoaded || force {
+		m.actualLoaded = false
 
 		m.mutex.Unlock()
 

--- a/simulation/internal/services/frontend/TestSuiteCore.go
+++ b/simulation/internal/services/frontend/TestSuiteCore.go
@@ -212,11 +212,21 @@ func (ts *testSuiteCore) ensureServicesStarted() {
 	if !initServiceDone {
 		require := ts.Require()
 
+		ctx := context.Background()
+
 		_ = ts.utf.Open(ts.T())
 
 		// Start the test web service, which all tests will use
 		require.NoError(initService(ts.cfg))
 		initServiceDone = true
+
+		// Load the standard inventory into the store which all tests will use
+		err := dbInventory.inventory.UpdateInventoryDefinition(ctx, ts.cfg.Inventory.InventoryDefinition)
+		require.NoError(err)
+
+		// Need to reload the actual inventory after loading the store.
+		err = dbInventory.LoadInventoryActual(ctx, true)
+		require.NoError(err)
 
 		ts.utf.Close()
 	}

--- a/simulation/internal/services/frontend/inventory.go
+++ b/simulation/internal/services/frontend/inventory.go
@@ -83,7 +83,7 @@ func handlerRacksList(w http.ResponseWriter, r *http.Request) {
 		"Listing all %d racks, max blades/rack=%d, max blade capacity=%v",
 		memoData.RackCount,
 		memoData.MaxBladeCount,
-		&memoData.MaxCapacity)
+		memoData.MaxCapacity)
 
 	b := common.URLPrefix(r)
 

--- a/simulation/internal/services/inventory/inventory.go
+++ b/simulation/internal/services/inventory/inventory.go
@@ -27,9 +27,6 @@ type server struct {
 
 	store *st.Store
 	inventory *ic.Inventory
-	inventoryRoot *ic.Root
-	inventoryRegion *ic.Region
-	inventoryZone *ic.Zone
 }
 
 func Register(svc *grpc.Server, cfg *config.GlobalConfig) error {
@@ -57,7 +54,7 @@ func Register(svc *grpc.Server, cfg *config.GlobalConfig) error {
 		timers: timers,
 	}
 
-	if err := s.initialiseInventory(cfg); err != nil {
+	if err := s.initializeInventory(cfg); err != nil {
 		return err
 	}
 
@@ -90,7 +87,7 @@ func (s *server) GetCurrentStatus(context.Context, *pb.InventoryStatusMsg) (*pb.
 	return nil, nil
 }
 
-func (s *server) initialiseInventory(cfg *config.GlobalConfig) error {
+func (s *server) initializeInventory(cfg *config.GlobalConfig) error {
 	// Initialize the underlying store
 	//
 	ctx := context.Background()
@@ -136,13 +133,15 @@ func (s *server) initializeRacks() error {
 
 	zone, err := s.inventory.NewZone(ic.DefinitionTable, regionName, zoneName)
 
+	if err != nil {
+		return err
+	}
+
 	_, racks, err := zone.FetchChildren(ctx)
 
 	if err != nil {
 		return err
 	}
-
-	s.inventoryZone = zone
 
 	for name, rack := range *racks {
 		// For each rack, create a rack item, supplying the tor, pdu, and blade

--- a/simulation/internal/services/inventory/inventory.go
+++ b/simulation/internal/services/inventory/inventory.go
@@ -6,6 +6,7 @@ import (
 	"google.golang.org/grpc"
 
 	ic "github.com/Jim3Things/CloudChamber/simulation/internal/clients/inventory"
+	st "github.com/Jim3Things/CloudChamber/simulation/internal/clients/store"
 	ts "github.com/Jim3Things/CloudChamber/simulation/internal/clients/timestamp"
 	tsc "github.com/Jim3Things/CloudChamber/simulation/internal/clients/trace_sink"
 	"github.com/Jim3Things/CloudChamber/simulation/internal/common"
@@ -23,6 +24,12 @@ type server struct {
 	racks map[string]*Rack
 
 	timers *ts.Timers
+
+	store *st.Store
+	inventory *ic.Inventory
+	inventoryRoot *ic.Root
+	inventoryRegion *ic.Region
+	inventoryZone *ic.Zone
 }
 
 func Register(svc *grpc.Server, cfg *config.GlobalConfig) error {
@@ -50,7 +57,11 @@ func Register(svc *grpc.Server, cfg *config.GlobalConfig) error {
 		timers: timers,
 	}
 
-	if err := s.initializeRacks(cfg.Inventory.InventoryDefinition); err != nil {
+	if err := s.initialiseInventory(cfg); err != nil {
+		return err
+	}
+
+	if err := s.initializeRacks(); err != nil {
 		return err
 	}
 
@@ -79,21 +90,76 @@ func (s *server) GetCurrentStatus(context.Context, *pb.InventoryStatusMsg) (*pb.
 	return nil, nil
 }
 
-func (s *server) initializeRacks(path string) error {
+func (s *server) initialiseInventory(cfg *config.GlobalConfig) error {
+	// Initialize the underlying store
+	//
+	ctx := context.Background()
+
+	st.Initialize(cfg)
+	s.store = st.NewStore()
+	s.inventory = ic.NewInventory(cfg, s.store)
+	
+	// NOTE TO Jim
+	//
+	// We need to decide who gets to write the defined inventory to the
+	// store. At present this is done by the frontend process, but it may
+	// well be that the inventoryd process should be doing that. 
+	//
+	//
+	// NOTE TO Mike
+	//
+	// Need to not have Start() also do the load. That should/is a separate call.
+	//
+	if err := s.inventory.Start(ctx); err != nil {
+		return err
+	}
+
+	if err := s.inventory.UpdateInventoryDefinition(ctx, cfg.Inventory.InventoryDefinition); err != nil {
+		return err
+	}
+
+	// At this point the inventory is loaded from the configured file
+	// into the store. All queries for the current defnitions should
+	// now be performed against the store.
+	//
+	return nil
+}
+
+func (s *server) initializeRacks() error {
 	ctx, span := tracing.StartSpan(
 		context.Background(),
 		tracing.WithName("Initializing the simulated inventory"),
 		tracing.WithContextValue(ts.EnsureTickInContext))
 	defer span.End()
 
-	zone, err := ic.ReadInventoryDefinition(ctx, path)
+	const (
+		// These will be whatever is defined in the inventory. Or they can be
+		// discovered by scanning for regions etc from the root of the definition
+		//
+		regionName = "region1"
+		zoneName   = "zone1"
+	)
+
+	zone, err := s.inventory.NewZone(ic.DefinitionTable, regionName, zoneName)
+
+	_, racks, err := zone.FetchChildren(ctx)
+
 	if err != nil {
 		return err
 	}
 
-	for name, r := range zone.Racks {
+	s.inventoryZone = zone
+
+	for name, rack := range *racks {
 		// For each rack, create a rack item, supplying the tor, pdu, and blade
 		tracing.Info(ctx, "Adding rack %q", name)
+
+		r, err := rack.GetDefinitionRackWithChildren(ctx)
+
+		if err != nil {
+			return err
+		}
+
 		s.racks[name] = newRack(ctx, name, r, s.timers)
 
 		// Start each rack (this gives us a channel and a goroutine)

--- a/simulation/internal/services/inventory/inventory.go
+++ b/simulation/internal/services/inventory/inventory.go
@@ -99,29 +99,18 @@ func (s *server) initialiseInventory(cfg *config.GlobalConfig) error {
 	s.store = st.NewStore()
 	s.inventory = ic.NewInventory(cfg, s.store)
 	
-	// NOTE TO Jim
-	//
-	// We need to decide who gets to write the defined inventory to the
-	// store. At present this is done by the frontend process, but it may
-	// well be that the inventoryd process should be doing that. 
-	//
-	//
-	// NOTE TO Mike
-	//
-	// Need to not have Start() also do the load. That should/is a separate call.
-	//
 	if err := s.inventory.Start(ctx); err != nil {
 		return err
 	}
 
+	// Load/update the store inventory definitions from the configured file.
+	// Once complete, all queries for the current definitions should be
+	// performed against the store.
+	//
 	if err := s.inventory.UpdateInventoryDefinition(ctx, cfg.Inventory.InventoryDefinition); err != nil {
 		return err
 	}
 
-	// At this point the inventory is loaded from the configured file
-	// into the store. All queries for the current defnitions should
-	// now be performed against the store.
-	//
 	return nil
 }
 
@@ -133,11 +122,16 @@ func (s *server) initializeRacks() error {
 	defer span.End()
 
 	const (
-		// These will be whatever is defined in the inventory. Or they can be
+		// These will match whatever is defined in the inventory. Or they can be
 		// discovered by scanning for regions etc from the root of the definition
+		// table.
 		//
-		regionName = "region1"
-		zoneName   = "zone1"
+		// If the inventory service is intended to provide service for a single
+		// zone as defined in (say) the configuration, then these values should
+		// be updated to reflect that configuration information.
+		//
+		regionName = "standard"
+		zoneName   = "standard"
 	)
 
 	zone, err := s.inventory.NewZone(ic.DefinitionTable, regionName, zoneName)

--- a/simulation/internal/services/inventory/pdu.go
+++ b/simulation/internal/services/inventory/pdu.go
@@ -41,7 +41,7 @@ const (
 // containing Rack.  Note that it currently does not fill in the cable
 // information, as that is missing from the inventory definition.  That is
 // done is the fixConnection function below.
-func newPdu(_ *pb.External_Pdu, r *Rack) *pdu {
+func newPdu(_ *pb.Definition_Pdu, r *Rack) *pdu {
 	p := &pdu{
 		cables: make(map[int64]*cable),
 		holder: r,

--- a/simulation/internal/services/inventory/rack.go
+++ b/simulation/internal/services/inventory/rack.go
@@ -52,7 +52,7 @@ const (
 // entries to determine its structure.  The resulting Rack is healthy, not yet
 // started, all blades are powered off, and all network connections are not yet
 // programmed.
-func newRack(ctx context.Context, name string, def *pb.External_Rack, timers *timestamp.Timers) *Rack {
+func newRack(ctx context.Context, name string, def *pb.Definition_Rack, timers *timestamp.Timers) *Rack {
 	return newRackInternal(ctx, name, def, timers, newPdu, newTor)
 }
 
@@ -62,10 +62,10 @@ func newRack(ctx context.Context, name string, def *pb.External_Rack, timers *ti
 func newRackInternal(
 	ctx context.Context,
 	name string,
-	def *pb.External_Rack,
+	def *pb.Definition_Rack,
 	timers *timestamp.Timers,
-	pduFunc func(*pb.External_Pdu, *Rack) *pdu,
-	torFunc func(*pb.External_Tor, *Rack) *tor) *Rack {
+	pduFunc func(*pb.Definition_Pdu, *Rack) *pdu,
+	torFunc func(*pb.Definition_Tor, *Rack) *tor) *Rack {
 	r := &Rack{
 		name:      name,
 		ch:        make(chan sm.Envelope, rackQueueDepth),
@@ -108,11 +108,11 @@ func newRackInternal(
 			sm.NullLeave),
 	)
 
-	r.pdu = pduFunc(def.Pdu, r)
-	r.tor = torFunc(def.Tor, r)
+	r.pdu = pduFunc(def.Pdus[0], r)
+	r.tor = torFunc(def.Tors[0], r)
 
 	for i, item := range def.Blades {
-		r.blades[i] = newBlade(item, r, i)
+		r.blades[i] = newBlade(item.GetCapacity(), r, i)
 
 		// These two calls are temporary fix-ups until the inventory definition
 		// includes the tor and pdu connectors

--- a/simulation/internal/services/inventory/testSuiteCore.go
+++ b/simulation/internal/services/inventory/testSuiteCore.go
@@ -57,15 +57,29 @@ func (ts *testSuiteCore) TearDownTest() {
 	ts.utf.Close()
 }
 
-func (ts *testSuiteCore) createDummyRack(bladeCount int) *pb.External_Rack {
-	rackDef := &pb.External_Rack{
-		Pdu:    &pb.External_Pdu{},
-		Tor:    &pb.External_Tor{},
-		Blades: make(map[int64]*pb.BladeCapacity),
+func (ts *testSuiteCore) createDummyRack(bladeCount int) *pb.Definition_Rack {
+	rackDef := &pb.Definition_Rack{
+		Pdus:   make(map[int64]*pb.Definition_Pdu),
+		Tors:   make(map[int64]*pb.Definition_Tor),
+		Blades: make(map[int64]*pb.Definition_Blade),
 	}
 
 	for i := 0; i < bladeCount; i++ {
-		rackDef.Blades[int64(i)] = &pb.BladeCapacity{}
+		rackDef.Blades[int64(i)] = &pb.Definition_Blade{
+			Details:  &pb.BladeDetails{},
+			Capacity: &pb.BladeCapacity{},
+			BootInfo: &pb.BladeBootInfo{},
+		}	
+	}
+
+	rackDef.Pdus[0] = &pb.Definition_Pdu{
+		Details: &pb.PduDetails{},
+		Ports:   make(map[int64]*pb.PowerPort),
+	}
+
+	rackDef.Tors[0] = &pb.Definition_Tor{
+		Details: &pb.TorDetails{},
+		Ports:   make(map[int64]*pb.NetworkPort),
 	}
 
 	return rackDef

--- a/simulation/internal/services/inventory/tor.go
+++ b/simulation/internal/services/inventory/tor.go
@@ -41,7 +41,7 @@ const (
 // and the containing Rack.  Note that it currently does not fill in the cable
 // information, as that is missing from the inventory definition.  That is
 // done is the fixConnection function below.
-func newTor(_ *pb.External_Tor, r *Rack) *tor {
+func newTor(_ *pb.Definition_Tor, r *Rack) *tor {
 	t := &tor{
 		cables: make(map[int64]*cable),
 		holder: r,

--- a/simulation/pkg/errors/errors.go
+++ b/simulation/pkg/errors/errors.go
@@ -424,8 +424,7 @@ type ErrConfigPduDuplicate struct {
 
 func (e ErrConfigPduDuplicate) Error() string {
 	return fmt.Sprintf(
-		"CloudChamber: Configuration detected duplicate Pdu %d in %s",
-		e.Pdu,
+		"CloudChamber: Configuration detected duplicate Pdu for %s",
 		pduAddress(e.Region, e.Zone, e.Rack, e.Pdu))
 }
 
@@ -456,8 +455,7 @@ type ErrConfigTorDuplicate struct {
 
 func (e ErrConfigTorDuplicate) Error() string {
 	return fmt.Sprintf(
-		"CloudChamber: Configuration detected duplicate Tor %d in %s",
-		e.Tor,
+		"CloudChamber: Configuration detected duplicate Tor for %s",
 		torAddress(e.Region, e.Zone, e.Rack, e.Tor))
 }
 
@@ -489,8 +487,7 @@ type ErrConfigBladeDuplicate struct {
 
 func (e ErrConfigBladeDuplicate) Error() string {
 	return fmt.Sprintf(
-		"CloudChamber: Configuration detected duplicate Blade %d in %s",
-		e.Blade,
+		"CloudChamber: Configuration detected duplicate Blade for %s",
 		bladeAddress(e.Region, e.Zone, e.Rack, e.Blade))
 }
 
@@ -606,7 +603,7 @@ type ErrRackValidationFailure struct {
 }
 
 func (evf ErrRackValidationFailure) Error() string {
-	return fmt.Sprintf("In rack %q: %v", evf.Rack, evf.Err)
+	return fmt.Sprintf("CloudChamber: in rack %q: %v", evf.Rack, evf.Err)
 }
 
 // ErrRegionValidationFailure indicates validation failure in the attributes associated
@@ -617,7 +614,7 @@ type ErrRegionValidationFailure struct {
 }
 
 func (e ErrRegionValidationFailure) Error() string {
-	return fmt.Sprintf("In rack %q: %v", e.Region, e.Err)
+	return fmt.Sprintf("CloudChamber: in region %q: %v", e.Region, e.Err)
 }
 
 // ErrUserAlreadyExists indicates the attempt to create a new user account


### PR DESCRIPTION
Updates the remaining existing inventory.yaml files to use the extended format
Removes the routines to read and process the earlier format
Removes the tests for the routines processing the earlier format
Updates the inventory service to load and process the extended inventory file
Updates the web server and inventory services so that the inventory service is the only service to load the configured inventory into the store