### PR TITLE
Reconcile rather than replace inventory definitions in the store with those read from a file

### DIFF
--- a/simulation/internal/clients/inventory/TestSuiteCore.go
+++ b/simulation/internal/clients/inventory/TestSuiteCore.go
@@ -73,5 +73,3 @@ func (ts *testSuiteCore) TearDownTest() {
 	ts.store.Disconnect()
 	ts.utf.Close()
 }
-
-

--- a/simulation/internal/clients/inventory/definition.go
+++ b/simulation/internal/clients/inventory/definition.go
@@ -620,30 +620,10 @@ func (r *Region) GetDetails() *pb.RegionDetails {
 	return cloneRegionDetails(r.details)
 }
 
-// EqualDetails is used to provide a simple equality check for use to determine
-// if the current details match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (r *Region) EqualDetails(details *pb.RegionDetails) bool {
-	return r.details.Name == details.Name &&
-	r.details.State == details.State &&
-	r.details.Location == details.Location &&
-	r.details.Notes == details.Notes
-}
-
-// NotEqualDetails is used to provide a simple equality check for use to determine
-// if the current details do not match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (r *Region) NotEqualDetails(details *pb.RegionDetails) bool {
-	return !r.EqualDetails(details)
-	}
-
 // GetDefinitionRegion returns a copy of the rack definition based on the contents of the
 // current object.
 //
 func (r *Region) GetDefinitionRegion() *pb.Definition_Region {
-
 	return &pb.Definition_Region{
 		Details: r.GetDetails(),
 		Zones:   make(map[string]*pb.Definition_Zone),
@@ -654,13 +634,19 @@ func (r *Region) GetDefinitionRegion() *pb.Definition_Region {
 // if the current region matches the supplied definition. Typically used
 // when looking to see if the record has been changed.
 //
+// Note: only considers information relating to the parent object and does
+//       not include comparisons for any descendants.
+//
 func (r *Region) Equal(d *pb.Definition_Region) bool {
-	return r.EqualDetails(d.Details)
+	return r.details.Equal(d.GetDetails())
 }
 
 // NotEqual is used to provide a simple equality check for use to determine
 // if the current region does not match the supplied definition. Typically used
 // when looking to see if the record has been changed.
+//
+// Note: only considers information relating to the parent object and does
+//       not include comparisons for any descendants.
 //
 func (r *Region) NotEqual(d *pb.Definition_Region) bool {
 	return !r.Equal(d)
@@ -968,25 +954,6 @@ func (z *Zone) GetDetails() *pb.ZoneDetails {
 	return cloneZoneDetails(z.details)
 }
 
-// EqualDetails is used to provide a simple equality check for use to determine
-// if the current details match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (z *Zone) EqualDetails(details *pb.ZoneDetails) bool {
-	return z.details.Enabled == details.Enabled &&
-	z.details.State == details.State &&
-	z.details.Location == details.Location &&
-	z.details.Notes == details.Notes
-}
-
-// NotEqualDetails is used to provide a simple equality check for use to determine
-// if the current details do not match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (z *Zone) NotEqualDetails(details *pb.ZoneDetails) bool {
-	return !z.EqualDetails(details)
-}
-
 // GetDefinitionZone returns a copy of the rack definition based on the contents of the
 // current object.
 //
@@ -1002,13 +969,19 @@ func (z *Zone) GetDefinitionZone() *pb.Definition_Zone {
 // if the current zone matches the supplied definition. Typically used
 // when looking to see if the record has been changed.
 //
+// Note: only considers information relating to the parent object and does
+//       not include comparisons for any descendants.
+//
 func (z *Zone) Equal(d *pb.Definition_Zone) bool {
-	return z.EqualDetails(d.Details)
+	return z.details.Equal(d.GetDetails())
 }
 
 // NotEqual is used to provide a simple equality check for use to determine
 // if the current zone does not match the supplied definition. Typically used
 // when looking to see if the record has been changed.
+//
+// Note: only considers information relating to the parent object and does
+//       not include comparisons for any descendants.
 //
 func (z *Zone) NotEqual(d *pb.Definition_Zone) bool {
 	return !z.Equal(d)
@@ -1455,25 +1428,6 @@ func (r *Rack) GetDetails() *pb.RackDetails {
 	return cloneRackDetails(r.details)
 }
 
-// EqualDetails is used to provide a simple equality check for use to determine
-// if the current details match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (r *Rack) EqualDetails(details *pb.RackDetails) bool {
-	return r.details.Enabled == details.Enabled &&
-	r.details.Condition == details.Condition &&
-	r.details.Location == details.Location &&
-	r.details.Notes == details.Notes
-}
-
-// NotEqualDetails is used to provide a simple equality check for use to determine
-// if the current details do not match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (r *Rack) NotEqualDetails(details *pb.RackDetails) bool {
-	return !r.EqualDetails(details)
-}
-
 // GetDefinitionRack returns a copy of the rack definition based on the contents of the
 // current object.
 //
@@ -1491,13 +1445,19 @@ func (r *Rack) GetDefinitionRack() *pb.Definition_Rack {
 // if the current rack matches the supplied definition. Typically used
 // when looking to see if the record has been changed.
 //
+// Note: only considers information relating to the parent object and does
+//       not include comparisons for any descendants.
+//
 func (r *Rack) Equal(d *pb.Definition_Rack) bool {
-	return r.EqualDetails(d.Details)
+	return r.details.Equal(d.GetDetails())
 }
 
 // NotEqual is used to provide a simple equality check for use to determine
 // if the current rack do not match the supplied definition. Typically used
 // when looking to see if the record has been changed.
+//
+// Note: only considers information relating to the parent object and does
+//       not include comparisons for any descendants.
 //
 func (r *Rack) NotEqual(d *pb.Definition_Rack) bool {
 	return !r.Equal(d)
@@ -2162,23 +2122,6 @@ func (p *Pdu) GetDetails() *pb.PduDetails {
 	return clonePduDetails(p.details)
 }
 
-// EqualDetails is used to provide a simple equality check for use to determine
-// if the current details match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (p *Pdu) EqualDetails(details *pb.PduDetails) bool {
-	return p.details.Enabled == details.Enabled &&
-	p.details.Condition == details.Condition
-}
-
-// NotEqualDetails is used to provide a simple equality check for use to determine
-// if the current details do not match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (p *Pdu) NotEqualDetails(details *pb.PduDetails) bool {
-	return !p.EqualDetails(details)
-}
-
 // SetPorts is used to attach some power port information to the object.
 //
 // The port information is not persisted to the store until an Update()
@@ -2212,19 +2155,12 @@ func (p *Pdu) EqualPorts(ports map[int64]*pb.PowerPort) bool {
 	}
 
 	for i, pp := range *p.ports {
-		if !pp.EqualPort(ports[i]) {
+		if !pp.Equal(ports[i]) {
 			return false
 		}
 	}
 
 	return true
-}
-// NotEqualPorts is used to provide a simple equality check for use to determine
-// if the current ports do not match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (p *Pdu) NotEqualPorts(ports map[int64]*pb.PowerPort) bool {
-	return !p.EqualPorts(ports)
 }
 
 // GetDefinitionPdu returns a copy of the pdu definition based on the contents of the
@@ -2244,7 +2180,7 @@ func (p *Pdu) GetDefinitionPdu() *pb.Definition_Pdu {
 // looking to see if the record has been changed.
 //
 func (p *Pdu) Equal(d *pb.Definition_Pdu) bool {
-	return p.EqualDetails(d.Details) && p.EqualPorts(d.Ports)
+	return p.details.Equal(d.GetDetails()) && p.EqualPorts(d.GetPorts())
 }
 
 // NotEqual is used to provide a simple equality check for use to determine
@@ -2514,23 +2450,6 @@ func (t *Tor) GetDetails() *pb.TorDetails {
 	return cloneTorDetails(t.details)
 }
 
-// EqualDetails is used to provide a simple equality check for use to determine
-// if the current details match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (t *Tor) EqualDetails(details *pb.TorDetails) bool {
-	return t.details.Enabled == details.Enabled &&
-	t.details.Condition == details.Condition
-}
-
-// NotEqualDetails is used to provide a simple equality check for use to determine
-// if the current details do not match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (t *Tor) NotEqualDetails(details *pb.TorDetails) bool {
-	return !t.EqualDetails(details)
-}
-
 // SetPorts is used to attach some network port information to the object.
 //
 // The port information is not persisted to the store until an Update()
@@ -2564,20 +2483,12 @@ func (t *Tor) EqualPorts(ports map[int64]*pb.NetworkPort) bool {
 	}
 
 	for i, np := range *t.ports {
-		if !np.EqualPort(ports[i]) {
+		if !np.Equal(ports[i]) {
 			return false
 		}
 	}
 
 	return true
-}
-
-// NotEqualPorts is used to provide a simple equality check for use to determine
-// if the current ports do not match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (t *Tor) NotEqualPorts(ports map[int64]*pb.NetworkPort) bool {
-	return !t.EqualPorts(ports)
 }
 
 // GetDefinitionTor returns a copy of the tor definition based on the contents of the
@@ -2597,7 +2508,7 @@ func (t *Tor) GetDefinitionTor() *pb.Definition_Tor {
 // when looking to see if the record has been changed.
 //
 func (t *Tor) Equal(d *pb.Definition_Tor) bool {
-	return t.EqualDetails(d.Details) && t.EqualPorts(d.Ports)
+	return t.details.Equal(d.GetDetails()) && t.EqualPorts(d.GetPorts())
 }
 
 // NotEqual is used to provide a simple equality check for use to determine
@@ -2875,23 +2786,6 @@ func (b *Blade) GetDetails() *pb.BladeDetails {
 	return cloneBladeDetails(b.details)
 }
 
-// EqualDetails is used to provide a simple equality check for use to determine
-// if the current details match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (b *Blade) EqualDetails(d *pb.BladeDetails) bool {
-	return b.details.Enabled == d.Enabled &&
-	b.details.Condition == d.Condition
-}
-
-// NotEqualDetails is used to provide a simple equality check for use to determine
-// if the current details do not match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (b *Blade) NotEqualDetails(d *pb.BladeDetails) bool {
-	return !b.EqualDetails(d)
-}
-
 // SetCapacity is used to attach some capacity information to the object.
 //
 // The capacity information is not persisted to the store until an Update()
@@ -2913,30 +2807,6 @@ func (b *Blade) SetCapacity(capacity *pb.BladeCapacity) {
 //
 func (b *Blade) GetCapacity() *pb.BladeCapacity {
 	return cloneBladeCpacity(b.capacity)
-}
-
-// EqualCapacity is used to provide a simple equality check for use to determine
-// if the current capacity match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (b *Blade) EqualCapacity(c *pb.BladeCapacity) bool {
-	if b.capacity.Arch == c.Arch &&
-	b.capacity.Cores == c.Cores &&
-	b.capacity.DiskInGb == c.DiskInGb &&
-	b.capacity.MemoryInMb == c.MemoryInMb &&
-	b.capacity.NetworkBandwidthInMbps == c.NetworkBandwidthInMbps {
-		return true
-	}
-
-	return false
-}
-
-// NotEqualCapacity is used to provide a simple equality check for use to determine
-// if the current capacity do not match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (b *Blade) NotEqualCapacity(c *pb.BladeCapacity) bool {
-	return !b.EqualCapacity(c)
 }
 
 // SetBootInfo is used to attach some boot information to the object.
