### PR TITLE
Add ability to establish Watchpoints on portion of the store namespace, part 1

### DIFF
--- a/simulation/internal/clients/inventory/TestSuiteCore.go
+++ b/simulation/internal/clients/inventory/TestSuiteCore.go
@@ -1,6 +1,7 @@
 package inventory
 
 import (
+	"context"
 	"flag"
 	"sync"
 
@@ -57,7 +58,7 @@ func (ts *testSuiteCore) SetupSuite() {
 	ts.utf = exporters.NewExporter(exporters.NewUTForwarder())
 	exporters.ConnectToProvider(ts.utf)
 
-	store.Initialize(cfg)
+	store.Initialize(context.Background(), cfg)
 
 	ts.cfg = cfg
 	ts.store = store.NewStore()

--- a/simulation/internal/clients/store/common_test.go
+++ b/simulation/internal/clients/store/common_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -44,7 +45,7 @@ func commonSetup() {
 		log.Fatalf("failed to process the global configuration: %v", err)
 	}
 
-	Initialize(cfg)
+	Initialize(context.Background(), cfg)
 }
 
 func testGenerateKeyFromNames(prefix string, name string) string {

--- a/simulation/internal/clients/store/store_test.go
+++ b/simulation/internal/clients/store/store_test.go
@@ -1294,6 +1294,10 @@ func TestStoreSetWatch(t *testing.T) {
 	_ = utf.Open(t)
 	defer utf.Close()
 
+	ctx, span := tracing.StartSpan(context.Background(),
+		tracing.WithContextValue(timestamp.OutsideTime))
+	defer span.End()
+
 	key := "TestStoreSetWatch/Key"
 
 	store := NewStore()
@@ -1302,7 +1306,7 @@ func TestStoreSetWatch(t *testing.T) {
 	err := store.Connect()
 	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
 
-	err = store.SetWatch(key)
+	_, err = store.SetWatch(ctx, key)
 	assert.NotNilf(t, err, "Unexpectedly succeeded setting a watch point - error: %v", err)
 	assert.Equal(t, errors.ErrStoreNotImplemented("SetWatch"), err, "Unexpected error response - expected: %v got: %v", errors.ErrStoreNotImplemented("SetWatch"), err)
 
@@ -1317,6 +1321,10 @@ func TestStoreSetWatchMultiple(t *testing.T) {
 	_ = utf.Open(t)
 	defer utf.Close()
 
+	ctx, span := tracing.StartSpan(context.Background(),
+		tracing.WithContextValue(timestamp.OutsideTime))
+	defer span.End()
+
 	keySet := []string{"TestStoreSetWatchMultiple/Key"}
 
 	store := NewStore()
@@ -1325,7 +1333,7 @@ func TestStoreSetWatchMultiple(t *testing.T) {
 	err := store.Connect()
 	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
 
-	err = store.SetWatchMultiple(keySet)
+	err = store.SetWatchMultiple(ctx, keySet)
 	assert.NotNilf(t, err, "Unexpectedly succeeded setting a watch point - error: %v", err)
 	assert.Equal(t, errors.ErrStoreNotImplemented("SetWatchMultiple"), err, "Unexpected error response - expected: %v got: %v", errors.ErrStoreNotImplemented("SetWatchMultiple"), err)
 
@@ -1340,6 +1348,10 @@ func TestStoreSetWatchPrefix(t *testing.T) {
 	_ = utf.Open(t)
 	defer utf.Close()
 
+	ctx, span := tracing.StartSpan(context.Background(),
+		tracing.WithContextValue(timestamp.OutsideTime))
+	defer span.End()
+
 	key := "TestStoreSetWatchPrefix/Key"
 
 	store := NewStore()
@@ -1348,7 +1360,7 @@ func TestStoreSetWatchPrefix(t *testing.T) {
 	err := store.Connect()
 	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
 
-	err = store.SetWatchWithPrefix(key)
+	err = store.SetWatchWithPrefix(ctx, key)
 	assert.NotNilf(t, err, "Unexpectedly succeeded setting a watch point - error: %v", err)
 	assert.Equal(t, errors.ErrStoreNotImplemented("SetWatchWithPrefix"), err, "Unexpected error response - expected: %v got: %v", errors.ErrStoreNotImplemented("SetWatchWithPrefix"), err)
 

--- a/simulation/internal/clients/store/store_test.go
+++ b/simulation/internal/clients/store/store_test.go
@@ -1306,36 +1306,12 @@ func TestStoreSetWatch(t *testing.T) {
 	err := store.Connect()
 	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
 
-	_, err = store.SetWatch(ctx, key)
+	w, err := store.SetWatch(ctx, key)
 	assert.NotNilf(t, err, "Unexpectedly succeeded setting a watch point - error: %v", err)
 	assert.Equal(t, errors.ErrStoreNotImplemented("SetWatch"), err, "Unexpected error response - expected: %v got: %v", errors.ErrStoreNotImplemented("SetWatch"), err)
 
-	store.Disconnect()
-
-	store = nil
-
-	return
-}
-
-func TestStoreSetWatchMultiple(t *testing.T) {
-	_ = utf.Open(t)
-	defer utf.Close()
-
-	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithContextValue(timestamp.OutsideTime))
-	defer span.End()
-
-	keySet := []string{"TestStoreSetWatchMultiple/Key"}
-
-	store := NewStore()
-	assert.NotNilf(t, store, "Failed to get the store as expected")
-
-	err := store.Connect()
-	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
-
-	err = store.SetWatchMultiple(ctx, keySet)
-	assert.NotNilf(t, err, "Unexpectedly succeeded setting a watch point - error: %v", err)
-	assert.Equal(t, errors.ErrStoreNotImplemented("SetWatchMultiple"), err, "Unexpected error response - expected: %v got: %v", errors.ErrStoreNotImplemented("SetWatchMultiple"), err)
+	require.NotNil(t, w)
+	w.Close(ctx)
 
 	store.Disconnect()
 
@@ -1360,9 +1336,12 @@ func TestStoreSetWatchPrefix(t *testing.T) {
 	err := store.Connect()
 	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
 
-	err = store.SetWatchWithPrefix(ctx, key)
+	w, err := store.SetWatchWithPrefix(ctx, key)
 	assert.NotNilf(t, err, "Unexpectedly succeeded setting a watch point - error: %v", err)
 	assert.Equal(t, errors.ErrStoreNotImplemented("SetWatchWithPrefix"), err, "Unexpected error response - expected: %v got: %v", errors.ErrStoreNotImplemented("SetWatchWithPrefix"), err)
+
+	require.NotNil(t, w)
+	w.Close(ctx)
 
 	store.Disconnect()
 

--- a/simulation/internal/clients/store/store_test.go
+++ b/simulation/internal/clients/store/store_test.go
@@ -1298,7 +1298,17 @@ func TestStoreSetWatch(t *testing.T) {
 		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
-	key := "TestStoreSetWatch/Key"
+	testName := "TestStoreSetWatch"
+	key := testGenerateKeyFromName(testName)
+
+	writeRequest := testGenerateRequestForWrite(0, key)
+	updateRequest := testGenerateRequestForWrite(0, key)
+	deleteRequest := testGenerateRequestForDelete(0, key)
+
+	assert.Equal(t, 1, len(writeRequest.Records))
+	assert.Equal(t, 1, len(updateRequest.Records))
+	assert.Equal(t, 1, len(deleteRequest.Records))
+
 
 	store := NewStore()
 	assert.NotNilf(t, store, "Failed to get the store as expected")
@@ -1307,10 +1317,69 @@ func TestStoreSetWatch(t *testing.T) {
 	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
 
 	w, err := store.SetWatch(ctx, key)
-	assert.NotNilf(t, err, "Unexpectedly succeeded setting a watch point - error: %v", err)
-	assert.Equal(t, errors.ErrStoreNotImplemented("SetWatch"), err, "Unexpected error response - expected: %v got: %v", errors.ErrStoreNotImplemented("SetWatch"), err)
-
+	assert.NoError(t, err, "Failed setting a watch point - error: %v", err)
 	require.NotNil(t, w)
+
+
+	writeResponse, err := store.WriteTxn(ctx, writeRequest)
+	assert.NoError(t, err, "Failed to write to store - error: %v", err)
+	require.NotNil(t, writeResponse)
+	assert.Equal(t, 0, len(writeResponse.Records))
+	assert.Less(t, revStoreInitial, writeResponse.Revision)
+
+	writeEvent := <-w.Events
+
+	require.NotNil(t, writeEvent)
+	assert.Equal(t, WatchEventTypeCreate, writeEvent.Type)
+	assert.Equal(t, key, writeEvent.Key)
+	assert.Equal(t, writeResponse.Revision, writeEvent.Revision)
+
+	assert.Equal(t, RevisionInvalid, writeEvent.OldRev)
+	assert.Equal(t, "", writeEvent.OldVal)
+
+	assert.Equal(t, writeResponse.Revision, writeEvent.NewRev)
+	assert.Equal(t, writeRequest.Records[key].Value, writeEvent.NewVal)
+
+
+	updateResponse, err := store.WriteTxn(ctx, updateRequest)
+	assert.NoError(t, err, "Failed to write to store - error: %v", err)
+	require.NotNil(t, updateResponse)
+	assert.Equal(t, 0, len(updateResponse.Records))
+	assert.Less(t, writeResponse.Revision, updateResponse.Revision)
+
+	updateEvent := <-w.Events
+
+	require.NotNil(t, updateEvent)
+	assert.Equal(t, WatchEventTypeUpdate, updateEvent.Type)
+	assert.Equal(t, key, updateEvent.Key)
+	assert.Equal(t, updateResponse.Revision, updateEvent.Revision)
+
+	assert.Equal(t, writeResponse.Revision, updateEvent.OldRev)
+	assert.Equal(t, writeRequest.Records[key].Value, updateEvent.OldVal)
+
+	assert.Equal(t, updateResponse.Revision, updateEvent.NewRev)
+	assert.Equal(t, updateRequest.Records[key].Value, updateEvent.NewVal)
+
+
+	deleteResponse, err := store.DeleteTxn(ctx, deleteRequest)
+	assert.NoError(t, err, "Failed to delete from store - error: %v", err)
+	require.NotNil(t, deleteResponse)
+	assert.Equal(t, 0, len(deleteResponse.Records))
+	assert.Less(t, updateResponse.Revision, deleteResponse.Revision)
+
+	deleteEvent := <-w.Events
+
+	require.NotNil(t, deleteEvent)
+	assert.Equal(t, WatchEventTypeDelete, deleteEvent.Type)
+	assert.Equal(t, key, deleteEvent.Key)
+	assert.Equal(t, deleteResponse.Revision, deleteEvent.Revision)
+
+	assert.Equal(t, updateResponse.Revision, deleteEvent.OldRev)
+	assert.Equal(t, updateRequest.Records[key].Value, deleteEvent.OldVal)
+
+	assert.Equal(t, RevisionInvalid, deleteEvent.NewRev)
+	assert.Equal(t, "" , deleteEvent.NewVal)
+
 	w.Close(ctx)
 
 	store.Disconnect()
@@ -1328,7 +1397,17 @@ func TestStoreSetWatchPrefix(t *testing.T) {
 		tracing.WithContextValue(timestamp.OutsideTime))
 	defer span.End()
 
-	key := "TestStoreSetWatchPrefix/Key"
+	testName := "TestStoreSetWatchPrefix"
+	key := testGenerateKeyFromName(testName)
+
+	writeRequest := testGenerateRequestForWrite(2, key)
+	updateRequest := testGenerateRequestForWrite(2, key)
+	deleteRequest := testGenerateRequestForDelete(2, key)
+
+	assert.Equal(t, 2, len(writeRequest.Records))
+	assert.Equal(t, 2, len(updateRequest.Records))
+	assert.Equal(t, 2, len(deleteRequest.Records))
+
 
 	store := NewStore()
 	assert.NotNilf(t, store, "Failed to get the store as expected")
@@ -1337,10 +1416,91 @@ func TestStoreSetWatchPrefix(t *testing.T) {
 	assert.Nilf(t, err, "Failed to connect to store - error: %v", err)
 
 	w, err := store.SetWatchWithPrefix(ctx, key)
-	assert.NotNilf(t, err, "Unexpectedly succeeded setting a watch point - error: %v", err)
-	assert.Equal(t, errors.ErrStoreNotImplemented("SetWatchWithPrefix"), err, "Unexpected error response - expected: %v got: %v", errors.ErrStoreNotImplemented("SetWatchWithPrefix"), err)
-
+	assert.NoError(t, err, "Failed setting a watch point - error: %v", err)
 	require.NotNil(t, w)
+
+
+	writeResponse, err := store.WriteTxn(ctx, writeRequest)
+	assert.NoError(t, err, "Failed to write to store - error: %v", err)
+	require.NotNil(t, writeResponse)
+	assert.Equal(t, 0, len(writeResponse.Records))
+	assert.Less(t, revStoreInitial, writeResponse.Revision)
+
+	// At this point we expect two events, one for each of the k/v pairs in the
+	// write request. The order of the events is arbitrary.
+	//
+	for i := 0; i < len(writeRequest.Records); i++ {
+		writeEvent := <-w.Events
+
+		require.NotNil(t, writeEvent)
+		assert.Equal(t, WatchEventTypeCreate, writeEvent.Type)
+		assert.Equal(t, writeResponse.Revision, writeEvent.Revision)
+
+		record, ok := writeRequest.Records[writeEvent.Key]
+		require.True(t, ok)
+
+		assert.Equal(t, RevisionInvalid, writeEvent.OldRev)
+		assert.Equal(t, "", writeEvent.OldVal)
+	
+		assert.Equal(t, writeResponse.Revision, writeEvent.NewRev)
+		assert.Equal(t, record.Value, writeEvent.NewVal)
+		}
+
+
+	updateResponse, err := store.WriteTxn(ctx, updateRequest)
+	assert.NoError(t, err, "Failed to write to store - error: %v", err)
+	require.NotNil(t, updateResponse)
+	assert.Equal(t, 0, len(updateResponse.Records))
+	assert.Less(t, writeResponse.Revision, updateResponse.Revision)
+
+	// Now we expect two update events, one for each of the k/v pairs in the
+	// update request. The order of the events is arbitrary.
+	//
+	for i := 0; i < len(updateRequest.Records); i++ {
+		updateEvent := <-w.Events
+
+		require.NotNil(t, updateEvent)
+		assert.Equal(t, WatchEventTypeUpdate, updateEvent.Type)
+		assert.Equal(t, updateResponse.Revision, updateEvent.Revision)
+
+		record, ok := updateRequest.Records[updateEvent.Key]
+		require.True(t, ok)
+
+		assert.Equal(t, writeResponse.Revision, updateEvent.OldRev)
+		assert.Equal(t, writeRequest.Records[updateEvent.Key].Value, updateEvent.OldVal)
+
+		assert.Equal(t, updateResponse.Revision, updateEvent.NewRev)
+		assert.Equal(t, record.Value, updateEvent.NewVal)
+	}
+
+
+	deleteResponse, err := store.DeleteTxn(ctx, deleteRequest)
+	assert.NoError(t, err, "Failed to delete from store - error: %v", err)
+	require.NotNil(t, deleteResponse)
+	assert.Equal(t, 0, len(deleteResponse.Records))
+	assert.Less(t, updateResponse.Revision, deleteResponse.Revision)
+
+	// Finally we expect two delete events, one for each of the k/v pairs in the
+	// delete request. The order of the events is arbitrary.
+	//
+	for i := 0; i < len(updateRequest.Records); i++ {
+		deleteEvent := <-w.Events
+
+		require.NotNil(t, deleteEvent)
+		assert.Equal(t, WatchEventTypeDelete, deleteEvent.Type)
+		assert.Equal(t, deleteResponse.Revision, deleteEvent.Revision)
+
+		_, ok := deleteRequest.Records[deleteEvent.Key]
+		require.True(t, ok)
+
+		assert.Equal(t, updateResponse.Revision, deleteEvent.OldRev)
+		assert.Equal(t, updateRequest.Records[deleteEvent.Key].Value, deleteEvent.OldVal)
+
+		assert.Equal(t, RevisionInvalid, deleteEvent.NewRev)
+		assert.Equal(t, "" , deleteEvent.NewVal)
+	}
+
+
 	w.Close(ctx)
 
 	store.Disconnect()

--- a/simulation/internal/clients/store/storeapi.go
+++ b/simulation/internal/clients/store/storeapi.go
@@ -796,8 +796,8 @@ func (store *Store) Watch(ctx context.Context, r KeyRoot, n string) (*Watch, err
 				Type:     ev.Type,
 				Revision: ev.Revision,
 				Key:      getNameFromKeyRootAndKey(r, ev.Key),
-				ValueNew: ev.ValueNew,
-				ValueOld: ev.ValueOld,
+				NewVal:   ev.NewVal,
+				OldVal:   ev.OldVal,
 			}
 		}
 

--- a/simulation/internal/clients/store/storeapi.go
+++ b/simulation/internal/clients/store/storeapi.go
@@ -765,3 +765,30 @@ func (store *Store) List(ctx context.Context, r KeyRoot, n string) (records *map
 
 	return &recs, response.Revision, nil
 }
+
+// Watch is a method use to establish
+//
+func (store *Store) Watch(ctx context.Context, r KeyRoot, n string) (err error) {
+	ctx, span := tracing.StartSpan(ctx,
+		tracing.WithContextValue(timestamp.EnsureTickInContext))
+	defer span.End()
+
+	if err = store.disconnected(ctx); err != nil {
+		return err
+	}
+
+	prefix := getNamespacePrefixFromKeyRoot(r)
+
+	tracing.UpdateSpanName(ctx, "Request to list keys under prefix %q", prefix)
+
+	k := getKeyFromKeyRootAndName(r, n)
+
+	err = store.SetWatchWithPrefix(ctx, k)
+
+	if err != nil {
+		return err
+	}
+
+
+	return nil
+}

--- a/simulation/internal/services/frontend/frontend.go
+++ b/simulation/internal/services/frontend/frontend.go
@@ -209,7 +209,7 @@ func initService(cfg *config.GlobalConfig) error {
 
 	// Initialize the underlying store
 	//
-	store.Initialize(cfg)
+	store.Initialize(ctx, cfg)
 
 	// initialize the inventory store and apply any updates from the configuration.
 	//

--- a/simulation/internal/services/inventory/inventory.go
+++ b/simulation/internal/services/inventory/inventory.go
@@ -88,11 +88,15 @@ func (s *server) GetCurrentStatus(context.Context, *pb.InventoryStatusMsg) (*pb.
 }
 
 func (s *server) initializeInventory(cfg *config.GlobalConfig) error {
+	ctx, span := tracing.StartSpan(
+		context.Background(),
+		tracing.WithName("Initializing the simulated inventory"),
+		tracing.WithContextValue(ts.EnsureTickInContext))
+	defer span.End()
+
 	// Initialize the underlying store
 	//
-	ctx := context.Background()
-
-	st.Initialize(cfg)
+	st.Initialize(ctx, cfg)
 	s.store = st.NewStore()
 	s.inventory = ic.NewInventory(cfg, s.store)
 	
@@ -114,7 +118,7 @@ func (s *server) initializeInventory(cfg *config.GlobalConfig) error {
 func (s *server) initializeRacks() error {
 	ctx, span := tracing.StartSpan(
 		context.Background(),
-		tracing.WithName("Initializing the simulated inventory"),
+		tracing.WithName("Initializing the simulated inventory racks"),
 		tracing.WithContextValue(ts.EnsureTickInContext))
 	defer span.End()
 

--- a/simulation/pkg/errors/errors.go
+++ b/simulation/pkg/errors/errors.go
@@ -1541,3 +1541,14 @@ type ErrIndexKeyValueMismatch struct {
 func (ekvm ErrIndexKeyValueMismatch) Error() string {
 	return fmt.Sprintf("CloudChamber: mismatch in index key %q for returned value %q in the %q namespace", ekvm.Key, ekvm.Value, ekvm.Namespace)
 }
+
+// ErrAlreadyClosed indicates the specified type of given name is already closed
+//
+type ErrAlreadyClosed struct {
+	Type string
+	Name string
+}
+
+func (e ErrAlreadyClosed) Error() string {
+	return fmt.Sprintf("CloudChamber: %s for %q is already closed", e.Type, e.Name)
+}


### PR DESCRIPTION
Add feature to the store to allow a client to establish one or more watchpoint on portions of the store namespace to detect changes to inventory, workloads, target, observed states etc.

This change provides the underlying primitives at the lower layer of the store which will establish watchpoints and translate from the etcd layer eventing mechanism to something a little more convenient.

This will be followed by part 2 which will contain the storeapi layer to connect the store primitives provided in this change to the store clients using concepts those clients can process.

As a result, changes to storeapi.go can be ignored for the present if desired, although part 2 will contain changes resembling those here but at a later date.

Also includes some minor changes related to passing in an external context for enhanced tracing in the store initialization paths.