### PR TITLE
Add title string to allow the started CMD window to be identified

### DIFF
--- a/simulation/scripts/StartCloudChamber.cmd
+++ b/simulation/scripts/StartCloudChamber.cmd
@@ -108,7 +108,7 @@ rem
 echo.
 echo Starting %TARGETBIN%
 
-start cmd /c "%TARGETBIN% -config=%2 >%CLOUDCHAMBERLOGS%\%BINARY:~0,-4%.log 2>&1"
+start "%TARGETBIN%" cmd /c "%TARGETBIN% -config=%2 >%CLOUDCHAMBERLOGS%\%BINARY:~0,-4%.log 2>&1"
 goto :StartBinaryExit
 
 


### PR DESCRIPTION
Currently, since no explicit title string is given to the  CMD windows use to host the individual processes, the default for CMD.exe is used.

Adding an explicit title string allows each CMD windows to be distinguished for each of the service processes.