@@ -2962,25 +2832,6 @@ func (b *Blade) GetBootInfo() *pb.BladeBootInfo {
 	return cloneBootInfo(b.bootInfo)
 }
 
-// EqualBootInfo is used to provide a simple equality check for use to determine
-// if the current capacity match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (b *Blade) EqualBootInfo(i *pb.BladeBootInfo) bool {
-	return b.bootInfo.Source == i.Source &&
-	b.bootInfo.Image == i.Image &&
-	b.bootInfo.Version == i.Version &&
-	b.bootInfo.Parameters == i.Parameters
-}
-
-// NotEqualBootInfo is used to provide a simple equality check for use to determine
-// if the current capacity do not match those supplied. Typically used when looking
-// to see if the record has been changed.
-//
-func (b *Blade) NotEqualBootInfo(i *pb.BladeBootInfo) bool {
-	return !b.EqualBootInfo(i)
-}
-
 // SetBootPowerOn is used to set the boot power on flag
 //
 func (b *Blade) SetBootPowerOn(bootOnPowerOn bool) {
@@ -2993,22 +2844,6 @@ func (b *Blade) SetBootPowerOn(bootOnPowerOn bool) {
 //
 func (b *Blade) GetBootOnPowerOn() bool {
 	return b.bootOnPowerOn
-}
-
-// EqualBootInfo is used to provide a simple equality check for use to determine
-// if the current power on field matches that supplied. Typically used when
-// looking to see if the record has been changed.
-//
-func (b *Blade) EqualBootOnPowerOn(p bool) bool {
-	return b.bootOnPowerOn == p
-}
-
-// NotEqualBootOnPowerOn is used to provide a simple equality check for use to determine
-// if the current power on field does not match that supplied. Typically used when
-// looking to see if the record has been changed.
-//
-func (b *Blade) NotEqualBootOnPowerOn(p bool) bool {
-	return !b.EqualBootOnPowerOn(p)
 }
 
 // GetDefinitionBlade returns a copy of the blade definition based on the contents of the
@@ -3028,10 +2863,10 @@ func (b *Blade) GetDefinitionBlade() *pb.Definition_Blade {
 // when looking to see if the record has been changed.
 //
 func (b *Blade) Equal(d *pb.Definition_Blade) bool {
-	return b.EqualDetails(d.GetDetails()) &&
-		   b.EqualCapacity(d.GetCapacity()) &&
-		   b.EqualBootInfo(d.GetBootInfo()) &&
-		   b.EqualBootOnPowerOn(d.GetBootOnPowerOn())
+	return b.details.Equal(d.GetDetails()) &&
+		   b.capacity.Equal(d.GetCapacity()) &&
+		   b.bootInfo.Equal(d.GetBootInfo()) &&
+		   b.GetBootOnPowerOn() == d.GetBootOnPowerOn()
 }
 
 // NotEqual is used to provide a simple equality check for use to determine

--- a/simulation/internal/clients/inventory/definition.go
+++ b/simulation/internal/clients/inventory/definition.go
@@ -620,6 +620,17 @@ func (r *Region) GetDetails() *pb.RegionDetails {
 	return cloneRegionDetails(r.details)
 }
 
+// EqualDetails is used to provide a simple equality check for use to determine
+// if the current details match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (r *Region) EqualDetails(details *pb.RegionDetails) bool {
+	return r.details.Name == details.Name &&
+	r.details.State == details.State &&
+	r.details.Location == details.Location &&
+	r.details.Notes == details.Notes
+}
+
 // GetDefinitionRegion returns a copy of the rack definition based on the contents of the
 // current object.
 //
@@ -629,6 +640,14 @@ func (r *Region) GetDefinitionRegion() *pb.Definition_Region {
 		Details: r.GetDetails(),
 		Zones:   make(map[string]*pb.Definition_Zone),
 	}
+}
+
+// Equal is used to provide a simple equality check for use to determine
+// if the current region matches the supplied definition. Typically used
+// when looking to see if the record has been changed.
+//
+func (r *Region) Equal(d *pb.Definition_Region) bool {
+	return r.EqualDetails(d.Details)
 }
 
 // Create is used to create a record in the underlying store for the
@@ -933,6 +952,17 @@ func (z *Zone) GetDetails() *pb.ZoneDetails {
 	return cloneZoneDetails(z.details)
 }
 
+// EqualDetails is used to provide a simple equality check for use to determine
+// if the current details match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (z *Zone) EqualDetails(details *pb.ZoneDetails) bool {
+	return z.details.Enabled == details.Enabled &&
+	z.details.State == details.State &&
+	z.details.Location == details.Location &&
+	z.details.Notes == details.Notes
+}
+
 // GetDefinitionZone returns a copy of the rack definition based on the contents of the
 // current object.
 //
@@ -942,6 +972,14 @@ func (z *Zone) GetDefinitionZone() *pb.Definition_Zone {
 		Details: z.GetDetails(),
 		Racks:   make(map[string]*pb.Definition_Rack),
 	}
+}
+
+// Equal is used to provide a simple equality check for use to determine
+// if the current zone matches the supplied definition. Typically used
+// when looking to see if the record has been changed.
+//
+func (z *Zone) Equal(d *pb.Definition_Zone) bool {
+	return z.EqualDetails(d.Details)
 }
 
 // Create is used to create a record in the underlying store for the
@@ -1385,6 +1423,17 @@ func (r *Rack) GetDetails() *pb.RackDetails {
 	return cloneRackDetails(r.details)
 }
 
+// EqualDetails is used to provide a simple equality check for use to determine
+// if the current details match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (r *Rack) EqualDetails(details *pb.RackDetails) bool {
+	return r.details.Enabled == details.Enabled &&
+	r.details.Condition == details.Condition &&
+	r.details.Location == details.Location &&
+	r.details.Notes == details.Notes
+}
+
 // GetDefinitionRack returns a copy of the rack definition based on the contents of the
 // current object.
 //
@@ -1396,6 +1445,14 @@ func (r *Rack) GetDefinitionRack() *pb.Definition_Rack {
 		Tors:    make(map[int64]*pb.Definition_Tor),
 		Blades:  make(map[int64]*pb.Definition_Blade),
 	}
+}
+
+// Equal is used to provide a simple equality check for use to determine
+// if the current rack matches the supplied definition. Typically used
+// when looking to see if the record has been changed.
+//
+func (r *Rack) Equal(d *pb.Definition_Rack) bool {
+	return r.EqualDetails(d.Details)
 }
 
 // GetDefinitionRackWithChildren returns a copy of the rack definition based on the contents of the
@@ -2057,6 +2114,15 @@ func (p *Pdu) GetDetails() *pb.PduDetails {
 	return clonePduDetails(p.details)
 }
 
+// EqualDetails is used to provide a simple equality check for use to determine
+// if the current details match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (p *Pdu) EqualDetails(details *pb.PduDetails) bool {
+	return p.details.Enabled == details.Enabled &&
+	p.details.Condition == details.Condition
+}
+
 // SetPorts is used to attach some power port information to the object.
 //
 // The port information is not persisted to the store until an Update()
@@ -2080,6 +2146,24 @@ func (p *Pdu) GetPorts() *map[int64]*pb.PowerPort {
 	return clonePowerPorts(p.ports)
 }
 
