### PR TITLE
Fix build break in request.tsx

### DIFF
--- a/pkg/protos/services/requests.tsx
+++ b/pkg/protos/services/requests.tsx
@@ -580,8 +580,8 @@ export const GetPolicyResponse = {
 export const WatchResponse = {
   fromJSON(object: any): WatchResponse {
     return {
-      expired: asBool(object.expired),
-      statusResponse: asItem<StatusResponse>(StatusResponse.fromJSON, object.statusResponse, undefined),0
+      expired: asItem<boolean | undefined>(Boolean, object.expired, undefined),
+      statusResponse: asItem<StatusResponse | undefined>(StatusResponse.fromJSON, object.statusResponse, undefined),
     }
   }
 }


### PR DESCRIPTION
The latent method in request.tsx causes a build break for the observer.  This change fixes that.