### PR TITLE
Add wall clock time to log output

### DIFF
--- a/pkg/protos/log/entry.proto
+++ b/pkg/protos/log/entry.proto
@@ -18,6 +18,8 @@ syntax = "proto3";
 
 package log;
 
+import "google/protobuf/timestamp.proto";
+
 option go_package = "github.com/Jim3Things/CloudChamber/simulation/pkg/protos/log";
 option csharp_namespace = "CloudChamber.Protos.Log";
 
@@ -114,6 +116,9 @@ message Event {
 
     // Outgoing link ID.  Ignored if the action is not AddLink.
     string link_id = 9;
+
+    // Real-world time when this event occurred.
+    google.protobuf.Timestamp at = 10;
 }
 
 // Describe a full correlated span, consisting of zero or more events.
@@ -150,4 +155,8 @@ message Entry {
     // where the request to start a new related span was made.
     string link_spanID = 11;
     string link_traceID = 12;
+
+    // Real-world time when this span started and ended.
+    google.protobuf.Timestamp started_at = 13;
+    google.protobuf.Timestamp ended_at = 14;
 }

--- a/simulation/internal/services/stepper/transcode.go
+++ b/simulation/internal/services/stepper/transcode.go
@@ -110,10 +110,7 @@ func convertToInternalPolicyRequest(
 	m *pb.PolicyRequest,
 	ch chan *sm.Response) (sm.Envelope, error) {
 
-	interval, err := ptypes.Duration(m.MeasuredDelay)
-	if err != nil {
-		return nil, err
-	}
+	interval := m.MeasuredDelay.AsDuration()
 
 	switch m.Policy {
 	case pb.StepperPolicy_NoWait:

--- a/simulation/internal/tracing/client/tracing.go
+++ b/simulation/internal/tracing/client/tracing.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/otel/api/kv"
 	"go.opentelemetry.io/otel/api/trace"
@@ -47,8 +48,9 @@ func Interceptor(
 
 	sev, resultMsg := decodeGrpcErr(err)
 
-	parent.AddEvent(
+	parent.AddEventWithTimestamp(
 		ctx,
+		time.Now(),
 		method,
 		kv.Int64(tracing.SeverityKey, int64(overrideSeverity(method, sev))),
 		kv.String(tracing.StackTraceKey, tracing.StackTrace()),

--- a/simulation/internal/tracing/events.go
+++ b/simulation/internal/tracing/events.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"time"
 
 	"go.opentelemetry.io/otel/api/kv"
 	"go.opentelemetry.io/otel/api/trace"
@@ -175,8 +176,9 @@ func Debug(ctx context.Context, a ...interface{}) {
 		kv.String(StackTraceKey, StackTrace()),
 		kv.String(MessageTextKey, cfg.filteredFormat(a[start:]...)))
 
-	trace.SpanFromContext(ctx).AddEvent(
+	trace.SpanFromContext(ctx).AddEventWithTimestamp(
 		ctx,
+		time.Now(),
 		MethodName(2),
 		res...)
 }
@@ -193,28 +195,10 @@ func Info(ctx context.Context, a ...interface{}) {
 		kv.String(StackTraceKey, StackTrace()),
 		kv.String(MessageTextKey, cfg.filteredFormat(a[start:]...)))
 
-	trace.SpanFromContext(ctx).AddEvent(
+	trace.SpanFromContext(ctx).AddEventWithTimestamp(
 		ctx,
+		time.Now(),
 		MethodName(2),
-		res...)
-}
-
-// OnEnter posts an informational trace event describing the entry into a
-// function
-func OnEnter(ctx context.Context, a ...interface{}) {
-	cfg := newTraceDetail()
-	start := addAnnotations(cfg, a)
-
-	res := append(
-		cfg.toKvPairs(),
-		kv.Int64(StepperTicksKey, common.TickFromContext(ctx)),
-		kv.Int64(SeverityKey, int64(pbl.Severity_Info)),
-		kv.String(StackTraceKey, StackTrace()),
-		kv.String(MessageTextKey, cfg.filteredFormat(a[start:]...)))
-
-	trace.SpanFromContext(ctx).AddEvent(
-		ctx,
-		fmt.Sprintf("On %q entry", MethodName(2)),
 		res...)
 }
 
@@ -230,8 +214,9 @@ func Warn(ctx context.Context, a ...interface{}) {
 		kv.String(StackTraceKey, StackTrace()),
 		kv.String(MessageTextKey, cfg.filteredFormat(a[start:]...)))
 
-	trace.SpanFromContext(ctx).AddEvent(
+	trace.SpanFromContext(ctx).AddEventWithTimestamp(
 		ctx,
+		time.Now(),
 		MethodName(2),
 		res...)
 }
@@ -275,8 +260,9 @@ func Error(ctx context.Context, a ...interface{}) error {
 
 	res = append(res, kv.String(MessageTextKey, err.Error()))
 
-	trace.SpanFromContext(ctx).AddEvent(
+	trace.SpanFromContext(ctx).AddEventWithTimestamp(
 		ctx,
+		time.Now(),
 		fmt.Sprintf("Error from %q", MethodName(3)),
 		res...)
 

--- a/simulation/internal/tracing/exporters/io_spans_test.go
+++ b/simulation/internal/tracing/exporters/io_spans_test.go
@@ -66,11 +66,11 @@ func (ts *ioSpanTestSuite) TestSingleRoot() {
 	s.add(entry, &io)
 
 	assert.Equal(
-		"\n[0102030405060708:0000000000000000] ok root ():\n"+
+		"\n1970-01-01T00:00:00Z:0s [0102030405060708:0000000000000000] ok root ():\n"+
 			"    stacks\n\n"+
-			"      @   0: [D] (test1) text1\n"+
+			"    1970-01-01T00:00:00Z  @   0: [D] (test1) text1\n"+
 			"        stack1\n"+
-			"      @   1: [D] (test2) text2\n"+
+			"    1970-01-01T00:00:00Z  @   1: [D] (test2) text2\n"+
 			"        stack2\n", io.String())
 
 	assert.Equal(0, len(s.known))
@@ -115,11 +115,11 @@ func (ts *ioSpanTestSuite) TestDoubleRoot() {
 	s.add(entry, &io)
 
 	assert.Equal(
-		"\n[0102030405060708:0000000000000000] ok root ():\n"+
+		"\n1970-01-01T00:00:00Z:0s [0102030405060708:0000000000000000] ok root ():\n"+
 			"    stacks\n\n"+
-			"      @   0: [D] (test1) text1\n"+
+			"    1970-01-01T00:00:00Z  @   0: [D] (test1) text1\n"+
 			"        stack1\n"+
-			"      @   1: [D] (test2) text2\n"+
+			"    1970-01-01T00:00:00Z  @   1: [D] (test2) text2\n"+
 			"        stack2\n", io.String())
 
 	assert.Equal(0, len(s.known))
@@ -129,11 +129,11 @@ func (ts *ioSpanTestSuite) TestDoubleRoot() {
 	s.add(entry2, &io)
 
 	assert.Equal(
-		"\n[1102030405060708:0000000000000000] ok root ():\n"+
+		"\n1970-01-01T00:00:00Z:0s [1102030405060708:0000000000000000] ok root ():\n"+
 			"    stacks\n\n"+
-			"      @   2: [D] (test3) text3\n"+
+			"    1970-01-01T00:00:00Z  @   2: [D] (test3) text3\n"+
 			"        stack3\n"+
-			"      @   3: [D] (test4) text4\n"+
+			"    1970-01-01T00:00:00Z  @   3: [D] (test4) text4\n"+
 			"        stack4\n",
 		io.String())
 
@@ -192,17 +192,17 @@ func (ts *ioSpanTestSuite) TestSimpleChildFirst() {
 	s.add(entry, &io)
 
 	assert.Equal(
-		"\n[0102030405060708:0000000000000000] ok root ():\n"+
+		"\n1970-01-01T00:00:00Z:0s [0102030405060708:0000000000000000] ok root ():\n"+
 			"    stacks\n\n"+
-			"      @   0: [D] (test1) text1\n"+
+			"    1970-01-01T00:00:00Z  @   0: [D] (test1) text1\n"+
 			"        stack1\n"+
-			"\n    [1102030405060708:0102030405060708] ok root ():\n"+
+			"\n    1970-01-01T00:00:00Z:0s [1102030405060708:0102030405060708] ok root ():\n"+
 			"        stacks\n\n"+
-			"          @   2: [D] (test3) text3\n"+
+			"        1970-01-01T00:00:00Z  @   2: [D] (test3) text3\n"+
 			"            stack3\n"+
-			"          @   3: [D] (test4) text4\n"+
+			"        1970-01-01T00:00:00Z  @   3: [D] (test4) text4\n"+
 			"            stack4\n"+
-			"      @   1: [D] (test2) text2\n"+
+			"    1970-01-01T00:00:00Z  @   1: [D] (test2) text2\n"+
 			"        stack2\n",
 		io.String())
 
@@ -262,17 +262,17 @@ func (ts *ioSpanTestSuite) TestSimpleChildLast() {
 	s.add(entry2, &io)
 
 	assert.Equal(
-		"\n[0102030405060708:0000000000000000] ok root ():\n"+
+		"\n1970-01-01T00:00:00Z:0s [0102030405060708:0000000000000000] ok root ():\n"+
 			"    stacks\n\n"+
-			"      @   0: [D] (test1) text1\n"+
+			"    1970-01-01T00:00:00Z  @   0: [D] (test1) text1\n"+
 			"        stack1\n"+
-			"\n    [1102030405060708:0102030405060708] ok root ():\n"+
+			"\n    1970-01-01T00:00:00Z:0s [1102030405060708:0102030405060708] ok root ():\n"+
 			"        stacks\n\n"+
-			"          @   2: [D] (test3) text3\n"+
+			"        1970-01-01T00:00:00Z  @   2: [D] (test3) text3\n"+
 			"            stack3\n"+
-			"          @   3: [D] (test4) text4\n"+
+			"        1970-01-01T00:00:00Z  @   3: [D] (test4) text4\n"+
 			"            stack4\n"+
-			"      @   1: [D] (test2) text2\n"+
+			"    1970-01-01T00:00:00Z  @   1: [D] (test2) text2\n"+
 			"        stack2\n",
 		io.String())
 


### PR DESCRIPTION
This adds the real world time to the log events and to the span start and end entries.

This is only formatted by the text formatters used for the log files and the unit test output.  Events are prefixed by the long date/time format.  Spans are prefixed by the start time in long date/time format and the duration.

This change closes #258 