+// EqualPorts is used to provide a simple equality check for use to determine
+// if the current ports match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (p *Pdu) EqualPorts(ports map[int64]*pb.PowerPort) bool {
+	if len(*p.ports) != len(ports) {
+		return false
+	}
+
+	for i, pp := range *p.ports {
+		if !pp.EqualPort(ports[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // GetDefinitionPdu returns a copy of the pdu definition based on the contents of the
 // current object.
 //
@@ -2090,6 +2174,14 @@ func (p *Pdu) GetDefinitionPdu() *pb.Definition_Pdu {
 	}
 
 	return pdu
+}
+
+// Equal is used to provide a simple equality check for use to determine
+// if the current pdu matches the supplied definition. Typically used when
+// looking to see if the record has been changed.
+//
+func (p *Pdu) Equal(d *pb.Definition_Pdu) bool {
+	return p.EqualDetails(d.Details) && p.EqualPorts(d.Ports)
 }
 
 // Create is used to create a record in the underlying store for the
@@ -2351,6 +2443,15 @@ func (t *Tor) GetDetails() *pb.TorDetails {
 	return cloneTorDetails(t.details)
 }
 
+// EqualDetails is used to provide a simple equality check for use to determine
+// if the current details match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (t *Tor) EqualDetails(details *pb.TorDetails) bool {
+	return t.details.Enabled == details.Enabled &&
+	t.details.Condition == details.Condition
+}
+
 // SetPorts is used to attach some network port information to the object.
 //
 // The port information is not persisted to the store until an Update()
@@ -2374,6 +2475,24 @@ func (t *Tor) GetPorts() *map[int64]*pb.NetworkPort {
 	return cloneNetworkPorts(t.ports)
 }
 
+// EqualPorts is used to provide a simple equality check for use to determine
+// if the current ports match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (t *Tor) EqualPorts(ports map[int64]*pb.NetworkPort) bool {
+	if len(*t.ports) != len(ports) {
+		return false
+	}
+
+	for i, np := range *t.ports {
+		if !np.EqualPort(ports[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // GetDefinitionTor returns a copy of the tor definition based on the contents of the
 // current object.
 //
@@ -2384,6 +2503,14 @@ func (t *Tor) GetDefinitionTor() *pb.Definition_Tor {
 	}
 
 	return tor
+}
+
+// Equal is used to provide a simple equality check for use to determine
+// if the current tor matches the supplied definition. Typically used
+// when looking to see if the record has been changed.
+//
+func (t *Tor) Equal(d *pb.Definition_Tor) bool {
+	return t.EqualDetails(d.Details) && t.EqualPorts(d.Ports)
 }
 
 // Create is used to create a record in the underlying store for the
@@ -2653,6 +2780,15 @@ func (b *Blade) GetDetails() *pb.BladeDetails {
 	return cloneBladeDetails(b.details)
 }
 
+// EqualDetails is used to provide a simple equality check for use to determine
+// if the current details match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (b *Blade) EqualDetails(d *pb.BladeDetails) bool {
+	return b.details.Enabled == d.Enabled &&
+	b.details.Condition == d.Condition
+}
+
 // SetCapacity is used to attach some capacity information to the object.
 //
 // The capacity information is not persisted to the store until an Update()
@@ -2674,6 +2810,22 @@ func (b *Blade) SetCapacity(capacity *pb.BladeCapacity) {
 //
 func (b *Blade) GetCapacity() *pb.BladeCapacity {
 	return cloneBladeCpacity(b.capacity)
+}
+
+// EqualCapacity is used to provide a simple equality check for use to determine
+// if the current capacity match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (b *Blade) EqualCapacity(c *pb.BladeCapacity) bool {
+	if b.capacity.Arch == c.Arch &&
+	b.capacity.Cores == c.Cores &&
+	b.capacity.DiskInGb == c.DiskInGb &&
+	b.capacity.MemoryInMb == c.MemoryInMb &&
+	b.capacity.NetworkBandwidthInMbps == c.NetworkBandwidthInMbps {
+		return true
+	}
+
+	return false
 }
 
 // SetBootInfo is used to attach some boot information to the object.
@@ -2699,6 +2851,17 @@ func (b *Blade) GetBootInfo() *pb.BladeBootInfo {
 	return cloneBootInfo(b.bootInfo)
 }
 
+// EqualBootInfo is used to provide a simple equality check for use to determine
+// if the current capacity match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (b *Blade) EqualBootInfo(i *pb.BladeBootInfo) bool {
+	return b.bootInfo.Source == i.Source &&
+	b.bootInfo.Image == i.Image &&
+	b.bootInfo.Version == i.Version &&
+	b.bootInfo.Parameters == i.Parameters
+}
+
 // SetBootPowerOn is used to set the boot power on flag
 //
 func (b *Blade) SetBootPowerOn(bootOnPowerOn bool) {
@@ -2713,6 +2876,14 @@ func (b *Blade) GetBootOnPowerOn() bool {
 	return b.bootOnPowerOn
 }
 
+// EqualBootInfo is used to provide a simple equality check for use to determine
+// if the current power on field matches that supplied. Typically used when
+// looking to see if the record has been changed.
+//
+func (b *Blade) EqualBootOnPowerOn(p bool) bool {
+	return b.bootOnPowerOn == p
+}
+
 // GetDefinitionBlade returns a copy of the blade definition based on the contents of the
 // current object.
 //
@@ -2723,6 +2894,17 @@ func (b *Blade) GetDefinitionBlade() *pb.Definition_Blade {
 		BootInfo:      b.GetBootInfo(),
 		BootOnPowerOn: b.GetBootOnPowerOn(),
 	}
+}
+
+// Equal is used to provide a simple equality check for use to determine
+// if the current blade matches the supplied definition. Typically used
+// when looking to see if the record has been changed.
+//
+func (b *Blade) Equal(d *pb.Definition_Blade) bool {
+	return b.EqualDetails(d.GetDetails()) &&
+		   b.EqualCapacity(d.GetCapacity()) &&
+		   b.EqualBootInfo(d.GetBootInfo()) &&
+		   b.EqualBootOnPowerOn(d.GetBootOnPowerOn())
 }
 
 // Create is used to create a record in the underlying store for the

--- a/simulation/internal/clients/inventory/definition.go
+++ b/simulation/internal/clients/inventory/definition.go
@@ -631,6 +631,14 @@ func (r *Region) EqualDetails(details *pb.RegionDetails) bool {
 	r.details.Notes == details.Notes
 }
 
+// NotEqualDetails is used to provide a simple equality check for use to determine
+// if the current details do not match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (r *Region) NotEqualDetails(details *pb.RegionDetails) bool {
+	return !r.EqualDetails(details)
+	}
+
 // GetDefinitionRegion returns a copy of the rack definition based on the contents of the
 // current object.
 //
@@ -648,6 +656,14 @@ func (r *Region) GetDefinitionRegion() *pb.Definition_Region {
 //
 func (r *Region) Equal(d *pb.Definition_Region) bool {
 	return r.EqualDetails(d.Details)
+}
+
+// NotEqual is used to provide a simple equality check for use to determine
+// if the current region does not match the supplied definition. Typically used
+// when looking to see if the record has been changed.
+//
+func (r *Region) NotEqual(d *pb.Definition_Region) bool {
+	return !r.Equal(d)
 }
 
 // Create is used to create a record in the underlying store for the
@@ -963,6 +979,14 @@ func (z *Zone) EqualDetails(details *pb.ZoneDetails) bool {
 	z.details.Notes == details.Notes
 }
 
+// NotEqualDetails is used to provide a simple equality check for use to determine
+// if the current details do not match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (z *Zone) NotEqualDetails(details *pb.ZoneDetails) bool {
+	return !z.EqualDetails(details)
+}
+
 // GetDefinitionZone returns a copy of the rack definition based on the contents of the
 // current object.
 //
@@ -980,6 +1004,14 @@ func (z *Zone) GetDefinitionZone() *pb.Definition_Zone {
 //
 func (z *Zone) Equal(d *pb.Definition_Zone) bool {
 	return z.EqualDetails(d.Details)
+}
+
+// NotEqual is used to provide a simple equality check for use to determine
+// if the current zone does not match the supplied definition. Typically used
+// when looking to see if the record has been changed.
+//
+func (z *Zone) NotEqual(d *pb.Definition_Zone) bool {
+	return !z.Equal(d)
 }
 
 // Create is used to create a record in the underlying store for the
@@ -1434,6 +1466,14 @@ func (r *Rack) EqualDetails(details *pb.RackDetails) bool {
 	r.details.Notes == details.Notes
 }
 
+// NotEqualDetails is used to provide a simple equality check for use to determine
+// if the current details do not match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (r *Rack) NotEqualDetails(details *pb.RackDetails) bool {
+	return !r.EqualDetails(details)
+}
+
 // GetDefinitionRack returns a copy of the rack definition based on the contents of the
 // current object.
 //
@@ -1453,6 +1493,14 @@ func (r *Rack) GetDefinitionRack() *pb.Definition_Rack {
 //
 func (r *Rack) Equal(d *pb.Definition_Rack) bool {
 	return r.EqualDetails(d.Details)
+}
+
+// NotEqual is used to provide a simple equality check for use to determine
+// if the current rack do not match the supplied definition. Typically used
+// when looking to see if the record has been changed.
+//
+func (r *Rack) NotEqual(d *pb.Definition_Rack) bool {
+	return !r.Equal(d)
 }
 
 // GetDefinitionRackWithChildren returns a copy of the rack definition based on the contents of the
@@ -2123,6 +2171,14 @@ func (p *Pdu) EqualDetails(details *pb.PduDetails) bool {
 	p.details.Condition == details.Condition
 }
 
+// NotEqualDetails is used to provide a simple equality check for use to determine
+// if the current details do not match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (p *Pdu) NotEqualDetails(details *pb.PduDetails) bool {
+	return !p.EqualDetails(details)
+}
+
 // SetPorts is used to attach some power port information to the object.
 //
 // The port information is not persisted to the store until an Update()
@@ -2163,6 +2219,13 @@ func (p *Pdu) EqualPorts(ports map[int64]*pb.PowerPort) bool {
 
 	return true
 }
+// NotEqualPorts is used to provide a simple equality check for use to determine
+// if the current ports do not match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (p *Pdu) NotEqualPorts(ports map[int64]*pb.PowerPort) bool {
+	return !p.EqualPorts(ports)
+}
 
 // GetDefinitionPdu returns a copy of the pdu definition based on the contents of the
 // current object.
@@ -2182,6 +2245,14 @@ func (p *Pdu) GetDefinitionPdu() *pb.Definition_Pdu {
 //
 func (p *Pdu) Equal(d *pb.Definition_Pdu) bool {
 	return p.EqualDetails(d.Details) && p.EqualPorts(d.Ports)
+}
+
+// NotEqual is used to provide a simple equality check for use to determine
+// if the current pdu do not match the supplied definition. Typically used when
+// looking to see if the record has been changed.
+//
+func (p *Pdu) NotEqual(d *pb.Definition_Pdu) bool {
+	return !p.Equal(d)
 }
 
 // Create is used to create a record in the underlying store for the
@@ -2452,6 +2523,14 @@ func (t *Tor) EqualDetails(details *pb.TorDetails) bool {
 	t.details.Condition == details.Condition
 }
 
+// NotEqualDetails is used to provide a simple equality check for use to determine
+// if the current details do not match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (t *Tor) NotEqualDetails(details *pb.TorDetails) bool {
+	return !t.EqualDetails(details)
+}
+
 // SetPorts is used to attach some network port information to the object.
 //
 // The port information is not persisted to the store until an Update()
@@ -2493,6 +2572,14 @@ func (t *Tor) EqualPorts(ports map[int64]*pb.NetworkPort) bool {
 	return true
 }
 
+// NotEqualPorts is used to provide a simple equality check for use to determine
+// if the current ports do not match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (t *Tor) NotEqualPorts(ports map[int64]*pb.NetworkPort) bool {
+	return !t.EqualPorts(ports)
+}
+
 // GetDefinitionTor returns a copy of the tor definition based on the contents of the
 // current object.
 //
@@ -2511,6 +2598,14 @@ func (t *Tor) GetDefinitionTor() *pb.Definition_Tor {
 //
 func (t *Tor) Equal(d *pb.Definition_Tor) bool {
 	return t.EqualDetails(d.Details) && t.EqualPorts(d.Ports)
+}
+
+// NotEqual is used to provide a simple equality check for use to determine
+// if the current tor does not match the supplied definition. Typically used
+// when looking to see if the record has been changed.
+//
+func (t *Tor) NotEqual(d *pb.Definition_Tor) bool {
+	return !t.Equal(d)
 }
 
 // Create is used to create a record in the underlying store for the
@@ -2789,6 +2884,14 @@ func (b *Blade) EqualDetails(d *pb.BladeDetails) bool {
 	b.details.Condition == d.Condition
 }
 
+// NotEqualDetails is used to provide a simple equality check for use to determine
+// if the current details do not match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (b *Blade) NotEqualDetails(d *pb.BladeDetails) bool {
+	return !b.EqualDetails(d)
+}
+
 // SetCapacity is used to attach some capacity information to the object.
 //
 // The capacity information is not persisted to the store until an Update()
@@ -2828,6 +2931,14 @@ func (b *Blade) EqualCapacity(c *pb.BladeCapacity) bool {
 	return false
 }
 
+// NotEqualCapacity is used to provide a simple equality check for use to determine
+// if the current capacity do not match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (b *Blade) NotEqualCapacity(c *pb.BladeCapacity) bool {
+	return !b.EqualCapacity(c)
+}
+
 // SetBootInfo is used to attach some boot information to the object.
 //
 // The boot information is not persisted to the store until an Update()
@@ -2862,6 +2973,14 @@ func (b *Blade) EqualBootInfo(i *pb.BladeBootInfo) bool {
 	b.bootInfo.Parameters == i.Parameters
 }
 
