### PR TITLE
Make logfile output redirection more reliable

### DIFF
--- a/simulation/scripts/StartCloudChamber.cmd
+++ b/simulation/scripts/StartCloudChamber.cmd
@@ -108,7 +108,7 @@ rem
 echo.
 echo Starting %TARGETBIN%
 
-start cmd /c "%TARGETBIN% -config=%2 2>&1 >%CLOUDCHAMBERLOGS%\%BINARY:~0,-4%.log"
+start cmd /c "%TARGETBIN% -config=%2 >%CLOUDCHAMBERLOGS%\%BINARY:~0,-4%.log 2>&1"
 goto :StartBinaryExit
 
 


### PR DESCRIPTION
Seems that for stderr to be properly re-directed to stdout, need to put the stderr re-direction *after* the stdout re-direction.