+// NotEqualBootInfo is used to provide a simple equality check for use to determine
+// if the current capacity do not match those supplied. Typically used when looking
+// to see if the record has been changed.
+//
+func (b *Blade) NotEqualBootInfo(i *pb.BladeBootInfo) bool {
+	return !b.EqualBootInfo(i)
+}
+
 // SetBootPowerOn is used to set the boot power on flag
 //
 func (b *Blade) SetBootPowerOn(bootOnPowerOn bool) {
@@ -2882,6 +3001,14 @@ func (b *Blade) GetBootOnPowerOn() bool {
 //
 func (b *Blade) EqualBootOnPowerOn(p bool) bool {
 	return b.bootOnPowerOn == p
+}
+
+// NotEqualBootOnPowerOn is used to provide a simple equality check for use to determine
+// if the current power on field does not match that supplied. Typically used when
+// looking to see if the record has been changed.
+//
+func (b *Blade) NotEqualBootOnPowerOn(p bool) bool {
+	return !b.EqualBootOnPowerOn(p)
 }
 
 // GetDefinitionBlade returns a copy of the blade definition based on the contents of the
@@ -2905,6 +3032,14 @@ func (b *Blade) Equal(d *pb.Definition_Blade) bool {
 		   b.EqualCapacity(d.GetCapacity()) &&
 		   b.EqualBootInfo(d.GetBootInfo()) &&
 		   b.EqualBootOnPowerOn(d.GetBootOnPowerOn())
+}
+
+// NotEqual is used to provide a simple equality check for use to determine
+// if the current blade matches the supplied definition. Typically used
+// when looking to see if the record has been changed.
+//
+func (b *Blade) NotEqual(d *pb.Definition_Blade) bool {
+	return !b.Equal(d)
 }
 
 // Create is used to create a record in the underlying store for the

--- a/simulation/internal/clients/inventory/definition_extended_test.go
+++ b/simulation/internal/clients/inventory/definition_extended_test.go
@@ -19,14 +19,6 @@ func (ts *definitionExtendedTestSuite) SetupSuite() {
 	ts.inventory = NewInventory(ts.cfg, ts.store)
 }
 
-func (ts *definitionExtendedTestSuite) SetupTest() {
-	ts.testSuiteCore.SetupTest()
-}
-
-func (ts *definitionExtendedTestSuite) TearDownTest() {
-	ts.testSuiteCore.TearDownTest()
-}
-
 func (ts *definitionExtendedTestSuite) TestReadInventoryDefinitionFromFileExtended() {
 	require := ts.Require()
 

--- a/simulation/internal/clients/inventory/definition_extended_test.go
+++ b/simulation/internal/clients/inventory/definition_extended_test.go
@@ -1,0 +1,133 @@
+package inventory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type definitionExtendedTestSuite struct {
+	testSuiteCore
+
+	inventory      *Inventory
+
+	// regionCount    int
+	// zonesPerRegion int
+	// racksPerZone   int
+	// pdusPerRack    int
+	// torsPerRack    int
+	// bladesPerRack  int
+
+	// portsPerPdu int
+	// portsPerTor int
+}
+
+func (ts *definitionExtendedTestSuite) SetupSuite() {
+	// require := ts.Require()
+
+	// ctx := context.Background()
+
+	ts.testSuiteCore.SetupSuite()
+
+	ts.inventory = NewInventory(ts.cfg, ts.store)
+
+	// // These values are relatively arbitrary. The only criteria is that different
+	// // constants were chosen to help separate different multiples of different
+	// // object types where possible and not to have values which are too large
+	// // to avoid lots of IO when setting up the test suite.
+	// //
+	// ts.regionCount = 2
+	// ts.zonesPerRegion = 3
+	// ts.racksPerZone = 4
+	// ts.pdusPerRack = 1
+	// ts.torsPerRack = 1
+	// ts.bladesPerRack = 5
+
+	// ts.portsPerPdu = ts.torsPerRack + ts.bladesPerRack
+	// ts.portsPerTor = ts.pdusPerRack + ts.torsPerRack + ts.bladesPerRack
+
+	// require.NoError(ts.utf.Open(ts.T()))
+	// require.NoError(ts.store.Connect())
+
+	// err := ts.createStandardInventory(ctx)
+	// require.NoError(err, "failed to create standard inventory")
+
+	// ts.store.Disconnect()
+	// ts.utf.Close()
+}
+
+func (ts *definitionExtendedTestSuite) SetupTest() {
+	require := ts.Require()
+
+	require.NoError(ts.utf.Open(ts.T()))
+
+	require.NoError(ts.store.Connect())
+}
+
+func (ts *definitionExtendedTestSuite) TearDownTest() {
+	ts.store.Disconnect()
+	ts.utf.Close()
+}
+
+func (ts *definitionExtendedTestSuite) TestReadInventoryDefinitionFromFileExtended() {
+	require := ts.Require()
+
+	_, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/extended")
+	require.NoError(err)
+}
+
+func (ts *definitionExtendedTestSuite) TestUpdateInventoryDefinitionExtended() {
+	require := ts.Require()
+
+	ctx := context.Background()
+
+	err := ts.inventory.UpdateInventoryDefinition(ctx, "./testdata/extended")
+	require.NoError(err)
+
+	err = ts.inventory.UpdateInventoryDefinition(ctx, "./testdata/extended")
+	require.NoError(err)
+}
+
+func (ts *definitionExtendedTestSuite) TestWriteInventoryDefinitionExtended() {
+	require := ts.Require()
+
+	ctx := context.Background()
+
+	root, err := ts.inventory.readInventoryDefinitionFromStore(ctx)
+	require.NoError(err)
+
+	err = ts.inventory.deleteInventoryDefinitionFromStore(ctx, root)
+	require.NoError(err)
+
+	root, err = ReadInventoryDefinitionFromFile(ctx, "./testdata/extended")
+	require.NoError(err)
+	require.NotNil(root)
+
+	err = ts.inventory.writeInventoryDefinitionToStore(ctx, root)
+	require.NoError(err)
+
+	rootReload, err := ts.inventory.readInventoryDefinitionFromStore(ctx)
+	require.NoError(err)
+	require.NotNil(rootReload)
+
+	err = ts.inventory.deleteInventoryDefinitionFromStore(ctx, rootReload)
+	require.NoError(err)
+}
+
+func (ts *definitionExtendedTestSuite) TestDeleteInventoryDefinitionExtended() {
+	require := ts.Require()
+
+	ctx := context.Background()
+
+	err := ts.inventory.UpdateInventoryDefinition(ctx, "./testdata/extended")
+	require.NoError(err)
+
+	err = ts.inventory.DeleteInventoryDefinition(ctx)
+	require.NoError(err)
+}
+
+
+func TestDefinitionExtendedTestSuite(t *testing.T) {
+	suite.Run(t, new(definitionExtendedTestSuite))
+}

--- a/simulation/internal/clients/inventory/definition_extended_test.go
+++ b/simulation/internal/clients/inventory/definition_extended_test.go
@@ -11,50 +11,12 @@ type definitionExtendedTestSuite struct {
 	testSuiteCore
 
 	inventory      *Inventory
-
-	// regionCount    int
-	// zonesPerRegion int
-	// racksPerZone   int
-	// pdusPerRack    int
-	// torsPerRack    int
-	// bladesPerRack  int
-
-	// portsPerPdu int
-	// portsPerTor int
 }
 
 func (ts *definitionExtendedTestSuite) SetupSuite() {
-	// require := ts.Require()
-
-	// ctx := context.Background()
-
 	ts.testSuiteCore.SetupSuite()
 
 	ts.inventory = NewInventory(ts.cfg, ts.store)
-
-	// // These values are relatively arbitrary. The only criteria is that different
-	// // constants were chosen to help separate different multiples of different
-	// // object types where possible and not to have values which are too large
-	// // to avoid lots of IO when setting up the test suite.
-	// //
-	// ts.regionCount = 2
-	// ts.zonesPerRegion = 3
-	// ts.racksPerZone = 4
-	// ts.pdusPerRack = 1
-	// ts.torsPerRack = 1
-	// ts.bladesPerRack = 5
-
-	// ts.portsPerPdu = ts.torsPerRack + ts.bladesPerRack
-	// ts.portsPerTor = ts.pdusPerRack + ts.torsPerRack + ts.bladesPerRack
-
-	// require.NoError(ts.utf.Open(ts.T()))
-	// require.NoError(ts.store.Connect())
-
-	// err := ts.createStandardInventory(ctx)
-	// require.NoError(err, "failed to create standard inventory")
-
-	// ts.store.Disconnect()
-	// ts.utf.Close()
 }
 
 func (ts *definitionExtendedTestSuite) SetupTest() {

--- a/simulation/internal/clients/inventory/definition_extended_test.go
+++ b/simulation/internal/clients/inventory/definition_extended_test.go
@@ -20,16 +20,11 @@ func (ts *definitionExtendedTestSuite) SetupSuite() {
 }
 
 func (ts *definitionExtendedTestSuite) SetupTest() {
-	require := ts.Require()
-
-	require.NoError(ts.utf.Open(ts.T()))
-
-	require.NoError(ts.store.Connect())
+	ts.testSuiteCore.SetupTest()
 }
 
 func (ts *definitionExtendedTestSuite) TearDownTest() {
-	ts.store.Disconnect()
-	ts.utf.Close()
+	ts.testSuiteCore.TearDownTest()
 }
 
 func (ts *definitionExtendedTestSuite) TestReadInventoryDefinitionFromFileExtended() {

--- a/simulation/internal/clients/inventory/definition_test.go
+++ b/simulation/internal/clients/inventory/definition_test.go
@@ -3551,25 +3551,77 @@ func (ts *definitionTestSuite) TestUpdateInventoryDefinitionAddRegion() {
 func (ts *definitionTestSuite) TestDeleteInventoryDefinitionBasic() {
 	require := ts.Require()
 
+	regionName := "region1"
+	zoneName := "zone1"
+	rackName := "rack1"
+	torId := int64(0)
+
+	errTorNotFound := errors.ErrTorNotFound{Region: regionName, Zone: zoneName, Rack: rackName, Tor: torId}
+
+	tor, err := ts.inventory.NewTor(namespace.DefinitionTable, regionName, zoneName, rackName, torId)
+	require.NoError(err)
+	require.NotNil(tor)
+
 	ctx := context.Background()
 
-	err := ts.inventory.UpdateInventoryDefinition(ctx, "./testdata/basic")
+	// Verify the sameple tor is not currently present in the inventory.
+	//
+	_, err = tor.Read(ctx)
+	require.ErrorIs(err, errTorNotFound)
+
+	err = ts.inventory.UpdateInventoryDefinition(ctx, "./testdata/basic")
+	require.NoError(err)
+
+	// Verify the sameple tor is now present in the inventory.
+	//
+	_, err = tor.Read(ctx)
 	require.NoError(err)
 
 	err = ts.inventory.DeleteInventoryDefinition(ctx)
 	require.NoError(err)
+
+	// Verify the sameple tor has been removed from the inventory.
+	//
+	_, err = tor.Read(ctx)
+	require.ErrorIs(err, errTorNotFound)
 }
 
 func (ts *definitionTestSuite) TestDeleteInventoryDefinitionSimple() {
 	require := ts.Require()
 
+	regionName := "region1"
+	zoneName := "zone1"
+	rackName := "rack2"
+	bladeId := int64(2)
+
+	errBladeNotFound := errors.ErrBladeNotFound{Region: regionName, Zone: zoneName, Rack: rackName, Blade: bladeId}
+
+	blade, err := ts.inventory.NewBlade(namespace.DefinitionTable, regionName, zoneName, rackName, bladeId)
+	require.NoError(err)
+	require.NotNil(blade)
+
 	ctx := context.Background()
 
-	err := ts.inventory.UpdateInventoryDefinition(ctx, "./testdata/simple")
+	// Verify the sameple blade is not currently present in the inventory.
+	//
+	_, err = blade.Read(ctx)
+	require.ErrorIs(err, errBladeNotFound)
+
+	err = ts.inventory.UpdateInventoryDefinition(ctx, "./testdata/simple")
+	require.NoError(err)
+
+	// Verify the sameple blade is now present in the inventory.
+	//
+	_, err = blade.Read(ctx)
 	require.NoError(err)
 
 	err = ts.inventory.DeleteInventoryDefinition(ctx)
 	require.NoError(err)
+
+	// Verify the sameple blade has been removed from the inventory.
+	//
+	_, err = blade.Read(ctx)
+	require.ErrorIs(err, errBladeNotFound)
 }
 
 func TestDefinitionTestSuite(t *testing.T) {

--- a/simulation/internal/clients/inventory/definition_test.go
+++ b/simulation/internal/clients/inventory/definition_test.go
@@ -417,16 +417,11 @@ func (ts *definitionTestSuite) SetupSuite() {
 }
 
 func (ts *definitionTestSuite) SetupTest() {
-	require := ts.Require()
-
-	require.NoError(ts.utf.Open(ts.T()))
-
-	require.NoError(ts.store.Connect())
+	ts.testSuiteCore.SetupTest()
 }
 
 func (ts *definitionTestSuite) TearDownTest() {
-	ts.store.Disconnect()
-	ts.utf.Close()
+	ts.testSuiteCore.TearDownTest()
 }
 
 func (ts *definitionTestSuite) TestNewRoot() {

--- a/simulation/internal/clients/inventory/definition_test.go
+++ b/simulation/internal/clients/inventory/definition_test.go
@@ -416,14 +416,6 @@ func (ts *definitionTestSuite) SetupSuite() {
 	ts.utf.Close()
 }
 
-func (ts *definitionTestSuite) SetupTest() {
-	ts.testSuiteCore.SetupTest()
-}
-
-func (ts *definitionTestSuite) TearDownTest() {
-	ts.testSuiteCore.TearDownTest()
-}
-
 func (ts *definitionTestSuite) TestNewRoot() {
 	assert := ts.Assert()
 	require := ts.Require()

--- a/simulation/internal/clients/inventory/definition_test.go
+++ b/simulation/internal/clients/inventory/definition_test.go
@@ -3249,43 +3249,10 @@ func (ts *definitionTestSuite) TestReadInventoryDefinitionFromFileBasic() {
 	require.NoError(err)
 }
 
-func (ts *definitionTestSuite) TestReadInventoryDefinitionFromFileExtended() {
-	require := ts.Require()
-
-	_, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/extended")
-	require.NoError(err)
-}
-
 func (ts *definitionTestSuite) TestReadInventoryDefinitionFromFileReference() {
 	require := ts.Require()
 
 	_, err := ReadInventoryDefinitionFromFile(context.Background(), "./testdata/reference")
-	require.NoError(err)
-}
-
-func (ts *definitionTestSuite) TestWriteInventoryDefinitionExtended() {
-	require := ts.Require()
-
-	ctx := context.Background()
-
-	root, err := ts.inventory.readInventoryDefinitionFromStore(ctx)
-	require.NoError(err)
-
-	err = ts.inventory.deleteInventoryDefinitionFromStore(ctx, root)
-	require.NoError(err)
-
-	root, err = ReadInventoryDefinitionFromFile(ctx, "./testdata/extended")
-	require.NoError(err)
-	require.NotNil(root)
-
-	err = ts.inventory.writeInventoryDefinitionToStore(ctx, root)
-	require.NoError(err)
-
-	rootReload, err := ts.inventory.readInventoryDefinitionFromStore(ctx)
-	require.NoError(err)
-	require.NotNil(rootReload)
-
-	err = ts.inventory.deleteInventoryDefinitionFromStore(ctx, rootReload)
 	require.NoError(err)
 }
 
@@ -3298,18 +3265,6 @@ func (ts *definitionTestSuite) TestUpdateInventoryDefinitionBasic() {
 	require.NoError(err)
 
 	err = ts.inventory.UpdateInventoryDefinition(ctx, "./testdata/basic")
-	require.NoError(err)
-}
-
-func (ts *definitionTestSuite) TestUpdateInventoryDefinitionExtended() {
-	require := ts.Require()
-
-	ctx := context.Background()
-
-	err := ts.inventory.UpdateInventoryDefinition(ctx, "./testdata/extended")
-	require.NoError(err)
-
-	err = ts.inventory.UpdateInventoryDefinition(ctx, "./testdata/extended")
 	require.NoError(err)
 }
 
@@ -3618,18 +3573,6 @@ func (ts *definitionTestSuite) TestDeleteInventoryDefinitionBasic() {
 	require.NoError(err)
 }
 
-func (ts *definitionTestSuite) TestDeleteInventoryDefinitionExtended() {
-	require := ts.Require()
-
-	ctx := context.Background()
-
-	err := ts.inventory.UpdateInventoryDefinition(ctx, "./testdata/extended")
-	require.NoError(err)
-
-	err = ts.inventory.DeleteInventoryDefinition(ctx)
-	require.NoError(err)
-}
-
 func (ts *definitionTestSuite) TestDeleteInventoryDefinitionSimple() {
 	require := ts.Require()
 
@@ -3642,6 +3585,6 @@ func (ts *definitionTestSuite) TestDeleteInventoryDefinitionSimple() {
 	require.NoError(err)
 }
 
-func TestInventoryTestSuite(t *testing.T) {
+func TestDefinitionTestSuite(t *testing.T) {
 	suite.Run(t, new(definitionTestSuite))
 }

--- a/simulation/internal/clients/inventory/definition_test.go
+++ b/simulation/internal/clients/inventory/definition_test.go
@@ -3304,9 +3304,8 @@ func (ts *definitionTestSuite) TestUpdateInventoryDefinitionChainedNoChange() {
 	// Since nothing changed, we expect no events.
 	//
 	select {
-	case ev, ok := <-watch.Events:
-		require.False(ok)
-		require.Nil(ev)
+	case <-watch.Events:
+		require.Fail("Should not get here - expecting no events from channel")
 
 	default:
 		// Nothing to do.

--- a/simulation/internal/clients/inventory/inventory.go
+++ b/simulation/internal/clients/inventory/inventory.go
@@ -832,8 +832,7 @@ func (m *Inventory) reconcileOldInventoryPdus(
 			return err
 		}
 
-		_, ok := (*pdusFile)[index]
-		if !ok {
+		if _, ok := (*pdusFile)[index]; !ok {
 			if _, err = pdu.Delete(ctx, true); err != nil {
 				return err
 			}
@@ -855,8 +854,7 @@ func (m *Inventory) reconcileOldInventoryTors(
 			return err
 		}
 
-		_, ok := (*torsFile)[index]
-		if !ok {
+		if _, ok := (*torsFile)[index]; !ok {
 			if _, err = tor.Delete(ctx, true); err != nil {
 				return err
 			}
@@ -878,8 +876,7 @@ func (m *Inventory) reconcileOldInventoryBlades(
 			return err
 		}
 
-		_, ok := (*bladesFile)[index]
-		if !ok {
+		if _, ok := (*bladesFile)[index]; !ok {
 			if _, err = blade.Delete(ctx, true); err != nil {
 				return err
 			}

--- a/simulation/internal/clients/inventory/inventory.go
+++ b/simulation/internal/clients/inventory/inventory.go
@@ -570,7 +570,7 @@ func (m *Inventory) reconcileNewInventoryRegion(
 		regionStore.SetDetails(regionFile.GetDetails())
 
 		_, err = regionStore.Create(ctx)
-	} else if err == nil && regionStore.NotEqualDetails(regionFile.GetDetails()) {
+	} else if err == nil && regionStore.NotEqual(regionFile) {
 		tracing.Info(ctx, "updating region %s", regionStore.Region)
 
 		regionStore.SetDetails(regionFile.GetDetails())
@@ -594,7 +594,7 @@ func (m *Inventory) reconcileNewInventoryZone(
 		zoneStore.SetDetails(zoneFile.GetDetails())
 
 		_, err = zoneStore.Create(ctx)
-	} else if err == nil && zoneStore.NotEqualDetails(zoneFile.GetDetails()) {
+	} else if err == nil && zoneStore.NotEqual(zoneFile) {
 		tracing.Info(ctx, "updating zone %s/%s", zoneStore.Region, zoneStore.Zone)
 
 		zoneStore.SetDetails(zoneFile.GetDetails())
@@ -618,7 +618,7 @@ func (m *Inventory) reconcileNewInventoryRack(
 		rackStore.SetDetails(rackFile.GetDetails())
 
 		_, err = rackStore.Create(ctx)
-	} else if err == nil && rackStore.NotEqualDetails(rackFile.GetDetails()) {
+	} else if err == nil && rackStore.NotEqual(rackFile) {
 		tracing.Info(ctx, "updating rack %s/%s/%s", rackStore.Region, rackStore.Zone, rackStore.Rack)
 
 		rackStore.SetDetails(rackFile.GetDetails())

--- a/simulation/internal/clients/inventory/inventory.go
+++ b/simulation/internal/clients/inventory/inventory.go
@@ -873,8 +873,8 @@ func (m *Inventory) reconcileNewInventory(
 	}
 
 	// Now that new items and updates have been processed, iterate over the store
-	// based inventory and check it it is still present in the file based inventory.
-	// If not, then delete the items from the store.
+	// based inventory and check that all the items are still present in the file
+	// based inventory. If not, then delete the items from the store.
 	//
 	rootStore, err := m.readInventoryDefinitionFromStore(ctx)
 

--- a/simulation/internal/clients/inventory/reader_test.go
+++ b/simulation/internal/clients/inventory/reader_test.go
@@ -17,18 +17,10 @@ type readerTestSuite struct {
 	testSuiteCore
 }
 
-func (ts *readerTestSuite) SetupSuite() {
-	ts.testSuiteCore.SetupSuite()
-}
-
 func (ts *readerTestSuite) SetupTest() {
 	ts.testSuiteCore.SetupTest()
 
 	viper.Reset()
-}
-
-func (ts *readerTestSuite) TearDownTest() {
-	ts.testSuiteCore.TearDownTest()
 }
 
 // first inventory definition test

--- a/simulation/internal/clients/inventory/reader_test.go
+++ b/simulation/internal/clients/inventory/reader_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type readerTestSuite struct {
-	testSuiteCore	
+	testSuiteCore
 }
 
 func (ts *readerTestSuite) SetupSuite() {
@@ -22,17 +22,13 @@ func (ts *readerTestSuite) SetupSuite() {
 }
 
 func (ts *readerTestSuite) SetupTest() {
-	require := ts.Require()
-
-	require.NoError(ts.utf.Open(ts.T()))
-	require.NoError(ts.store.Connect())
+	ts.testSuiteCore.SetupTest()
 
 	viper.Reset()
 }
 
 func (ts *readerTestSuite) TearDownTest() {
-	ts.store.Disconnect()
-	ts.utf.Close()
+	ts.testSuiteCore.TearDownTest()
 }
 
 // first inventory definition test
@@ -306,7 +302,7 @@ func (ts *readerTestSuite) TestReadInventoryDefinitionBasic() {
 				if !assert.Equal(rackName, rackExpectedName, "Found unexpected rack: %s", rackName) {
 					continue
 				}
-		
+
 				assert.True(rack.Details.Enabled)
 				assert.Equal(pb.Condition_operational, rack.Details.Condition)
 				assert.Equal("Pacific NW, row 1, rack 1", rack.Details.Location)

--- a/simulation/internal/clients/inventory/testdata/BadYaml/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/BadYaml/inventory.yaml
@@ -16,7 +16,7 @@ BladeTypes:
     Capacity:
       Cores: 16
       MemoryInMb: 16384
-      DiskInGb: 240 
+      DiskInGb: 240
       NetworkBandwidthInMbps: 2048
       Arch: "X64"
 
@@ -63,7 +63,7 @@ RackTypes:
 # Start of layout
 #
 Details:
-  Name: "Simple Test Inventory"
+  Name: "Bad Yaml"
   Notes: "Test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades. Racks have duplicate names."
 Regions:
   - Name: region1

--- a/simulation/internal/clients/inventory/testdata/ChainedAddBlade/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/ChainedAddBlade/inventory.yaml
@@ -1,6 +1,4 @@
-# Simple test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades.
-#
-# Blades in rack1 have duplicate IDs.
+# Chained Add Blade - test configuration based on the Chained Base configuration but with added blade and associated Pdu and Tor ports.
 
 BladeTypeS:
   - &bladeType1
@@ -19,6 +17,22 @@ BladeTypeS:
       DiskInGb: 240
       NetworkBandwidthInMbps: 2048
       Arch: "X64"
+  - &bladeType2
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: local
+      Image: standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
+      Cores: 8
+      MemoryInMb: 16384
+      DiskInGb: 120
+      NetworkBandwidthInMbps: 2048
+      Arch: "X64"
 
 TorTypes:
   - &torType1
@@ -28,7 +42,8 @@ TorTypes:
     Ports:
       - {Index:  0, Wired: true, Item: {Type:   pdu, Id:  0, Port: 1}}
       - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
-      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 1}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 0}}
+      - {Index:  3, Wired: true, Item: {Type: blade, Id:  3, Port: 0}}
 
 PduTypes:
   - &pduType1
@@ -38,7 +53,8 @@ PduTypes:
     Ports:
       - {Index:  0, Wired: true, Item: {Type:   tor, Id:  0, Port: 1}}
       - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
-      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 1}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 0}}
+      - {Index:  3, Wired: true, Item: {Type: blade, Id:  3, Port: 0}}
 
 RackTypes:
   - &rackType1
@@ -50,25 +66,10 @@ RackTypes:
     Blades:
       - Index: 1
         <<: *bladeType1
-      - Index: 1
-        <<: *bladeType1
-    Tors:
-      - Index: 0
-        <<: *torType1
-    Pdus:
-      - Index: 0
-        <<: *pduType1
-  - &rackType2
-    Details:
-      Enabled: true
-      Condition: Operational
-      Location: "Pacific NW, row 1, rack 1"
-      Notes: "rack definition, 1 pdu, 1 tor, 2 blades"
-    Blades:
-      - Index: 1
-        <<: *bladeType1
       - Index: 2
-        <<: *bladeType1
+        <<: *bladeType2
+      - Index: 3
+        <<: *bladeType2
     Tors:
       - Index: 0
         <<: *torType1
@@ -76,12 +77,27 @@ RackTypes:
       - Index: 0
         <<: *pduType1
 
+ZoneTypes:
+  - &zoneType1
+    Details:
+      Enabled: true
+      State: In_Service
+      Location: "DC-PNW-0"
+      Notes: "Base zone"
+    Racks:
+      - Name: rack1
+        <<: *rackType1
+        Details:
+          Enabled: true
+          Condition: Operational
+          Location: "DC-PNW-0-rack1"
+          Notes: "RackName: rack1"
 
 # Start of layout
 #
 Details:
-  Name: "Bad Yaml Blade"
-  Notes: "Test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades. Blades in rack1 have duplicate IDs."
+  Name: "Chained Add Blade"
+  Notes: "Test configuration based on the Chained Base configuration but with added blade."
 Regions:
   - Name: region1
     Details:
@@ -90,13 +106,4 @@ Regions:
       Notes: "Test Region 1"
     Zones:
       - Name: zone1
-        Details:
-          Enabled: true
-          State: In_Service
-          Location: "Pacific NW, row 1"
-          Notes: "Simple zone definition"
-        Racks:
-          - Name: rack1
-            <<: *rackType1
-          - Name: rack2
-            <<: *rackType2
+        <<: *zoneType1

--- a/simulation/internal/clients/inventory/testdata/ChainedAddRack/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/ChainedAddRack/inventory.yaml
@@ -1,0 +1,120 @@
+# Chained Add Rack - test configuration comprising 1 region, with 1 zone, with the zone having 3 racks, with each rack having a single pdu, a single tor and 2 blades.
+
+BladeTypeS:
+  - &bladeType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: local
+      Image: standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
+      Cores: 16
+      MemoryInMb: 16384
+      DiskInGb: 240
+      NetworkBandwidthInMbps: 2048
+      Arch: "X64"
+  - &bladeType2
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: local
+      Image: standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
+      Cores: 8
+      MemoryInMb: 16384
+      DiskInGb: 120
+      NetworkBandwidthInMbps: 2048
+      Arch: "X64"
+
+TorTypes:
+  - &torType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   pdu, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 0}}
+
+PduTypes:
+  - &pduType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   tor, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 0}}
+
+RackTypes:
+  - &rackType1
+    Details:
+      Enabled: true
+      Condition: Operational
+      Location: "Pacific NW, row 1, rack 1"
+      Notes: "rack definition, 1 pdu, 1 tor, 2 blades"
+    Blades:
+      - Index: 1
+        <<: *bladeType1
+      - Index: 2
+        <<: *bladeType2
+    Tors:
+      - Index: 0
+        <<: *torType1
+    Pdus:
+      - Index: 0
+        <<: *pduType1
+
+ZoneTypes:
+  - &zoneType1
+    Details:
+      Enabled: true
+      State: In_Service
+      Location: "DC-PNW-0"
+      Notes: "Base zone"
+    Racks:
+      - Name: rack1
+        <<: *rackType1
+        Details:
+          Enabled: true
+          Condition: Operational
+          Location: "DC-PNW-0-rack1"
+          Notes: "RackName: rack1"
+      - Name: rack2
+        <<: *rackType1
+        Details:
+          Enabled: true
+          Condition: Operational
+          Location: "DC-PNW-0-rack2"
+          Notes: "RackName: rack2"
+      - Name: rack3
+        <<: *rackType1
+        Details:
+          Enabled: true
+          Condition: Operational
+          Location: "DC-PNW-0-rack3"
+          Notes: "RackName: rack3"
+
+
+# Start of layout
+#
+Details:
+  Name: "Chained Add Rack"
+  Notes: "Test configuration based on the Chained Base configuration but with added rack."
+Regions:
+  - Name: region1
+    Details:
+      State: In_Service
+      Location: "Pacific NW"
+      Notes: "Test Region 1"
+    Zones:
+      - Name: zone1
+        <<: *zoneType1

--- a/simulation/internal/clients/inventory/testdata/ChainedAddRegion/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/ChainedAddRegion/inventory.yaml
@@ -1,0 +1,121 @@
+# Chained Add Region - test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades.
+
+BladeTypeS:
+  - &bladeType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: local
+      Image: standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
+      Cores: 16
+      MemoryInMb: 16384
+      DiskInGb: 240
+      NetworkBandwidthInMbps: 2048
+      Arch: "X64"
+  - &bladeType2
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: local
+      Image: standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
+      Cores: 8
+      MemoryInMb: 16384
+      DiskInGb: 120
+      NetworkBandwidthInMbps: 2048
+      Arch: "X64"
+
+TorTypes:
+  - &torType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   pdu, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 0}}
+
+PduTypes:
+  - &pduType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   tor, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 0}}
+
+RackTypes:
+  - &rackType1
+    Details:
+      Enabled: true
+      Condition: Operational
+      Location: "Pacific NW, row 1, rack 1"
+      Notes: "rack definition, 1 pdu, 1 tor, 2 blades"
+    Blades:
+      - Index: 1
+        <<: *bladeType1
+      - Index: 2
+        <<: *bladeType2
+    Tors:
+      - Index: 0
+        <<: *torType1
+    Pdus:
+      - Index: 0
+        <<: *pduType1
+
+ZoneTypes:
+  - &zoneType1
+    Details:
+      Enabled: true
+      State: In_Service
+      Location: "DC-PNW-0"
+      Notes: "Base zone"
+    Racks:
+      - Name: rack1
+        <<: *rackType1
+        Details:
+          Enabled: true
+          Condition: Operational
+          Location: "DC-PNW-0-rack1"
+          Notes: "RackName: rack1"
+      - Name: rack2
+        <<: *rackType1
+        Details:
+          Enabled: true
+          Condition: Operational
+          Location: "DC-PNW-0-rack2"
+          Notes: "RackName: rack2"
+
+
+# Start of layout
+#
+Details:
+  Name: "Chained Add Region"
+  Notes: "Test configuration based on the Chained Base configuration but with added region."
+Regions:
+  - Name: region1
+    Details:
+      State: In_Service
+      Location: "Pacific NW"
+      Notes: "Test Region 1"
+    Zones:
+      - Name: zone1
+        <<: *zoneType1
+  - Name: region2
+    Details:
+      State: In_Service
+      Location: "Pacific NW"
+      Notes: "Test Region 2"
+    Zones:
+      - Name: zone1
+        <<: *zoneType1

--- a/simulation/internal/clients/inventory/testdata/ChainedAddZone/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/ChainedAddZone/inventory.yaml
@@ -1,6 +1,4 @@
-# Simple test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades.
-#
-# Blades in rack1 have duplicate IDs.
+# Chained Add Zone - test configuration comprising 1 region, with 2 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades.
 
 BladeTypeS:
   - &bladeType1
@@ -19,6 +17,22 @@ BladeTypeS:
       DiskInGb: 240
       NetworkBandwidthInMbps: 2048
       Arch: "X64"
+  - &bladeType2
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: local
+      Image: standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
+      Cores: 8
+      MemoryInMb: 16384
+      DiskInGb: 120
+      NetworkBandwidthInMbps: 2048
+      Arch: "X64"
 
 TorTypes:
   - &torType1
@@ -28,7 +42,7 @@ TorTypes:
     Ports:
       - {Index:  0, Wired: true, Item: {Type:   pdu, Id:  0, Port: 1}}
       - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
-      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 1}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 0}}
 
 PduTypes:
   - &pduType1
@@ -38,7 +52,7 @@ PduTypes:
     Ports:
       - {Index:  0, Wired: true, Item: {Type:   tor, Id:  0, Port: 1}}
       - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
-      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 1}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 0}}
 
 RackTypes:
   - &rackType1
@@ -50,38 +64,44 @@ RackTypes:
     Blades:
       - Index: 1
         <<: *bladeType1
-      - Index: 1
-        <<: *bladeType1
+      - Index: 2
+        <<: *bladeType2
     Tors:
       - Index: 0
         <<: *torType1
     Pdus:
       - Index: 0
         <<: *pduType1
-  - &rackType2
+
+ZoneTypes:
+  - &zoneType1
     Details:
       Enabled: true
-      Condition: Operational
-      Location: "Pacific NW, row 1, rack 1"
-      Notes: "rack definition, 1 pdu, 1 tor, 2 blades"
-    Blades:
-      - Index: 1
-        <<: *bladeType1
-      - Index: 2
-        <<: *bladeType1
-    Tors:
-      - Index: 0
-        <<: *torType1
-    Pdus:
-      - Index: 0
-        <<: *pduType1
+      State: In_Service
+      Location: "DC-PNW-0"
+      Notes: "Base zone"
+    Racks:
+      - Name: rack1
+        <<: *rackType1
+        Details:
+          Enabled: true
+          Condition: Operational
+          Location: "DC-PNW-0-rack1"
+          Notes: "RackName: rack1"
+      - Name: rack2
+        <<: *rackType1
+        Details:
+          Enabled: true
+          Condition: Operational
+          Location: "DC-PNW-0-rack2"
+          Notes: "RackName: rack2"
 
 
 # Start of layout
 #
 Details:
-  Name: "Bad Yaml Blade"
-  Notes: "Test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades. Blades in rack1 have duplicate IDs."
+  Name: "Chained Add Zone"
+  Notes: "Test configuration based on the Chained Base configuration but with added zone."
 Regions:
   - Name: region1
     Details:
@@ -90,13 +110,6 @@ Regions:
       Notes: "Test Region 1"
     Zones:
       - Name: zone1
-        Details:
-          Enabled: true
-          State: In_Service
-          Location: "Pacific NW, row 1"
-          Notes: "Simple zone definition"
-        Racks:
-          - Name: rack1
-            <<: *rackType1
-          - Name: rack2
-            <<: *rackType2
+        <<: *zoneType1
+      - Name: zone2
+        <<: *zoneType1

--- a/simulation/internal/clients/inventory/testdata/ChainedBase/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/ChainedBase/inventory.yaml
@@ -1,6 +1,4 @@
-# Simple test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades.
-#
-# Blades in rack1 have duplicate IDs.
+# Chained Base - test configuration comprising 1 region, with 1 zone, with the zone having 1 rack, with each rack having a single pdu, a single tor and 2 blades.
 
 BladeTypeS:
   - &bladeType1
@@ -19,6 +17,22 @@ BladeTypeS:
       DiskInGb: 240
       NetworkBandwidthInMbps: 2048
       Arch: "X64"
+  - &bladeType2
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: local
+      Image: standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
+      Cores: 8
+      MemoryInMb: 16384
+      DiskInGb: 120
+      NetworkBandwidthInMbps: 2048
+      Arch: "X64"
 
 TorTypes:
   - &torType1
@@ -28,7 +42,7 @@ TorTypes:
     Ports:
       - {Index:  0, Wired: true, Item: {Type:   pdu, Id:  0, Port: 1}}
       - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
-      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 1}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 0}}
 
 PduTypes:
   - &pduType1
@@ -38,7 +52,7 @@ PduTypes:
     Ports:
       - {Index:  0, Wired: true, Item: {Type:   tor, Id:  0, Port: 1}}
       - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
-      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 1}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 0}}
 
 RackTypes:
   - &rackType1
@@ -50,25 +64,8 @@ RackTypes:
     Blades:
       - Index: 1
         <<: *bladeType1
-      - Index: 1
-        <<: *bladeType1
-    Tors:
-      - Index: 0
-        <<: *torType1
-    Pdus:
-      - Index: 0
-        <<: *pduType1
-  - &rackType2
-    Details:
-      Enabled: true
-      Condition: Operational
-      Location: "Pacific NW, row 1, rack 1"
-      Notes: "rack definition, 1 pdu, 1 tor, 2 blades"
-    Blades:
-      - Index: 1
-        <<: *bladeType1
       - Index: 2
-        <<: *bladeType1
+        <<: *bladeType2
     Tors:
       - Index: 0
         <<: *torType1
@@ -76,12 +73,27 @@ RackTypes:
       - Index: 0
         <<: *pduType1
 
+ZoneTypes:
+  - &zoneType1
+    Details:
+      Enabled: true
+      State: In_Service
+      Location: "DC-PNW-0"
+      Notes: "Base zone"
+    Racks:
+      - Name: rack1
+        <<: *rackType1
+        Details:
+          Enabled: true
+          Condition: Operational
+          Location: "DC-PNW-0-rack1"
+          Notes: "RackName: rack1"
 
 # Start of layout
 #
 Details:
-  Name: "Bad Yaml Blade"
-  Notes: "Test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades. Blades in rack1 have duplicate IDs."
+  Name: "Chained Base"
+  Notes: "Chained Base - Test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades."
 Regions:
   - Name: region1
     Details:
@@ -90,13 +102,4 @@ Regions:
       Notes: "Test Region 1"
     Zones:
       - Name: zone1
-        Details:
-          Enabled: true
-          State: In_Service
-          Location: "Pacific NW, row 1"
-          Notes: "Simple zone definition"
-        Racks:
-          - Name: rack1
-            <<: *rackType1
-          - Name: rack2
-            <<: *rackType2
+        <<: *zoneType1

--- a/simulation/internal/clients/inventory/testdata/ChainedChangeBlade/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/ChainedChangeBlade/inventory.yaml
@@ -1,0 +1,113 @@
+# Chained Alter Blade - test configuration comprising 1 region, with 1 zone, with the zone having 2 racks, with each rack having a single pdu, a single tor and 2 blades.
+
+BladeTypeS:
+  - &bladeType1
+    Details:
+      Enabled: true
+      Condition: Not_In_Service
+    BootInfo:
+      Source: local
+      Image: standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
+      Cores: 16
+      MemoryInMb: 16384
+      DiskInGb: 240
+      NetworkBandwidthInMbps: 2048
+      Arch: "X64"
+  - &bladeType2
+    Details:
+      Enabled: true
+      Condition: Operational
+    BootInfo:
+      Source: local
+      Image: standard.vhdx
+      Version: latest
+      Parameters: "-version=1 -node=$NODENAME$"
+    BootOnPowerOn: true
+    Capacity:
+      Cores: 8
+      MemoryInMb: 16384
+      DiskInGb: 120
+      NetworkBandwidthInMbps: 10240
+      Arch: "X64"
+
+TorTypes:
+  - &torType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   pdu, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 0}}
+
+PduTypes:
+  - &pduType1
+    Details:
+      Enabled: true
+      Condition: Operational
+    Ports:
+      - {Index:  0, Wired: true, Item: {Type:   tor, Id:  0, Port: 1}}
+      - {Index:  1, Wired: true, Item: {Type: blade, Id:  1, Port: 0}}
+      - {Index:  2, Wired: true, Item: {Type: blade, Id:  2, Port: 0}}
+
+RackTypes:
+  - &rackType1
+    Details:
+      Enabled: true
+      Condition: Operational
+      Location: "Pacific NW, row 1, rack 1"
+      Notes: "rack definition, 1 pdu, 1 tor, 2 blades"
+    Blades:
+      - Index: 1
+        <<: *bladeType1
+      - Index: 2
+        <<: *bladeType2
+    Tors:
+      - Index: 0
+        <<: *torType1
+    Pdus:
+      - Index: 0
+        <<: *pduType1
+
+ZoneTypes:
+  - &zoneType1
+    Details:
+      Enabled: true
+      State: In_Service
+      Location: "DC-PNW-0"
+      Notes: "Base zone"
+    Racks:
+      - Name: rack1
+        <<: *rackType1
+        Details:
+          Enabled: true
+          Condition: Operational
+          Location: "DC-PNW-0-rack1"
+          Notes: "RackName: rack1"
+      - Name: rack2
+        <<: *rackType1
+        Details:
+          Enabled: true
+          Condition: Operational
+          Location: "DC-PNW-0-rack2"
+          Notes: "RackName: rack2"
+
+
+# Start of layout
+#
+Details:
+  Name: "Chained Change Blade"
+  Notes: "Test configuration based on the Chained Base configuration but with modified blade."
+Regions:
+  - Name: region1
+    Details:
+      State: In_Service
+      Location: "Pacific NW"
+      Notes: "Test Region 1"
+    Zones:
+      - Name: zone1
+        <<: *zoneType1

--- a/simulation/internal/clients/inventory/testdata/Intermediate/inventory.yaml
+++ b/simulation/internal/clients/inventory/testdata/Intermediate/inventory.yaml
@@ -1,5 +1,5 @@
 Details:
-  Name: "Basic Test Inventory"
+  Name: "Intermediate"
   Notes: "Test configuration comprising single region, with a single zone, with 2 racks, which each have a single pdu, a single tor and 4 blades."
 Regions:
   - Name: region1
@@ -35,7 +35,7 @@ Regions:
                 Capacity:
                   Cores: 16
                   MemoryInMb: 16384
-                  DiskInGb: 240 
+                  DiskInGb: 240
                   NetworkBandwidthInMbps: 2048
                   Arch: "X64"
               - Index: 2
@@ -158,55 +158,55 @@ Regions:
                 Ports:
                   - Index: 0
                     Wired: true
-                    Item: 
+                    Item:
                       Type: pdu
                       Id: 0
                       Port: 1
                   - Index: 1
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 1
                       Port: 0
                   - Index: 2
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 2
                       Port: 1
                   - Index: 3
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 3
                       Port: 1
                   - Index: 4
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 4
                       Port: 1
                   - Index: 5
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 5
                       Port: 1
                   - Index: 6
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 6
                       Port: 1
                   - Index: 7
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 7
                       Port: 1
                   - Index: 8
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 8
                       Port: 1
@@ -218,7 +218,7 @@ Regions:
                 Ports:
                   - Index: 0
                     Wired: true
-                    Item: 
+                    Item:
                       Type: tor
                       Id: 0
                       Port: 1
@@ -230,7 +230,7 @@ Regions:
                       Port: 0
                   - Index: 2
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 2
                       Port: 0
@@ -290,7 +290,7 @@ Regions:
                 Capacity:
                   Cores: 16
                   MemoryInMb: 16384
-                  DiskInGb: 240 
+                  DiskInGb: 240
                   NetworkBandwidthInMbps: 2048
                   Arch: "X64"
               - Index: 2
@@ -413,55 +413,55 @@ Regions:
                 Ports:
                   - Index: 0
                     Wired: true
-                    Item: 
+                    Item:
                       Type: pdu
                       Id: 0
                       Port: 1
                   - Index: 1
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 1
                       Port: 0
                   - Index: 2
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 2
                       Port: 1
                   - Index: 3
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 3
                       Port: 1
                   - Index: 4
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 4
                       Port: 1
                   - Index: 5
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 5
                       Port: 1
                   - Index: 6
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 6
                       Port: 1
                   - Index: 7
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 7
                       Port: 1
                   - Index: 8
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 8
                       Port: 1
@@ -473,7 +473,7 @@ Regions:
                 Ports:
                   - Index: 0
                     Wired: true
-                    Item: 
+                    Item:
                       Type: tor
                       Id: 0
                       Port: 1
@@ -485,7 +485,7 @@ Regions:
                       Port: 0
                   - Index: 2
                     Wired: true
-                    Item: 
+                    Item:
                       Type: blade
                       Id: 2
                       Port: 0

--- a/simulation/pkg/protos/inventory/definition.Validate.go
+++ b/simulation/pkg/protos/inventory/definition.Validate.go
@@ -216,7 +216,7 @@ func (x *Definition_Blade) Validate(prefix string) error {
 
 	// Validate that the capacity is valid
 	//
-	if err := x.Capacity.Validate(fmt.Sprintf("%s", prefix)); err != nil {
+	if err := x.Capacity.Validate(prefix); err != nil {
 			return err
 	}
 
@@ -228,7 +228,7 @@ func (x *Definition_Blade) Validate(prefix string) error {
 //
 func (x *Definition_Rack) Validate(prefix string) error {
 
-	// Verify that rack has at least the minimum number of pdus..., 
+	// Verify that rack has at least the minimum number of pdus...,
 	//
 	countPdus := int64(len(x.Pdus))
 
@@ -250,7 +250,7 @@ func (x *Definition_Rack) Validate(prefix string) error {
 		}
 	}
 
-	// Verify that rack has at least the minimum number of tors..., 
+	// Verify that rack has at least the minimum number of tors...,
 	//
 	countTors := int64(len(x.Tors))
 
@@ -272,7 +272,7 @@ func (x *Definition_Rack) Validate(prefix string) error {
 		}
 	}
 
-	// Verify that rack has at least the minimum number of blades..., 
+	// Verify that rack has at least the minimum number of blades...,
 	//
 	countBlades := int64(len(x.Blades))
 

--- a/simulation/pkg/protos/inventory/inventory.Utility.go
+++ b/simulation/pkg/protos/inventory/inventory.Utility.go
@@ -1,0 +1,15 @@
+// Assorted utility routines for types from the various protobuf definitions
+
+package inventory
+
+func (hw *Hardware) EqualHardware(item *Hardware) bool {
+	return hw.Type == item.Type && hw.Id == item.Id
+}
+
+func (pp *PowerPort) EqualPort(port *PowerPort) bool {
+	return pp.Wired == port.Wired && pp.Item.EqualHardware(port.Item)
+}
+
+func (np *NetworkPort) EqualPort(port *NetworkPort) bool {
+	return np.Wired == port.Wired && np.Item.EqualHardware(port.Item)
+}

--- a/simulation/pkg/protos/inventory/inventory.Utility.go
+++ b/simulation/pkg/protos/inventory/inventory.Utility.go
@@ -2,14 +2,155 @@
 
 package inventory
 
-func (hw *Hardware) EqualHardware(item *Hardware) bool {
-	return hw.Type == item.Type && hw.Id == item.Id
+func (hw *Hardware) Equal(h *Hardware) bool {
+	return hw.GetType() == h.GetType() && hw.GetId() == h.GetId()
 }
 
-func (pp *PowerPort) EqualPort(port *PowerPort) bool {
-	return pp.Wired == port.Wired && pp.Item.EqualHardware(port.Item)
+func (pp *PowerPort) Equal(p *PowerPort) bool {
+	return pp.GetWired() == p.GetWired() && pp.Item.Equal(p.Item)
 }
 
-func (np *NetworkPort) EqualPort(port *NetworkPort) bool {
-	return np.Wired == port.Wired && np.Item.EqualHardware(port.Item)
+func (np *NetworkPort) Equal(p *NetworkPort) bool {
+	return np.GetWired() == p.GetWired() && np.Item.Equal(p.Item)
+}
+
+func (rd *RootDetails) Equal(d *RootDetails) bool {
+	return rd.GetName() == d.GetName() && rd.GetNotes() == d.GetNotes()
+}
+
+func (rd *RegionDetails) Equal(d *RegionDetails) bool {
+	return rd.GetName() == d.GetName() &&
+		   rd.GetState() == d.GetState() &&
+		   rd.GetLocation() == d.GetLocation() &&
+		   rd.GetNotes() == d.GetNotes()
+}
+
+func (zd *ZoneDetails) Equal(d *ZoneDetails) bool {
+	return zd.GetEnabled() == d.GetEnabled() &&
+		   zd.GetState() == d.GetState() &&
+		   zd.GetLocation() == d.GetLocation() &&
+		   zd.GetNotes() == d.GetNotes()
+}
+
+func (rd *RackDetails) Equal(d *RackDetails) bool {
+	return rd.GetEnabled() == d.GetEnabled() &&
+		   rd.GetCondition() == d.GetCondition() &&
+		   rd.GetLocation() == d.GetLocation() &&
+		   rd.GetNotes() == d.GetNotes()
+}
+
+func (pd *PduDetails) Equal(d *PduDetails) bool {
+	return pd.GetEnabled() == d.GetEnabled() && pd.GetCondition() == d.GetCondition()
+}
+
+func (td *TorDetails) Equal(d *TorDetails) bool {
+	return td.GetEnabled() == d.GetEnabled() && td.GetCondition() == d.GetCondition()
+}
+
+func (bd *BladeDetails) Equal(d *BladeDetails) bool {
+	return bd.GetEnabled() == d.GetEnabled() && bd.GetCondition() == d.GetCondition()
+}
+
+func (bc *BladeCapacity) Equal(c *BladeCapacity) bool {
+	return bc.GetArch() == c.GetArch() &&
+		   bc.GetCores() == c.GetCores() &&
+		   bc.GetDiskInGb() == c.GetDiskInGb() &&
+		   bc.GetMemoryInMb() == c.GetMemoryInMb() &&
+		   bc.GetNetworkBandwidthInMbps() == c.GetNetworkBandwidthInMbps()
+}
+
+func (bi *BladeBootInfo) Equal(i *BladeBootInfo) bool {
+	return bi.GetSource() == i.GetSource() &&
+		   bi.GetImage() == i.GetImage() &&
+		   bi.GetVersion() == i.GetVersion() &&
+		   bi.GetParameters() == i.GetParameters()
+}
+
+func (dt *Definition_Pdu) EqualPorts(d *Definition_Pdu) bool {
+	switch {
+	case dt == nil && d == nil:
+		return true
+
+	case (dt == nil) != (d == nil):
+		return false
+	}
+
+	dtPorts := dt.GetPorts()
+	dPorts := d.GetPorts()
+
+	if len(dtPorts) != len(dPorts) {
+		return false
+	}
+
+	for i, pp := range dtPorts {
+		if !pp.Equal(dPorts[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (dt *Definition_Pdu) Equal(d *Definition_Pdu) bool {
+	switch {
+	case dt == nil && d == nil:
+		return true
+
+	case (dt == nil) != (d == nil):
+		return false
+	}
+
+	return dt.Details.Equal(d.GetDetails()) && dt.EqualPorts(d)
+}
+
+func (dt *Definition_Tor) EqualPorts(d *Definition_Tor) bool {
+	switch {
+	case dt == nil && d == nil:
+		return true
+
+	case (dt == nil) != (d == nil):
+		return false
+	}
+
+	dtPorts := dt.GetPorts()
+	dPorts := d.GetPorts()
+
+	if len(dtPorts) != len(dPorts) {
+		return false
+	}
+
+	for i, pp := range dtPorts {
+		if !pp.Equal(dPorts[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (dt *Definition_Tor) Equal(d *Definition_Tor) bool {
+	switch {
+	case dt == nil && d == nil:
+		return true
+
+	case (dt == nil) != (d == nil):
+		return false
+	}
+
+	return dt.Details.Equal(d.GetDetails()) && dt.EqualPorts(d)
+}
+
+func (db *Definition_Blade) Equal(d *Definition_Blade) bool {
+	switch {
+	case db == nil && d == nil:
+		return true
+
+	case (db == nil) != (d == nil):
+		return false
+	}
+
+	return db.Details.Equal(d.GetDetails()) &&
+		   db.Capacity.Equal(d.GetCapacity()) &&
+		   db.BootInfo.Equal(d.GetBootInfo()) &&
+		   db.GetBootOnPowerOn() == d.GetBootOnPowerOn()
 }


### PR DESCRIPTION
Currently, whenever a new set of inventory definitions is read from file, the existing store copy is completely deleted and then the new version from the file is written to the store. This generates a large number of changes which will lead to a large number of Watch events being sent to any registered listeners. This is quite taxing on the system and could well lead to short term workload failures event for minor changes to an inventory.

This edit instead compares the incoming definitions from an inventory.yaml files and compare those definitions with the set already present in the store and will only update the store where there are differences as a result of additions, updates or deletions. For cases where there are just minor changes, this will not lead to large number of Watch events and so avoid major disturbances in the simulation.

In all cases, the store copy of the definitions will match those in the incoming file once the reconciliation process is complete.

Other changes:
- ensured all testdata inventory files have names in the definition which match their filenames and purpose
- broke out longer running inventory tests into a separate module to avoid issues with test passes under VsCode hitting a test timeout limit
- small number of changes in the tracing pattern in the store layer. If this proves successful, expect further changes along the same lines.
- fixed issue with reading specific testdata inventory yaml files in face of Viper tracking originally specified file paths and names by using a separate viper instance when reading inventory definition files.

FYI: I've recently figured out how to get the editor to trim trailing white space on a line, hence lot of trimmed lines in PR. Sorry.
