### PR TITLE
Add Impact statements to inventoryd operations

### DIFF
--- a/pkg/protos/log/entry.proto
+++ b/pkg/protos/log/entry.proto
@@ -47,7 +47,7 @@ enum Action {
     // relationships are strong - they can safely assume that both spans will
     // complete, they will execute in the same process, and that completion of the
     // overall trace ID is not complete until both are complete.
-    SpanStart = 3;
+    SpanStart = 1;
 
     // AddLink is used to place a the request point that may result in a linked
     // span.  It has an associated ID that is assigned by the active span at the
@@ -59,25 +59,22 @@ enum Action {
     // linked information as soft (optional) parent/child relationships.  If they
     // can put them into a logical execution tree, they do so.  If they cannot,
     // then they do not.
-    AddLink = 4;
+    AddLink = 2;
 
     // AddImpact is used to add an impact target to the span information.  The
     // impact value is a string stored in the text field, and is expected to
     // match the format used by the normal span KV structure (e.g. R:foo to 
     // indicate a read impact on component 'foo').
-    AddImpact = 5;
+    AddImpact = 3;
 }
 
 enum Severity {
     Debug = 0;
 
-    // This is the severity use to denote a purely explanatory entry
-    Reason = 1;
-
-    Info = 2;
-    Warning = 3;
-    Error = 4;
-    Fatal = 5;
+    Info = 1;
+    Warning = 2;
+    Error = 3;
+    Fatal = 4;
 }
 
 // Describe an impacted module

--- a/pkg/protos/log/entry.proto
+++ b/pkg/protos/log/entry.proto
@@ -40,14 +40,6 @@ enum Action {
     // child trace event.
     Trace = 0;
 
-    // UpdateSpanName and UpdateReason are directives to edit the containing span
-    // information.  The first replaces the span's name field, and the second
-    // replaces the span's reason text. This allows for better descriptions for a
-    // span once the details have been better understood - e.g. 'logging in a user'
-    // vs. 'logging in user "admin"'.
-    UpdateSpanName = 1;
-    UpdateReason = 2;
-
     // SpanStart is used to place the child span in the correct spot in the
     // sequence of events in the containing span.  It identifies the child span's
     // ID.  Structured formatters will expand the child span at this point in the
@@ -68,6 +60,12 @@ enum Action {
     // can put them into a logical execution tree, they do so.  If they cannot,
     // then they do not.
     AddLink = 4;
+
+    // AddImpact is used to add an impact target to the span information.  The
+    // impact value is a string stored in the text field, and is expected to
+    // match the format used by the normal span KV structure (e.g. R:foo to 
+    // indicate a read impact on component 'foo').
+    AddImpact = 5;
 }
 
 enum Severity {
@@ -105,20 +103,17 @@ message Event {
     // Formatted caller's stack trace
     string stack_trace = 5;
 
-    // The set of modules impacted, and the type of impact.
-    repeated Module impacted = 6;
-
     // Action to take when this trace is encountered.
-    Action event_action = 7;
+    Action event_action = 6;
 
     // Child's span ID.  Ignored if the action is not SpanStart.
-    string span_id = 8;
+    string span_id = 7;
 
     // Outgoing link ID.  Ignored if the action is not AddLink.
-    string link_id = 9;
+    string link_id = 8;
 
     // Real-world time when this event occurred.
-    google.protobuf.Timestamp at = 10;
+    google.protobuf.Timestamp at = 9;
 }
 
 // Describe a full correlated span, consisting of zero or more events.
@@ -159,4 +154,7 @@ message Entry {
     // Real-world time when this span started and ended.
     google.protobuf.Timestamp started_at = 13;
     google.protobuf.Timestamp ended_at = 14;
+
+    // The set of modules impacted, and the type of impact.
+    repeated Module impacted = 15;
 }

--- a/pkg/protos/log/entry.ts_ref
+++ b/pkg/protos/log/entry.ts_ref
@@ -1,4 +1,8 @@
 /* eslint-disable */
+import { util, configure } from "protobufjs/minimal";
+import * as Long from "long";
+import { Timestamp } from "../../../../../../google/protobuf/timestamp";
+
 export const protobufPackage = "log";
 
 /** Describe the type of impact that this event has on a module. */
@@ -67,15 +71,6 @@ export enum Action {
    */
   Trace = 0,
   /**
-   * UpdateSpanName - UpdateSpanName and UpdateReason are directives to edit the containing span
-   * information.  The first replaces the span's name field, and the second
-   * replaces the span's reason text. This allows for better descriptions for a
-   * span once the details have been better understood - e.g. 'logging in a user'
-   * vs. 'logging in user "admin"'.
-   */
-  UpdateSpanName = 1,
-  UpdateReason = 2,
-  /**
    * SpanStart - SpanStart is used to place the child span in the correct spot in the
    * sequence of events in the containing span.  It identifies the child span's
    * ID.  Structured formatters will expand the child span at this point in the
@@ -98,6 +93,13 @@ export enum Action {
    * then they do not.
    */
   AddLink = 4,
+  /**
+   * AddImpact - AddImpact is used to add an impact target to the span information.  The
+   * impact value is a string stored in the text field, and is expected to
+   * match the format used by the normal span KV structure (e.g. R:foo to
+   * indicate a read impact on component 'foo').
+   */
+  AddImpact = 5,
   UNRECOGNIZED = -1,
 }
 
@@ -106,18 +108,15 @@ export function actionFromJSON(object: any): Action {
     case 0:
     case "Trace":
       return Action.Trace;
-    case 1:
-    case "UpdateSpanName":
-      return Action.UpdateSpanName;
-    case 2:
-    case "UpdateReason":
-      return Action.UpdateReason;
     case 3:
     case "SpanStart":
       return Action.SpanStart;
     case 4:
     case "AddLink":
       return Action.AddLink;
+    case 5:
+    case "AddImpact":
+      return Action.AddImpact;
     case -1:
     case "UNRECOGNIZED":
     default:
@@ -129,14 +128,12 @@ export function actionToJSON(object: Action): string {
   switch (object) {
     case Action.Trace:
       return "Trace";
-    case Action.UpdateSpanName:
-      return "UpdateSpanName";
-    case Action.UpdateReason:
-      return "UpdateReason";
     case Action.SpanStart:
       return "SpanStart";
     case Action.AddLink:
       return "AddLink";
+    case Action.AddImpact:
+      return "AddImpact";
     default:
       return "UNKNOWN";
   }
@@ -217,14 +214,14 @@ export interface Event {
   text: string;
   /** Formatted caller's stack trace */
   stackTrace: string;
-  /** The set of modules impacted, and the type of impact. */
-  impacted: Module[];
   /** Action to take when this trace is encountered. */
   eventAction: Action;
   /** Child's span ID.  Ignored if the action is not SpanStart. */
   spanId: string;
   /** Outgoing link ID.  Ignored if the action is not AddLink. */
   linkId: string;
+  /** Real-world time when this event occurred. */
+  at: Date | undefined;
 }
 
 /** Describe a full correlated span, consisting of zero or more events. */
@@ -257,8 +254,13 @@ export interface Entry {
    * The link span ID and trace ID identify the active span at the point
    * where the request to start a new related span was made.
    */
-  linkSpanID: string;
-  linkTraceID: string;
+  linkSpanid: string;
+  linkTraceid: string;
+  /** Real-world time when this span started and ended. */
+  startedAt: Date | undefined;
+  endedAt: Date | undefined;
+  /** The set of modules impacted, and the type of impact. */
+  impacted: Module[];
 }
 
 const baseModule: object = { impact: 0, name: "" };
@@ -301,7 +303,6 @@ const baseEvent: object = {
 export const Event = {
   fromJSON(object: any): Event {
     const message = { ...baseEvent } as Event;
-    message.impacted = [];
     if (object.tick !== undefined && object.tick !== null) {
       message.tick = Number(object.tick);
     } else {
@@ -327,11 +328,6 @@ export const Event = {
     } else {
       message.stackTrace = "";
     }
-    if (object.impacted !== undefined && object.impacted !== null) {
-      for (const e of object.impacted) {
-        message.impacted.push(Module.fromJSON(e));
-      }
-    }
     if (object.eventAction !== undefined && object.eventAction !== null) {
       message.eventAction = actionFromJSON(object.eventAction);
     } else {
@@ -347,6 +343,11 @@ export const Event = {
     } else {
       message.linkId = "";
     }
+    if (object.at !== undefined && object.at !== null) {
+      message.at = fromJsonTimestamp(object.at);
+    } else {
+      message.at = undefined;
+    }
     return message;
   },
 
@@ -358,17 +359,11 @@ export const Event = {
     message.name !== undefined && (obj.name = message.name);
     message.text !== undefined && (obj.text = message.text);
     message.stackTrace !== undefined && (obj.stackTrace = message.stackTrace);
-    if (message.impacted) {
-      obj.impacted = message.impacted.map((e) =>
-        e ? Module.toJSON(e) : undefined
-      );
-    } else {
-      obj.impacted = [];
-    }
     message.eventAction !== undefined &&
       (obj.eventAction = actionToJSON(message.eventAction));
     message.spanId !== undefined && (obj.spanId = message.spanId);
     message.linkId !== undefined && (obj.linkId = message.linkId);
+    message.at !== undefined && (obj.at = message.at.toISOString());
     return obj;
   },
 };
@@ -383,14 +378,15 @@ const baseEntry: object = {
   infrastructure: false,
   reason: "",
   startingLink: "",
-  linkSpanID: "",
-  linkTraceID: "",
+  linkSpanid: "",
+  linkTraceid: "",
 };
 
 export const Entry = {
   fromJSON(object: any): Entry {
     const message = { ...baseEntry } as Entry;
     message.event = [];
+    message.impacted = [];
     if (object.name !== undefined && object.name !== null) {
       message.name = String(object.name);
     } else {
@@ -441,15 +437,30 @@ export const Entry = {
     } else {
       message.startingLink = "";
     }
-    if (object.linkSpanID !== undefined && object.linkSpanID !== null) {
-      message.linkSpanID = String(object.linkSpanID);
+    if (object.linkSpanid !== undefined && object.linkSpanid !== null) {
+      message.linkSpanid = String(object.linkSpanid);
     } else {
-      message.linkSpanID = "";
+      message.linkSpanid = "";
     }
-    if (object.linkTraceID !== undefined && object.linkTraceID !== null) {
-      message.linkTraceID = String(object.linkTraceID);
+    if (object.linkTraceid !== undefined && object.linkTraceid !== null) {
+      message.linkTraceid = String(object.linkTraceid);
     } else {
-      message.linkTraceID = "";
+      message.linkTraceid = "";
+    }
+    if (object.startedAt !== undefined && object.startedAt !== null) {
+      message.startedAt = fromJsonTimestamp(object.startedAt);
+    } else {
+      message.startedAt = undefined;
+    }
+    if (object.endedAt !== undefined && object.endedAt !== null) {
+      message.endedAt = fromJsonTimestamp(object.endedAt);
+    } else {
+      message.endedAt = undefined;
+    }
+    if (object.impacted !== undefined && object.impacted !== null) {
+      for (const e of object.impacted) {
+        message.impacted.push(Module.fromJSON(e));
+      }
     }
     return message;
   },
@@ -472,9 +483,43 @@ export const Entry = {
     message.reason !== undefined && (obj.reason = message.reason);
     message.startingLink !== undefined &&
       (obj.startingLink = message.startingLink);
-    message.linkSpanID !== undefined && (obj.linkSpanID = message.linkSpanID);
-    message.linkTraceID !== undefined &&
-      (obj.linkTraceID = message.linkTraceID);
+    message.linkSpanid !== undefined && (obj.linkSpanid = message.linkSpanid);
+    message.linkTraceid !== undefined &&
+      (obj.linkTraceid = message.linkTraceid);
+    message.startedAt !== undefined &&
+      (obj.startedAt = message.startedAt.toISOString());
+    message.endedAt !== undefined &&
+      (obj.endedAt = message.endedAt.toISOString());
+    if (message.impacted) {
+      obj.impacted = message.impacted.map((e) =>
+        e ? Module.toJSON(e) : undefined
+      );
+    } else {
+      obj.impacted = [];
+    }
     return obj;
   },
 };
+
+function fromTimestamp(t: Timestamp): Date {
+  let millis = t.seconds * 1_000;
+  millis += t.nanos / 1_000_000;
+  return new Date(millis);
+}
+
+function fromJsonTimestamp(o: any): Date {
+  if (o instanceof Date) {
+    return o;
+  } else if (typeof o === "string") {
+    return new Date(o);
+  } else {
+    return fromTimestamp(Timestamp.fromJSON(o));
+  }
+}
+
+// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
+// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
+if (util.Long !== Long) {
+  util.Long = Long as any;
+  configure();
+}

--- a/simulation/internal/clients/inventory/inventory.go
+++ b/simulation/internal/clients/inventory/inventory.go
@@ -54,7 +54,6 @@ package inventory
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/Jim3Things/CloudChamber/simulation/internal/clients/namespace"
@@ -81,22 +80,21 @@ const (
 	// Eventually these will dissapear as the front-end and higher layers learn
 	// abouts regions, zones, multiple pdus and tors.
 	//
-	DefaultZone   = "standard"
+	DefaultZone = "standard"
 
 	// DefaultPdu is used to provide a value for the non-existing pdu ID
 	// while the transition to the new inventory extended schemaa continues.
 	// Eventually these will dissapear as the front-end and higher layers learn
 	// abouts regions, zones, multiple pdus and tors.
 	//
-	DefaultPdu    = int64(0)
+	DefaultPdu = int64(0)
 
 	// DefaultTor is used to provide a value for the non-existing tor ID
 	// while the transition to the new inventory extended schemaa continues.
 	// Eventually these will dissapear as the front-end and higher layers learn
 	// abouts regions, zones, multiple pdus and tors.
 	//
-	DefaultTor    = int64(0)
-
+	DefaultTor = int64(0)
 )
 
 type inventoryRevision interface {
@@ -301,7 +299,6 @@ type inventoryBlade interface {
 
 	SetBootPowerOn(bootOnPowerOn bool)
 	GetBootOnPowerOn() bool
-
 }
 
 // Provide a set of definitions to cope with calls to a "null" object.
@@ -350,7 +347,7 @@ func (n *nullItem) NewPdu(name string) (*interface{}, error) {
 	return nil, errors.ErrNullItem
 }
 
-func (n *nullItem) NewTor( name string) (*interface{}, error) {
+func (n *nullItem) NewTor(name string) (*interface{}, error) {
 	return nil, errors.ErrNullItem
 }
 
@@ -407,7 +404,6 @@ func (n *nullItem) GetBootInfo() (bool, *interface{}) {
 	return false, nil
 }
 
-
 // ZoneSummary contains the summary data for a single zone. The contents
 // are either zero or are (re-)computed whenever the inventory definitions
 // are loaded from file. They are a cache of data in the store to avoid
@@ -463,12 +459,12 @@ type Inventory struct {
 //
 func NewInventory(cfg *config.GlobalConfig, store *store.Store) *Inventory {
 	return &Inventory{
-		mutex:              sync.RWMutex{},
-		cfg:                cfg,
-		Store:              store,
-		RootSummary:        &RootSummary{},
+		mutex:       sync.RWMutex{},
+		cfg:         cfg,
+		Store:       store,
+		RootSummary: &RootSummary{},
 		DefaultZoneSummary: &ZoneSummary{
-			MaxCapacity:   &pb.BladeCapacity{
+			MaxCapacity: &pb.BladeCapacity{
 				Accelerators: []*pb.Accelerator{},
 			},
 		},
@@ -558,9 +554,9 @@ func (m *Inventory) DeleteInventoryDefinition(ctx context.Context) error {
 }
 
 func (m *Inventory) reconcileNewInventoryRegion(
-	ctx         context.Context,
+	ctx context.Context,
 	regionStore *Region,
-	regionFile  *pb.Definition_Region,
+	regionFile *pb.Definition_Region,
 ) error {
 	_, err := regionStore.Read(ctx)
 
@@ -582,9 +578,9 @@ func (m *Inventory) reconcileNewInventoryRegion(
 }
 
 func (m *Inventory) reconcileNewInventoryZone(
-	ctx         context.Context,
-	zoneStore   *Zone,
-	zoneFile    *pb.Definition_Zone,
+	ctx context.Context,
+	zoneStore *Zone,
+	zoneFile *pb.Definition_Zone,
 ) error {
 	_, err := zoneStore.Read(ctx)
 
@@ -606,9 +602,9 @@ func (m *Inventory) reconcileNewInventoryZone(
 }
 
 func (m *Inventory) reconcileNewInventoryRack(
-	ctx         context.Context,
-	rackStore   *Rack,
-	rackFile    *pb.Definition_Rack,
+	ctx context.Context,
+	rackStore *Rack,
+	rackFile *pb.Definition_Rack,
 ) error {
 	_, err := rackStore.Read(ctx)
 
@@ -642,9 +638,9 @@ func (m *Inventory) reconcileNewInventoryRack(
 }
 
 func (m *Inventory) reconcileNewInventoryPdu(
-	ctx      context.Context,
+	ctx context.Context,
 	pduStore *Pdu,
-	pduFile  *pb.Definition_Pdu,
+	pduFile *pb.Definition_Pdu,
 ) error {
 	_, err := pduStore.Read(ctx)
 
@@ -670,9 +666,9 @@ func (m *Inventory) reconcileNewInventoryPdu(
 }
 
 func (m *Inventory) reconcileNewInventoryTor(
-	ctx      context.Context,
+	ctx context.Context,
 	torStore *Tor,
-	torFile  *pb.Definition_Tor,
+	torFile *pb.Definition_Tor,
 ) error {
 	_, err := torStore.Read(ctx)
 
@@ -698,9 +694,9 @@ func (m *Inventory) reconcileNewInventoryTor(
 }
 
 func (m *Inventory) reconcileNewInventoryBlade(
-	ctx      context.Context,
+	ctx context.Context,
 	bladeStore *Blade,
-	bladeFile  *pb.Definition_Blade,
+	bladeFile *pb.Definition_Blade,
 ) error {
 	_, err := bladeStore.Read(ctx)
 
@@ -728,9 +724,9 @@ func (m *Inventory) reconcileNewInventoryBlade(
 }
 
 func (m *Inventory) reconcileNewInventoryPdus(
-	ctx       context.Context,
+	ctx context.Context,
 	rackStore *Rack,
-	pdus      *map[int64]*pb.Definition_Pdu,
+	pdus *map[int64]*pb.Definition_Pdu,
 ) error {
 	for index, pduFile := range *pdus {
 		pduStore, err := rackStore.NewPdu(index)
@@ -747,9 +743,9 @@ func (m *Inventory) reconcileNewInventoryPdus(
 }
 
 func (m *Inventory) reconcileNewInventoryTors(
-	ctx       context.Context,
+	ctx context.Context,
 	rackStore *Rack,
-	tors      *map[int64]*pb.Definition_Tor,
+	tors *map[int64]*pb.Definition_Tor,
 ) error {
 	for index, torFile := range *tors {
 		torStore, err := rackStore.NewTor(index)
@@ -766,9 +762,9 @@ func (m *Inventory) reconcileNewInventoryTors(
 }
 
 func (m *Inventory) reconcileNewInventoryBlades(
-	ctx       context.Context,
+	ctx context.Context,
 	rackStore *Rack,
-	blades    *map[int64]*pb.Definition_Blade,
+	blades *map[int64]*pb.Definition_Blade,
 ) error {
 	for index, bladeFile := range *blades {
 		bladeStore, err := rackStore.NewBlade(index)
@@ -785,10 +781,10 @@ func (m *Inventory) reconcileNewInventoryBlades(
 }
 
 func (m *Inventory) reconcileOldInventoryRacks(
-	ctx       context.Context,
-	zone      *Zone,
+	ctx context.Context,
+	zone *Zone,
 	zoneStore *pb.Definition_Zone,
-	zoneFile  *pb.Definition_Zone,
+	zoneFile *pb.Definition_Zone,
 ) error {
 	for rackName, rackStore := range zoneStore.Racks {
 		rack, err := zone.NewChild(rackName)
@@ -821,10 +817,10 @@ func (m *Inventory) reconcileOldInventoryRacks(
 }
 
 func (m *Inventory) reconcileOldInventoryPdus(
-	ctx       context.Context,
-	rack      *Rack,
+	ctx context.Context,
+	rack *Rack,
 	pdusStore *map[int64]*pb.Definition_Pdu,
-	pdusFile  *map[int64]*pb.Definition_Pdu,
+	pdusFile *map[int64]*pb.Definition_Pdu,
 ) error {
 	for index := range *pdusStore {
 		pdu, err := rack.NewPdu(index)
@@ -843,10 +839,10 @@ func (m *Inventory) reconcileOldInventoryPdus(
 }
 
 func (m *Inventory) reconcileOldInventoryTors(
-	ctx       context.Context,
-	rack      *Rack,
+	ctx context.Context,
+	rack *Rack,
 	torsStore *map[int64]*pb.Definition_Tor,
-	torsFile  *map[int64]*pb.Definition_Tor,
+	torsFile *map[int64]*pb.Definition_Tor,
 ) error {
 	for index := range *torsStore {
 		tor, err := rack.NewTor(index)
@@ -865,10 +861,10 @@ func (m *Inventory) reconcileOldInventoryTors(
 }
 
 func (m *Inventory) reconcileOldInventoryBlades(
-	ctx         context.Context,
-	rack        *Rack,
+	ctx context.Context,
+	rack *Rack,
 	bladesStore *map[int64]*pb.Definition_Blade,
-	bladesFile  *map[int64]*pb.Definition_Blade,
+	bladesFile *map[int64]*pb.Definition_Blade,
 ) error {
 	for index := range *bladesStore {
 		blade, err := rack.NewBlade(index)
@@ -1029,7 +1025,6 @@ func (m *Inventory) buildSummaryInformation(ctx context.Context, root *pb.Defini
 		rootSummary.MaxBladeCount,
 		rootSummary.MaxCapacity)
 
-
 	zone, err := m.getDefaultZone(root)
 
 	if err != nil {
@@ -1162,124 +1157,225 @@ func (m *Inventory) writeInventoryDefinitionToStore(ctx context.Context, root *p
 	storeRoot.SetDetails(root.Details)
 
 	for regionName, region := range root.Regions {
-		ctx, span := tracing.StartSpan(ctx,
-			tracing.WithName(fmt.Sprintf("Write inventory definition for region %q", regionName)),
-			tracing.WithContextValue(timestamp.EnsureTickInContext),
-			tracing.AsInternal())
-		defer span.End()
-
-		storeRegion, err := storeRoot.NewChild(regionName)
-		if err != nil {
+		if err = m.writeOneRegion(ctx, regionName, storeRoot, region); err != nil {
 			return err
 		}
+	}
 
-		storeRegion.SetDetails(region.GetDetails())
+	return nil
+}
 
-		if _, err = storeRegion.Create(ctx); err != nil {
+// writeOneRegion writes the records associated with the supplied region to the
+// store.
+func (m *Inventory) writeOneRegion(
+	ctx context.Context,
+	regionName string,
+	storeRoot *Root,
+	region *pb.Definition_Region) error {
+	ctx, span := tracing.StartSpan(ctx,
+		tracing.WithName("Write inventory definition for region %q", regionName),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
+		tracing.AsInternal())
+	defer span.End()
+
+	storeRegion, err := storeRoot.NewChild(regionName)
+	if err != nil {
+		return err
+	}
+
+	storeRegion.SetDetails(region.GetDetails())
+
+	if _, err = storeRegion.Create(ctx); err != nil {
+		return err
+	}
+
+	for zoneName, zone := range region.Zones {
+		if err = m.writeOneZone(ctx, regionName, zoneName, storeRegion, zone); err != nil {
 			return err
 		}
+	}
 
-		for zoneName, zone := range region.Zones {
-			ctx, span := tracing.StartSpan(ctx,
-				tracing.WithName(fmt.Sprintf("Write inventory definition for region %q, zone %q", regionName, zoneName)),
-				tracing.WithContextValue(timestamp.EnsureTickInContext),
-				tracing.AsInternal())
-			defer span.End()
+	return nil
+}
 
-			storeZone, err := storeRegion.NewChild(zoneName)
-			if err != nil {
-				return err
-			}
+// writeOneZone writes the records associated with the supplied zone to the store.
+func (m *Inventory) writeOneZone(
+	ctx context.Context,
+	regionName string,
+	zoneName string,
+	storeRegion *Region,
+	zone *pb.Definition_Zone) error {
+	ctx, span := tracing.StartSpan(ctx,
+		tracing.WithName(
+			"Write inventory definition for region %q, zone %q",
+			regionName, zoneName),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
+		tracing.AsInternal())
+	defer span.End()
 
-			storeZone.SetDetails(zone.GetDetails())
+	storeZone, err := storeRegion.NewChild(zoneName)
+	if err != nil {
+		return err
+	}
 
-			if _, err = storeZone.Create(ctx); err != nil {
-				return err
-			}
+	storeZone.SetDetails(zone.GetDetails())
 
-			for rackName, rack := range zone.Racks {
-				ctx, span := tracing.StartSpan(ctx,
-					tracing.WithName(fmt.Sprintf("Write inventory definition for region %q, zone %q, rack %q", regionName, zoneName, rackName)),
-					tracing.WithContextValue(timestamp.EnsureTickInContext),
-					tracing.AsInternal())
-				defer span.End()
+	if _, err = storeZone.Create(ctx); err != nil {
+		return err
+	}
 
-				storeRack, err := storeZone.NewChild(rackName)
-				if err != nil {
-					return err
-				}
-
-				storeRack.SetDetails(rack.GetDetails())
-
-				if _, err = storeRack.Create(ctx); err != nil {
-					return err
-				}
-
-				for index, pdu := range rack.Pdus {
-					ctx, span := tracing.StartSpan(ctx,
-						tracing.WithName(fmt.Sprintf("Write inventory definition for region %q, zone %q, rack %q, pdu %d", regionName, zoneName, rackName, index)),
-						tracing.WithContextValue(timestamp.EnsureTickInContext),
-						tracing.AsInternal())
-					defer span.End()
-
-					storePdu, err := storeRack.NewPdu(index)
-					if err != nil {
-						return err
-					}
-					ports := pdu.GetPorts()
-
-					storePdu.SetDetails(pdu.GetDetails())
-					storePdu.SetPorts(&ports)
-
-					if _, err = storePdu.Create(ctx); err != nil {
-						return err
-					}
-				}
-
-				for index, tor := range rack.Tors {
-					ctx, span := tracing.StartSpan(ctx,
-						tracing.WithName(fmt.Sprintf("Write inventory definition for region %q, zone %q, rack %q, tor %d", regionName, zoneName, rackName, index)),
-						tracing.WithContextValue(timestamp.EnsureTickInContext),
-						tracing.AsInternal())
-					defer span.End()
-
-					storeTor, err := storeRack.NewTor(index)
-					if err != nil {
-						return err
-					}
-
-					ports := tor.GetPorts()
-					storeTor.SetDetails(tor.GetDetails())
-					storeTor.SetPorts(&ports)
-
-					if _, err = storeTor.Create(ctx); err != nil {
-						return err
-					}
-				}
-
-				for index, blade := range rack.Blades {
-					ctx, span := tracing.StartSpan(ctx,
-						tracing.WithName(fmt.Sprintf("Write inventory definition for region %q, zone %q, rack %q, blade %d", regionName, zoneName, rackName, index)),
-						tracing.WithContextValue(timestamp.EnsureTickInContext),
-						tracing.AsInternal())
-					defer span.End()
-
-					storeBlade, err := storeRack.NewBlade(index)
-					if err != nil {
-						return err
-					}
-
-					storeBlade.SetDetails(blade.GetDetails())
-					storeBlade.SetCapacity(blade.GetCapacity())
-					storeBlade.SetBootInfo(blade.GetBootInfo())
-					storeBlade.SetBootPowerOn(blade.GetBootOnPowerOn())
-
-					if _, err = storeBlade.Create(ctx); err != nil {
-						return err
-					}
-				}
-			}
+	for rackName, rack := range zone.Racks {
+		if err = m.writeOneRack(ctx, regionName, zoneName, rackName, storeZone, rack); err != nil {
+			return err
 		}
+	}
+
+	return nil
+}
+
+// writeOneRack writes the records associated with the supplied rack to the store.
+func (m *Inventory) writeOneRack(
+	ctx context.Context,
+	regionName string,
+	zoneName string,
+	rackName string,
+	storeZone *Zone,
+	rack *pb.Definition_Rack) error {
+	ctx, span := tracing.StartSpan(ctx,
+		tracing.WithName(
+			"Write inventory definition for region %q, zone %q, rack %q",
+			regionName, zoneName, rackName),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
+		tracing.AsInternal())
+	defer span.End()
+
+	storeRack, err := storeZone.NewChild(rackName)
+	if err != nil {
+		return err
+	}
+
+	storeRack.SetDetails(rack.GetDetails())
+
+	if _, err = storeRack.Create(ctx); err != nil {
+		return err
+	}
+
+	for index, pdu := range rack.Pdus {
+		if err = m.writeOnePdu(ctx, regionName, zoneName, rackName, index, storeRack, pdu); err != nil {
+			return err
+		}
+	}
+
+	for index, tor := range rack.Tors {
+		if err = m.writeOneTor(ctx, regionName, zoneName, rackName, index, storeRack, tor); err != nil {
+			return err
+		}
+	}
+
+	for index, blade := range rack.Blades {
+		if err = m.writeOneBlade(ctx, regionName, zoneName, rackName, index, storeRack, blade); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeOnePdu writes the record associated with the supplied PDU.
+func (m *Inventory) writeOnePdu(
+	ctx context.Context,
+	regionName string,
+	zoneName string,
+	rackName string,
+	index int64,
+	storeRack *Rack,
+	pdu *pb.Definition_Pdu) error {
+	ctx, span := tracing.StartSpan(ctx,
+		tracing.WithName(
+			"Write inventory definition for region %q, zone %q, rack %q, pdu %d",
+			regionName, zoneName, rackName, index),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
+		tracing.AsInternal())
+	defer span.End()
+
+	storePdu, err := storeRack.NewPdu(index)
+	if err != nil {
+		return err
+	}
+	ports := pdu.GetPorts()
+
+	storePdu.SetDetails(pdu.GetDetails())
+	storePdu.SetPorts(&ports)
+
+	if _, err = storePdu.Create(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// writeOneTor writes the record associated with the supplied TOR.
+func (m *Inventory) writeOneTor(
+	ctx context.Context,
+	regionName string,
+	zoneName string,
+	rackName string,
+	index int64,
+	storeRack *Rack,
+	tor *pb.Definition_Tor) error {
+	ctx, span := tracing.StartSpan(ctx,
+		tracing.WithName(
+			"Write inventory definition for region %q, zone %q, rack %q, tor %d",
+			regionName, zoneName, rackName, index),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
+		tracing.AsInternal())
+	defer span.End()
+
+	storeTor, err := storeRack.NewTor(index)
+	if err != nil {
+		return err
+	}
+
+	ports := tor.GetPorts()
+	storeTor.SetDetails(tor.GetDetails())
+	storeTor.SetPorts(&ports)
+
+	if _, err = storeTor.Create(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// writeOneBlade writes the record associated with the supplied blade.
+func (m *Inventory) writeOneBlade(
+	ctx context.Context,
+	regionName string,
+	zoneName string,
+	rackName string,
+	index int64,
+	storeRack *Rack,
+	blade *pb.Definition_Blade) error {
+	ctx, span := tracing.StartSpan(ctx,
+		tracing.WithName(
+			"Write inventory definition for region %q, zone %q, rack %q, blade %d",
+			regionName, zoneName, rackName, index),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
+		tracing.AsInternal())
+	defer span.End()
+
+	storeBlade, err := storeRack.NewBlade(index)
+	if err != nil {
+		return err
+	}
+
+	storeBlade.SetDetails(blade.GetDetails())
+	storeBlade.SetCapacity(blade.GetCapacity())
+	storeBlade.SetBootInfo(blade.GetBootInfo())
+	storeBlade.SetBootPowerOn(blade.GetBootOnPowerOn())
+
+	if _, err = storeBlade.Create(ctx); err != nil {
+		return err
 	}
 
 	return nil
@@ -1347,13 +1443,13 @@ func (m *Inventory) deleteInventoryDefinitionFromStore(ctx context.Context, stor
 					blade.Delete(ctx, true)
 				}
 
-			rack.Delete(ctx, true)
+				rack.Delete(ctx, true)
 			}
 
-		zone.Delete(ctx, true)
+			zone.Delete(ctx, true)
 		}
 
-	region.Delete(ctx, true)
+		region.Delete(ctx, true)
 	}
 
 	return nil
@@ -1386,8 +1482,8 @@ func (m *Inventory) buildSummaryForRoot(
 		maxCapacity.MemoryInMb = common.MaxInt64(maxCapacity.MemoryInMb, regionSummary.MaxCapacity.MemoryInMb)
 
 		maxCapacity.NetworkBandwidthInMbps = common.MaxInt64(
-				maxCapacity.NetworkBandwidthInMbps,
-				regionSummary.MaxCapacity.NetworkBandwidthInMbps)
+			maxCapacity.NetworkBandwidthInMbps,
+			regionSummary.MaxCapacity.NetworkBandwidthInMbps)
 	}
 
 	return &RootSummary{
@@ -1424,8 +1520,8 @@ func (m *Inventory) buildSummaryForRegion(
 		maxCapacity.MemoryInMb = common.MaxInt64(maxCapacity.MemoryInMb, zoneSummary.MaxCapacity.MemoryInMb)
 
 		maxCapacity.NetworkBandwidthInMbps = common.MaxInt64(
-				maxCapacity.NetworkBandwidthInMbps,
-				zoneSummary.MaxCapacity.NetworkBandwidthInMbps)
+			maxCapacity.NetworkBandwidthInMbps,
+			zoneSummary.MaxCapacity.NetworkBandwidthInMbps)
 
 		maxBladeCount = common.MaxInt(maxBladeCount, zoneSummary.MaxBladeCount)
 	}

--- a/simulation/internal/clients/store/storeapi.go
+++ b/simulation/internal/clients/store/storeapi.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -386,7 +385,7 @@ func (store *Store) Read(ctx context.Context, kr namespace.KeyRoot, n string) (v
 	k := namespace.GetKeyFromKeyRootAndName(kr, n)
 
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithName(fmt.Sprintf("Read value from namespace %s with prefix %s for key %s", n, prefix, k)),
+		tracing.WithName("Read value from namespace %s with prefix %s for key %s", n, prefix, k),
 		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
@@ -431,7 +430,7 @@ func (store *Store) Read(ctx context.Context, kr namespace.KeyRoot, n string) (v
 			tracing.WithReplacement(
 				regexp.MustCompile(
 					`passwordHash\\\"\:(.*?),\\\"`),
-					`passwordHash\":\"...REDACTED...\",\"`),
+				`passwordHash\":\"...REDACTED...\",\"`),
 			"found record with revision %v and value %q",
 			rev,
 			val)
@@ -450,7 +449,7 @@ func (store *Store) Update(ctx context.Context, r namespace.KeyRoot, n string, r
 	k := namespace.GetKeyFromKeyRootAndName(r, n)
 
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithName(fmt.Sprintf("Request to update value in namespace %s with prefix %s for key %s", n, prefix, k)),
+		tracing.WithName("Request to update value in namespace %s with prefix %s for key %s", n, prefix, k),
 		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
@@ -672,7 +671,7 @@ func (store *Store) List(ctx context.Context, r namespace.KeyRoot, n string) (re
 	k := namespace.GetKeyFromKeyRootAndName(r, n)
 
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithName(fmt.Sprintf("Request to list entries from namespace %s with prefix %s under key %s", n, prefix, k)),
+		tracing.WithName("Request to list entries from namespace %s with prefix %s under key %s", n, prefix, k),
 		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
@@ -720,7 +719,6 @@ func (store *Store) Watch(ctx context.Context, r namespace.KeyRoot, n string) (*
 		tracing.WithContextValue(timestamp.EnsureTickInContext))
 	defer span.End()
 
-
 	prefix := namespace.GetNamespacePrefixFromKeyRoot(r)
 
 	tracing.UpdateSpanName(ctx, "Request to list keys under prefix %q", prefix)
@@ -736,7 +734,7 @@ func (store *Store) Watch(ctx context.Context, r namespace.KeyRoot, n string) (*
 
 	notifications := make(chan WatchEvent)
 
-	go func ()  {
+	go func() {
 		for ev := range resp.Events {
 			notifications <- WatchEvent{
 				Type:     ev.Type,
@@ -766,7 +764,7 @@ func (store *Store) Watch(ctx context.Context, r namespace.KeyRoot, n string) (*
 func (w *Watch) Close(ctx context.Context) error {
 	ctx, span := tracing.StartSpan(ctx,
 		tracing.WithContextValue(timestamp.EnsureTickInContext))
-		tracing.WithName("Attempting to close event channel")
+	tracing.WithName("Attempting to close event channel")
 	defer span.End()
 
 	cancel := w.cancel

--- a/simulation/internal/clients/store/storeapi.go
+++ b/simulation/internal/clients/store/storeapi.go
@@ -763,8 +763,8 @@ func (store *Store) Watch(ctx context.Context, r namespace.KeyRoot, n string) (*
 //
 func (w *Watch) Close(ctx context.Context) error {
 	ctx, span := tracing.StartSpan(ctx,
-		tracing.WithContextValue(timestamp.EnsureTickInContext))
-	tracing.WithName("Attempting to close event channel")
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
+		tracing.WithName("Attempting to close event channel"))
 	defer span.End()
 
 	cancel := w.cancel

--- a/simulation/internal/clients/timestamp/listener.go
+++ b/simulation/internal/clients/timestamp/listener.go
@@ -397,7 +397,7 @@ func (l *Listener) send(notify chan Completion, err error) {
 func (l *Listener) log(f string, args ...interface{}) {
 	_, span := tracing.StartSpan(
 		context.Background(),
-		tracing.WithName(fmt.Sprintf(f, args...)),
+		tracing.WithName(f, args...),
 		tracing.AsInternal(),
 		tracing.WithContextValue(OutsideTime))
 	span.End()

--- a/simulation/internal/services/frontend/frontend.go
+++ b/simulation/internal/services/frontend/frontend.go
@@ -109,7 +109,7 @@ func normalizeURL(next http.Handler) http.Handler {
 func traceRequest(spanName string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, span := tracing.StartSpan(context.Background(),
-			tracing.WithName(fmt.Sprintf("%s: %s %q", spanName, r.Method, r.URL.String())),
+			tracing.WithName("%s: %s %q", spanName, r.Method, r.URL.String()),
 			tracing.AsInternal(),
 			tracing.WithContextValue(ts.OutsideTime))
 		defer span.End()

--- a/simulation/internal/services/frontend/logs_test.go
+++ b/simulation/internal/services/frontend/logs_test.go
@@ -142,7 +142,6 @@ func (ts *LogTestSuite) TestGetAfter() {
 				Name:       "testEvent",
 				Text:       "xyzzy",
 				StackTrace: "zzzz",
-				Impacted:   nil,
 			},
 		},
 		Infrastructure: false,
@@ -173,6 +172,7 @@ func (ts *LogTestSuite) TestGetAfter() {
 		require.Equal(entry.Status, resEntry.Status)
 		require.Equal(entry.StackTrace, resEntry.StackTrace)
 		require.Equal(entry.Reason, resEntry.Reason)
+		require.Equal(entry.Impacted, resEntry.Impacted)
 
 		require.Equal(len(entry.Event), len(resEntry.Event))
 
@@ -181,7 +181,6 @@ func (ts *LogTestSuite) TestGetAfter() {
 
 		require.Equal(event.Name, resEvent.Name)
 		require.Equal(event.StackTrace, resEvent.StackTrace)
-		require.Equal(event.Impacted, resEvent.Impacted)
 		require.Equal(event.Text, resEvent.Text)
 		require.Equal(event.Tick, resEvent.Tick)
 		require.Equal(event.Severity, resEvent.Severity)

--- a/simulation/internal/services/frontend/users.go
+++ b/simulation/internal/services/frontend/users.go
@@ -74,6 +74,7 @@ func handlerUsersList(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracing.StartSpan(context.Background(),
 		tracing.WithName("Get User List"),
 		tracing.WithContextValue(timestamp.EnsureTickInContext),
+		tracing.WithImpact(tracing.ImpactRead, "/users"),
 		tracing.AsInternal())
 	defer span.End()
 
@@ -103,7 +104,6 @@ func handlerUsersList(w http.ResponseWriter, r *http.Request) {
 		}
 
 		tracing.Info(ctx,
-			tracing.WithImpactRead("/users"),
 			"   Listing user %q: %q%s", entry.Name, target, protected)
 
 		users.Users = append(users.Users, &pb.UserList_Entry{
@@ -127,14 +127,15 @@ func handlerUsersList(w http.ResponseWriter, r *http.Request) {
 }
 
 func handlerUserCreate(w http.ResponseWriter, r *http.Request) {
-	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithName("Create New User"),
-		tracing.WithContextValue(timestamp.EnsureTickInContext),
-		tracing.AsInternal())
-	defer span.End()
-
 	vars := mux.Vars(r)
 	username := vars["username"]
+
+	ctx, span := tracing.StartSpan(context.Background(),
+		tracing.WithName(fmt.Sprintf("Creating user %q", username)),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
+		tracing.WithImpact(tracing.ImpactCreate, "/users/"+username),
+		tracing.AsInternal())
+	defer span.End()
 
 	err := doSessionHeader(
 		ctx, w, r,
@@ -146,8 +147,6 @@ func handlerUserCreate(w http.ResponseWriter, r *http.Request) {
 		postHTTPError(ctx, w, err)
 		return
 	}
-
-	tracing.UpdateSpanName(ctx, "Creating user %q", username)
 
 	u := &pb.UserDefinition{}
 	if err = jsonpb.Unmarshal(r.Body, u); err != nil {
@@ -174,7 +173,6 @@ func handlerUserCreate(w http.ResponseWriter, r *http.Request) {
 
 	tracing.Info(
 		ctx,
-		tracing.WithImpactCreate("/users/"+username),
 		"Created user %q, pwd: <redacted>, enabled: %v, rights: %s",
 		username,
 		u.Enabled,
@@ -189,14 +187,15 @@ func handlerUserCreate(w http.ResponseWriter, r *http.Request) {
 }
 
 func handlerUserRead(w http.ResponseWriter, r *http.Request) {
-	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithName("Get User Details"),
-		tracing.WithContextValue(timestamp.EnsureTickInContext),
-		tracing.AsInternal())
-	defer span.End()
-
 	vars := mux.Vars(r)
 	username := vars["username"]
+
+	ctx, span := tracing.StartSpan(context.Background(),
+		tracing.WithName(fmt.Sprintf("Getting details for user %q", username)),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
+		tracing.WithImpact(tracing.ImpactRead, "/users/"+username),
+		tracing.AsInternal())
+	defer span.End()
 
 	err := doSessionHeader(
 		ctx, w, r,
@@ -208,8 +207,6 @@ func handlerUserRead(w http.ResponseWriter, r *http.Request) {
 		postHTTPError(ctx, w, err)
 		return
 	}
-
-	tracing.UpdateSpanName(ctx, "Getting details for user %q", username)
 
 	u, rev, err := userRead(ctx, username)
 
@@ -229,7 +226,6 @@ func handlerUserRead(w http.ResponseWriter, r *http.Request) {
 
 	tracing.Info(
 		ctx,
-		tracing.WithImpactRead("/users/"+username),
 		"Returning details for user %s", formatUser(username, ext))
 
 	// Get the user entry, and serialize it to json
@@ -242,14 +238,15 @@ func handlerUserRead(w http.ResponseWriter, r *http.Request) {
 
 // Update the user entry
 func handlerUserUpdate(w http.ResponseWriter, r *http.Request) {
-	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithName("Update User Details"),
-		tracing.WithContextValue(timestamp.EnsureTickInContext),
-		tracing.AsInternal())
-	defer span.End()
-
 	vars := mux.Vars(r)
 	username := vars["username"]
+
+	ctx, span := tracing.StartSpan(context.Background(),
+		tracing.WithName(fmt.Sprintf("Updating details on user %q", username)),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
+		tracing.WithImpact(tracing.ImpactModify, "/users/"+username),
+		tracing.AsInternal())
+	defer span.End()
 
 	var caller *pb.User
 
@@ -268,8 +265,6 @@ func handlerUserUpdate(w http.ResponseWriter, r *http.Request) {
 		postHTTPError(ctx, w, err)
 		return
 	}
-
-	tracing.UpdateSpanName(ctx, "Updating details on user %q", username)
 
 	// All updates are qualified by an ETag match.  The ETag comes from the database
 	// revision number.  So, first we get the 'if-match' tag to determine the revision
@@ -323,7 +318,6 @@ func handlerUserUpdate(w http.ResponseWriter, r *http.Request) {
 
 	tracing.Info(
 		ctx,
-		tracing.WithImpactModify("/users/"+username),
 		"Returning details for user %s", formatUser(username, ext))
 
 	p := jsonpb.Marshaler{}
@@ -334,14 +328,15 @@ func handlerUserUpdate(w http.ResponseWriter, r *http.Request) {
 
 // Delete the user entry
 func handlerUserDelete(w http.ResponseWriter, r *http.Request) {
-	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithName("Delete User"),
-		tracing.WithContextValue(timestamp.EnsureTickInContext),
-		tracing.AsInternal())
-	defer span.End()
-
 	vars := mux.Vars(r)
 	username := vars["username"]
+
+	ctx, span := tracing.StartSpan(context.Background(),
+		tracing.WithName(fmt.Sprintf("Deleting user %q", username)),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
+		tracing.WithImpact(tracing.ImpactDelete, "/users/"+username),
+		tracing.AsInternal())
+	defer span.End()
 
 	err := doSessionHeader(
 		ctx, w, r,
@@ -353,8 +348,6 @@ func handlerUserDelete(w http.ResponseWriter, r *http.Request) {
 		postHTTPError(ctx, w, err)
 		return
 	}
-
-	tracing.UpdateSpanName(ctx, "Deleting user %q", username)
 
 	if err = userRemove(ctx, username); err != nil {
 		postHTTPError(ctx, w, err)
@@ -383,10 +376,12 @@ func handlerUserOperation(w http.ResponseWriter, r *http.Request) {
 
 		switch op {
 		case Login:
+			tracing.AddImpact(ctx, tracing.ImpactUse, "/users/"+username)
 			tracing.UpdateSpanName(ctx, "Logging in user %q", username)
 			s, err = login(ctx, session, r)
 
 		case Logout:
+			tracing.AddImpact(ctx, tracing.ImpactUse, "/users/"+username)
 			tracing.UpdateSpanName(ctx, "Logging out user %q", username)
 			s, err = logout(ctx, session, r)
 
@@ -412,14 +407,15 @@ func handlerUserOperation(w http.ResponseWriter, r *http.Request) {
 
 // Set a new password on the specified account
 func handlerUserSetPassword(w http.ResponseWriter, r *http.Request) {
-	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithName("Perform User Operation"),
-		tracing.WithContextValue(timestamp.EnsureTickInContext),
-		tracing.AsInternal())
-	defer span.End()
-
 	vars := mux.Vars(r)
 	username := vars["username"]
+
+	ctx, span := tracing.StartSpan(context.Background(),
+		tracing.WithName(fmt.Sprintf("Updating the password for user %q", username)),
+		tracing.WithContextValue(timestamp.EnsureTickInContext),
+		tracing.WithImpact(tracing.ImpactModify, "/users/"+username),
+		tracing.AsInternal())
+	defer span.End()
 
 	err := doSessionHeader(
 		ctx, w, r,
@@ -431,8 +427,6 @@ func handlerUserSetPassword(w http.ResponseWriter, r *http.Request) {
 		postHTTPError(ctx, w, err)
 		return
 	}
-
-	tracing.UpdateSpanName(ctx, "Updating the password for user %q", username)
 
 	// All updates are qualified by an ETag match.  The ETag comes from the database
 	// revision number.  So, first we get the 'if-match' tag to determine the revision
@@ -468,7 +462,6 @@ func handlerUserSetPassword(w http.ResponseWriter, r *http.Request) {
 
 	tracing.Info(
 		ctx,
-		tracing.WithImpactModify("/users/"+username),
 		"Password changed for user %q", username)
 	_, err = fmt.Fprintf(w, "Password changed for user %q", username)
 

--- a/simulation/internal/services/frontend/users.go
+++ b/simulation/internal/services/frontend/users.go
@@ -131,7 +131,7 @@ func handlerUserCreate(w http.ResponseWriter, r *http.Request) {
 	username := vars["username"]
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithName(fmt.Sprintf("Creating user %q", username)),
+		tracing.WithName("Creating user %q", username),
 		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.WithImpact(tracing.ImpactCreate, "/users/"+username),
 		tracing.AsInternal())
@@ -191,7 +191,7 @@ func handlerUserRead(w http.ResponseWriter, r *http.Request) {
 	username := vars["username"]
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithName(fmt.Sprintf("Getting details for user %q", username)),
+		tracing.WithName("Getting details for user %q", username),
 		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.WithImpact(tracing.ImpactRead, "/users/"+username),
 		tracing.AsInternal())
@@ -242,7 +242,7 @@ func handlerUserUpdate(w http.ResponseWriter, r *http.Request) {
 	username := vars["username"]
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithName(fmt.Sprintf("Updating details on user %q", username)),
+		tracing.WithName("Updating details on user %q", username),
 		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.WithImpact(tracing.ImpactModify, "/users/"+username),
 		tracing.AsInternal())
@@ -332,7 +332,7 @@ func handlerUserDelete(w http.ResponseWriter, r *http.Request) {
 	username := vars["username"]
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithName(fmt.Sprintf("Deleting user %q", username)),
+		tracing.WithName("Deleting user %q", username),
 		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.WithImpact(tracing.ImpactDelete, "/users/"+username),
 		tracing.AsInternal())
@@ -411,7 +411,7 @@ func handlerUserSetPassword(w http.ResponseWriter, r *http.Request) {
 	username := vars["username"]
 
 	ctx, span := tracing.StartSpan(context.Background(),
-		tracing.WithName(fmt.Sprintf("Updating the password for user %q", username)),
+		tracing.WithName("Updating the password for user %q", username),
 		tracing.WithContextValue(timestamp.EnsureTickInContext),
 		tracing.WithImpact(tracing.ImpactModify, "/users/"+username),
 		tracing.AsInternal())

--- a/simulation/internal/services/inventory/blade.go
+++ b/simulation/internal/services/inventory/blade.go
@@ -69,21 +69,21 @@ func newBlade(ctx context.Context, def *pb.Definition_Blade, name string, r *Rac
 		id:               id,
 		sm:               nil,
 		capacity:         messages.NewCapacity(),
-		architecture:     capacity.Arch,
+		architecture:     capacity.GetArch(),
 		used:             messages.NewCapacity(),
 		workloads:        make(map[string]*workload),
-		bootOnPower:      def.BootOnPowerOn,
+		bootOnPower:      def.GetBootOnPowerOn(),
 		hasActiveTimer:   false,
 		activeTimerID:    0,
 		matchTimerExpiry: 0,
 	}
 
-	b.capacity.Consumables[messages.CapacityCores] = float64(capacity.Cores)
-	b.capacity.Consumables[messages.CapacityMemory] = float64(capacity.MemoryInMb)
-	b.capacity.Consumables[messages.CapacityDisk] = float64(capacity.DiskInGb)
-	b.capacity.Consumables[messages.CapacityNetwork] = float64(capacity.NetworkBandwidthInMbps)
+	b.capacity.Consumables[messages.CapacityCores] = float64(capacity.GetCores())
+	b.capacity.Consumables[messages.CapacityMemory] = float64(capacity.GetMemoryInMb())
+	b.capacity.Consumables[messages.CapacityDisk] = float64(capacity.GetDiskInGb())
+	b.capacity.Consumables[messages.CapacityNetwork] = float64(capacity.GetNetworkBandwidthInMbps())
 
-	for _, a := range capacity.Accelerators {
+	for _, a := range capacity.GetAccelerators() {
 		b.capacity.Consumables[messages.AcceleratorPrefix+a.String()] = float64(1)
 	}
 

--- a/simulation/internal/services/inventory/blade_test.go
+++ b/simulation/internal/services/inventory/blade_test.go
@@ -2,6 +2,7 @@ package inventory
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -84,7 +85,14 @@ func (ts *BladeTestSuite) TestGetStatus() {
 
 	rackDef := ts.createDummyRack(2)
 
-	r := newRack(context.Background(), ts.rackName(), rackDef, ts.timers)
+	r := newRack(
+		context.Background(),
+		ts.rackName(),
+		rackDef,
+		fmt.Sprintf("racks/%s/pdus/",ts.rackName()),
+		fmt.Sprintf("racks/%s/tors/",ts.rackName()),
+		fmt.Sprintf("racks/%s/blades/",ts.rackName()),
+		ts.timers)
 	require.NotNil(r)
 	ctx := ts.advance(context.Background())
 
@@ -141,7 +149,14 @@ func (ts *BladeTestSuite) TestPowerOn() {
 
 	rackDef := ts.createDummyRack(2)
 
-	r := newRack(context.Background(), ts.rackName(), rackDef, ts.timers)
+	r := newRack(
+		context.Background(),
+		ts.rackName(),
+		rackDef,
+		fmt.Sprintf("racks/%s/pdus/",ts.rackName()),
+		fmt.Sprintf("racks/%s/tors/",ts.rackName()),
+		fmt.Sprintf("racks/%s/blades/",ts.rackName()),
+		ts.timers)
 	require.NotNil(r)
 	ctx := ts.advance(context.Background())
 
@@ -174,7 +189,14 @@ func (ts *BladeTestSuite) TestPowerOnPersistence() {
 
 	rackDef := ts.createDummyRack(2)
 
-	r := newRack(context.Background(), ts.rackName(), rackDef, ts.timers)
+	r := newRack(
+		context.Background(),
+		ts.rackName(),
+		rackDef,
+		fmt.Sprintf("racks/%s/pdus/", ts.rackName()),
+		fmt.Sprintf("racks/%s/tors/", ts.rackName()),
+		fmt.Sprintf("racks/%s/blades/", ts.rackName()),
+		ts.timers)
 	require.NotNil(r)
 	ctx := ts.advance(context.Background())
 

--- a/simulation/internal/services/inventory/inventory.go
+++ b/simulation/internal/services/inventory/inventory.go
@@ -27,7 +27,7 @@ type server struct {
 
 	timers *ts.Timers
 
-	store *st.Store
+	store     *st.Store
 	inventory *ic.Inventory
 }
 
@@ -155,9 +155,9 @@ func (s *server) initializeRacks() error {
 		return err
 	}
 
-	for name, rack := range *racks {
+	for _, rack := range *racks {
 		// For each rack, create a rack item, supplying the tor, pdu, and blade
-		tracing.Info(ctx, "Adding rack %q", name)
+		tracing.Info(ctx, "Adding rack %s", rack.Key)
 
 		r, err := rack.GetDefinitionRackWithChildren(ctx)
 
@@ -165,10 +165,17 @@ func (s *server) initializeRacks() error {
 			return err
 		}
 
-		s.racks[name] = newRack(ctx, name, r, s.timers)
+		s.racks[rack.Key] = newRack(
+			ctx,
+			rack.Key,
+			r,
+			rack.KeyIndexPdu,
+			rack.KeyIndexTor,
+			rack.KeyIndexBlade,
+			s.timers)
 
 		// Start each rack (this gives us a channel and a goroutine)
-		if err = s.racks[name].start(ctx); err != nil {
+		if err = s.racks[rack.Key].start(ctx); err != nil {
 			return err
 		}
 	}

--- a/simulation/internal/services/inventory/messages/messageTarget.go
+++ b/simulation/internal/services/inventory/messages/messageTarget.go
@@ -77,3 +77,25 @@ func (m *MessageTarget) Describe() string {
 
 	return fmt.Sprintf("%s in rack %q", preamble, m.rackName())
 }
+
+func (m *MessageTarget) String() string {
+	component := "unknown"
+	switch m.element {
+	case targetBlade:
+		component = "blade"
+		break
+
+	case targetTor:
+		component = "tor"
+		break
+
+	case targetPdu:
+		component = "pdu"
+		break
+
+	default:
+		break
+	}
+
+	return fmt.Sprintf("racks/%s/%s/%d", m.Rack, component, m.blade)
+}

--- a/simulation/internal/services/inventory/pdu_test.go
+++ b/simulation/internal/services/inventory/pdu_test.go
@@ -2,6 +2,7 @@ package inventory
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -25,7 +26,14 @@ func (ts *PduTestSuite) TestCreatePdu() {
 
 	rackDef := ts.createDummyRack(2)
 
-	r := newRack(context.Background(), ts.rackName(), rackDef, ts.timers)
+	r := newRack(
+		context.Background(),
+		ts.rackName(),
+		rackDef,
+		fmt.Sprintf("racks/%s/pdus/", ts.rackName()),
+		fmt.Sprintf("racks/%s/tors/", ts.rackName()),
+		fmt.Sprintf("racks/%s/blades/", ts.rackName()),
+		ts.timers)
 	require.NotNil(r)
 	assert.Equal(pb.Actual_Rack_awaiting_start, r.sm.CurrentIndex)
 

--- a/simulation/internal/services/inventory/rack.go
+++ b/simulation/internal/services/inventory/rack.go
@@ -112,10 +112,10 @@ func newRackInternal(
 
 	tracing.AddImpact(ctx, tracing.ImpactCreate, name)
 
-	r.pdu = pduFunc(ctx, def.Pdus[0], fmt.Sprintf("%s%d", pduKey, 0), r)
-	r.tor = torFunc(ctx, def.Tors[0], fmt.Sprintf("%s%d", torKey, 0), r)
+	r.pdu = pduFunc(ctx, def.GetPdus()[0], fmt.Sprintf("%s%d", pduKey, 0), r)
+	r.tor = torFunc(ctx, def.GetTors()[0], fmt.Sprintf("%s%d", torKey, 0), r)
 
-	for i, item := range def.Blades {
+	for i, item := range def.GetBlades() {
 		r.blades[i] = newBlade(ctx, item, fmt.Sprintf("%s%d", bladeKey, i), r, i)
 
 		// These two calls are temporary fix-ups until the inventory definition
@@ -169,7 +169,7 @@ func (r *Rack) forwardToBlade(ctxIn context.Context, id int64, msg sm.Envelope) 
 	if b, ok := r.blades[id]; ok {
 		ctx, span := tracing.StartSpan(
 			ctxIn,
-			tracing.WithName(fmt.Sprintf("Processing message %q on blade", msg)),
+			tracing.WithName("Processing message %q on blade", msg),
 			tracing.WithNewRoot(),
 			tracing.WithLink(msg.SpanContext(), msg.LinkID()),
 			tracing.WithContextValue(timestamp.EnsureTickInContext))

--- a/simulation/internal/services/inventory/rack.go
+++ b/simulation/internal/services/inventory/rack.go
@@ -19,8 +19,6 @@ import (
 // governed by a mesh of state machines rooted in the one for the Rack as a
 // whole.
 type Rack struct {
-	name string
-
 	// ch is the channel to send requests along to the Rack's goroutine, which
 	// is where the state machine runs.
 	ch chan sm.Envelope
@@ -46,8 +44,15 @@ const (
 // entries to determine its structure.  The resulting Rack is healthy, not yet
 // started, all blades are powered off, and all network connections are not yet
 // programmed.
-func newRack(ctx context.Context, name string, def *pb.Definition_Rack, timers *timestamp.Timers) *Rack {
-	return newRackInternal(ctx, name, def, timers, newPdu, newTor)
+func newRack(
+	ctx context.Context,
+	name string,
+	def *pb.Definition_Rack,
+	pduKey string,
+	torKey string,
+	bladeKey string,
+	timers *timestamp.Timers) *Rack {
+	return newRackInternal(ctx, name, def, pduKey, torKey, bladeKey, timers, newPdu, newTor)
 }
 
 // newRackInternal is the implementation behind newRack.  It supports
@@ -57,11 +62,13 @@ func newRackInternal(
 	ctx context.Context,
 	name string,
 	def *pb.Definition_Rack,
+	pduKey string,
+	torKey string,
+	bladeKey string,
 	timers *timestamp.Timers,
-	pduFunc func(*pb.Definition_Pdu, *Rack) *pdu,
-	torFunc func(*pb.Definition_Tor, *Rack) *tor) *Rack {
+	pduFunc func(context.Context, *pb.Definition_Pdu, string, *Rack) *pdu,
+	torFunc func(context.Context, *pb.Definition_Tor, string, *Rack) *tor) *Rack {
 	r := &Rack{
-		name:      name,
 		ch:        make(chan sm.Envelope, rackQueueDepth),
 		tor:       nil,
 		pdu:       nil,
@@ -72,6 +79,7 @@ func newRackInternal(
 	}
 
 	r.sm = sm.NewSM(r,
+		name,
 		sm.WithFirstState(
 			pb.Actual_Rack_awaiting_start,
 			sm.NullEnter,
@@ -102,11 +110,13 @@ func newRackInternal(
 			sm.NullLeave),
 	)
 
-	r.pdu = pduFunc(def.Pdus[0], r)
-	r.tor = torFunc(def.Tors[0], r)
+	tracing.AddImpact(ctx, tracing.ImpactCreate, name)
+
+	r.pdu = pduFunc(ctx, def.Pdus[0], fmt.Sprintf("%s%d", pduKey, 0), r)
+	r.tor = torFunc(ctx, def.Tors[0], fmt.Sprintf("%s%d", torKey, 0), r)
 
 	for i, item := range def.Blades {
-		r.blades[i] = newBlade(item.GetCapacity(), r, i)
+		r.blades[i] = newBlade(ctx, item, fmt.Sprintf("%s%d", bladeKey, i), r, i)
 
 		// These two calls are temporary fix-ups until the inventory definition
 		// includes the tor and pdu connectors
@@ -121,7 +131,7 @@ func newRackInternal(
 // processing.  This will likely not be the final destination, but requires
 // operation by the TOR in order to reach its final destination.
 func (r *Rack) ViaTor(ctx context.Context, msg sm.Envelope) error {
-	tracing.Info(ctx, "Forwarding %v to TOR in rack %q", msg, r.name)
+	tracing.Info(ctx, "Forwarding %v to TOR in rack %q", msg, r.sm.Name)
 
 	r.tor.Receive(ctx, msg)
 
@@ -132,7 +142,7 @@ func (r *Rack) ViaTor(ctx context.Context, msg sm.Envelope) error {
 // processing.  This may or may not impact the full PDU and the all blades,
 // or only one blade's power state.
 func (r *Rack) ViaPDU(ctx context.Context, msg sm.Envelope) error {
-	tracing.Info(ctx, "Forwarding '%v' to PDU in rack %q", msg, r.name)
+	tracing.Info(ctx, "Forwarding '%v' to PDU in rack %q", msg, r.sm.Name)
 	r.pdu.Receive(ctx, msg)
 
 	return nil
@@ -143,7 +153,7 @@ func (r *Rack) ViaPDU(ctx context.Context, msg sm.Envelope) error {
 // to simulate a working network connection for reachability, or a working power
 // cable for execution.
 func (r *Rack) ViaBlade(ctx context.Context, id int64, msg sm.Envelope) error {
-	tracing.Info(ctx, "Forwarding '%v' to blade %d in rack %q", msg, id, r.name)
+	tracing.Info(ctx, "Forwarding '%v' to blade %d in rack %q", msg, id, r.sm.Name)
 	if b, ok := r.blades[id]; ok {
 		b.Receive(ctx, msg)
 		return nil
@@ -275,7 +285,7 @@ func startSim(ctx context.Context, machine *sm.SM, m sm.Envelope) bool {
 	tracing.UpdateSpanName(
 		ctx,
 		"Starting the simulation of rack %q",
-		r.name)
+		r.sm.Name)
 
 	err := r.sm.Start(ctx)
 

--- a/simulation/internal/services/inventory/rack_test.go
+++ b/simulation/internal/services/inventory/rack_test.go
@@ -2,6 +2,7 @@ package inventory
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -32,7 +33,14 @@ func (ts *RackTestSuite) TestCreateRack() {
 		tracing.WithName("test rack creation"),
 		tracing.WithContextValue(tsc.EnsureTickInContext))
 
-	r := newRack(ctx, ts.rackName(), rackDef, ts.timers)
+	r := newRack(
+		ctx,
+		ts.rackName(),
+		rackDef,
+		fmt.Sprintf("racks/%s/pdus/", ts.rackName()),
+		fmt.Sprintf("racks/%s/tors/", ts.rackName()),
+		fmt.Sprintf("racks/%s/blades/", ts.rackName()),
+		ts.timers)
 
 	span.End()
 
@@ -53,7 +61,14 @@ func (ts *RackTestSuite) TestStartStopRack() {
 		tracing.WithName("test rack start and stop"),
 		tracing.WithContextValue(tsc.EnsureTickInContext))
 
-	r := newRack(ctx, ts.rackName(), rackDef, ts.timers)
+	r := newRack(
+		ctx,
+		ts.rackName(),
+		rackDef,
+		fmt.Sprintf("racks/%s/pdus/", ts.rackName()),
+		fmt.Sprintf("racks/%s/tors/", ts.rackName()),
+		fmt.Sprintf("racks/%s/blades/", ts.rackName()),
+		ts.timers)
 	require.NotNil(r)
 	assert.Equal(len(rackDef.Blades), len(r.blades))
 	assert.Equal(pb.Actual_Rack_awaiting_start, r.sm.CurrentIndex)
@@ -88,7 +103,14 @@ func (ts *RackTestSuite) TestStartStartStopRack() {
 		tracing.WithName("test rack start, start, and stop"),
 		tracing.WithContextValue(tsc.EnsureTickInContext))
 
-	r := newRack(ctx, ts.rackName(), rackDef, ts.timers)
+	r := newRack(
+		ctx,
+		ts.rackName(),
+		rackDef,
+		fmt.Sprintf("racks/%s/pdus/", ts.rackName()),
+		fmt.Sprintf("racks/%s/tors/", ts.rackName()),
+		fmt.Sprintf("racks/%s/blades/", ts.rackName()),
+		ts.timers)
 	require.NotNil(r)
 	assert.Equal(len(rackDef.Blades), len(r.blades))
 	assert.Equal(pb.Actual_Rack_awaiting_start, r.sm.CurrentIndex)
@@ -129,7 +151,14 @@ func (ts *RackTestSuite) TestStartStopStopRack() {
 		tracing.WithName("test rack start, stop, and stop"),
 		tracing.WithContextValue(tsc.EnsureTickInContext))
 
-	r := newRack(ctx, ts.rackName(), rackDef, ts.timers)
+	r := newRack(
+		ctx,
+		ts.rackName(),
+		rackDef,
+		fmt.Sprintf("racks/%s/pdus/", ts.rackName()),
+		fmt.Sprintf("racks/%s/tors/", ts.rackName()),
+		fmt.Sprintf("racks/%s/blades/", ts.rackName()),
+		ts.timers)
 	require.NotNil(r)
 	assert.Equal(len(rackDef.Blades), len(r.blades))
 	assert.Equal(pb.Actual_Rack_awaiting_start, r.sm.CurrentIndex)
@@ -167,7 +196,14 @@ func (ts *RackTestSuite) TestStopNoStartRack() {
 		tracing.WithName("test rack stop without a start"),
 		tracing.WithContextValue(tsc.EnsureTickInContext))
 
-	r := newRack(ctx, ts.rackName(), rackDef, ts.timers)
+	r := newRack(
+		ctx,
+		ts.rackName(),
+		rackDef,
+		fmt.Sprintf("racks/%s/pdus/", ts.rackName()),
+		fmt.Sprintf("racks/%s/tors/", ts.rackName()),
+		fmt.Sprintf("racks/%s/blades/", ts.rackName()),
+		ts.timers)
 	require.NotNil(r)
 	assert.Equal(len(rackDef.Blades), len(r.blades))
 	assert.Equal(pb.Actual_Rack_awaiting_start, r.sm.CurrentIndex)
@@ -191,7 +227,14 @@ func (ts *RackTestSuite) TestPowerOnPdu() {
 		tracing.WithName("test powering on PDU from rack"),
 		tracing.WithContextValue(tsc.EnsureTickInContext))
 
-	r := newRack(ctx, ts.rackName(), rackDef, ts.timers)
+	r := newRack(
+		ctx,
+		ts.rackName(),
+		rackDef,
+		fmt.Sprintf("racks/%s/pdus/", ts.rackName()),
+		fmt.Sprintf("racks/%s/tors/", ts.rackName()),
+		fmt.Sprintf("racks/%s/blades/", ts.rackName()),
+		ts.timers)
 	require.NotNil(r)
 	assert.Equal(len(rackDef.Blades), len(r.blades))
 	assert.Equal(pb.Actual_Rack_awaiting_start, r.sm.CurrentIndex)

--- a/simulation/internal/services/inventory/tor_test.go
+++ b/simulation/internal/services/inventory/tor_test.go
@@ -2,6 +2,7 @@ package inventory
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -27,7 +28,14 @@ func (ts *TorTestSuite) TestCreateTor() {
 
 	rackDef := ts.createDummyRack(2)
 
-	r := newRack(context.Background(), ts.rackName(), rackDef, ts.timers)
+	r := newRack(
+		context.Background(),
+		ts.rackName(),
+		rackDef,
+		fmt.Sprintf("racks/%s/pdus/", ts.rackName()),
+		fmt.Sprintf("racks/%s/tors/", ts.rackName()),
+		fmt.Sprintf("racks/%s/blades/", ts.rackName()),
+		ts.timers)
 	require.NotNil(r)
 
 	t := r.tor

--- a/simulation/internal/services/repair_manager/ruler/rules.go
+++ b/simulation/internal/services/repair_manager/ruler/rules.go
@@ -176,7 +176,7 @@ func Process(ctx context.Context, rules []Rule, tables Tables, vars map[string]s
 					reason = fmt.Sprintf("%s%s%s", reason, so, r.Replace(choice.Chosen))
 					ctx, span := tracing.StartSpan(
 						ctx,
-						tracing.WithName(fmt.Sprintf("Executing %q rule", rule.Name)),
+						tracing.WithName("Executing %q rule", rule.Name),
 						tracing.WithReason(reason),
 						tracing.WithContextValue(timestamp.EnsureTickInContext))
 
@@ -199,7 +199,7 @@ func Process(ctx context.Context, rules []Rule, tables Tables, vars map[string]s
 			if !anyChosen {
 				ctx, span := tracing.StartSpan(
 					ctx,
-					tracing.WithName(fmt.Sprintf("Executing %q rule", rule.Name)),
+					tracing.WithName("Executing %q rule", rule.Name),
 					tracing.WithReason(reason),
 					tracing.WithContextValue(timestamp.EnsureTickInContext))
 				tracing.Info(ctx, "No choice found to execute")

--- a/simulation/internal/services/stepper/stepper.go
+++ b/simulation/internal/services/stepper/stepper.go
@@ -61,6 +61,7 @@ func newStepper(startingPolicy int) *stepper {
 	}
 
 	s.sm = sm.NewSM(s,
+		"Stepper",
 		sm.WithFirstState(
 			pb.StepperState_awaiting_start,
 			sm.NullEnter,

--- a/simulation/internal/services/tracing_sink/sink_test.go
+++ b/simulation/internal/services/tracing_sink/sink_test.go
@@ -103,7 +103,6 @@ func createEntry(events int) *log2.Entry {
 			Name:       fmt.Sprintf("Event-%d", i),
 			Text:       "xxxx",
 			StackTrace: fmt.Sprintf("xxxx%d", i),
-			Impacted:   nil,
 		})
 	}
 
@@ -124,7 +123,6 @@ func createRootEntry(events int) *log2.Entry {
 			Name:       fmt.Sprintf("Event-%d", i),
 			Text:       "xxxx",
 			StackTrace: fmt.Sprintf("xxxx%d", i),
-			Impacted:   nil,
 		})
 	}
 
@@ -149,6 +147,7 @@ func assertEntryMatches(t *testing.T, expected *log2.Entry, actual *log2.Entry) 
 	assert.Equal(t, expected.StackTrace, actual.StackTrace)
 	assert.Equal(t, expected.Status, actual.Status)
 	assert.Equal(t, len(expected.Event), len(actual.Event))
+	assert.Equal(t, len(expected.Impacted), len(actual.Impacted))
 
 	for i := 0; i < len(expected.Event); i++ {
 		assertEventMatches(t, expected.Event[i], actual.Event[i])
@@ -161,7 +160,6 @@ func assertEventMatches(t *testing.T, expected *log2.Event, actual *log2.Event) 
 	assert.Equal(t, expected.StackTrace, actual.StackTrace)
 	assert.Equal(t, expected.Severity, actual.Severity)
 	assert.Equal(t, expected.Text, actual.Text)
-	assert.Equal(t, len(expected.Impacted), len(actual.Impacted))
 }
 
 func TestGetAfterNoEntries(t *testing.T) {

--- a/simulation/internal/tracing/constants.go
+++ b/simulation/internal/tracing/constants.go
@@ -9,11 +9,7 @@ const (
 	ChildSpanKey    = "cc-child-span"
 	ActionKey       = "cc-action"
 	ImpactKey       = "cc-impact"
-
-	// Envelope keys
-	SourceTraceID   = "cc-starting-span-trace-id"
-	SourceSpanID    = "cc-starting-span-span-id"
-	SourceTraceFlgs = "cc-starting-span-trace-flags"
+	SpanNameKey     = "cc-span-name"
 
 	// link tracking keys
 	LinkTagKey = "cc-link-tag"

--- a/simulation/internal/tracing/exporters/common.go
+++ b/simulation/internal/tracing/exporters/common.go
@@ -56,6 +56,12 @@ func extractEntry(_ context.Context, data *trace.SpanData) *log.Entry {
 				entry.LinkSpanID = data.Links[0].SpanID.String()
 				entry.LinkTraceID = data.Links[0].TraceID.String()
 			}
+
+		case tracing.ImpactKey:
+			entry.Impacted = processImpacts(attr.Value.AsArray())
+
+		case tracing.SpanNameKey:
+			entry.Name = attr.Value.AsString()
 		}
 	}
 
@@ -89,18 +95,12 @@ func extractEntry(_ context.Context, data *trace.SpanData) *log.Entry {
 
 			case tracing.ActionKey:
 				item.EventAction = log.Action(attr.Value.AsInt64())
-
-			case tracing.ImpactKey:
-				item.Impacted = processImpacts(attr.Value.AsArray())
 			}
 		}
 
 		switch item.EventAction {
-		case log.Action_UpdateSpanName:
-			entry.Name = item.Text
-
-		case log.Action_UpdateReason:
-			entry.Reason = item.Text
+		case log.Action_AddImpact:
+			entry.Impacted = append(entry.Impacted, processOneImpact(item.Text))
 
 		default:
 			entry.Event = append(entry.Event, &item)
@@ -118,7 +118,7 @@ func formatEntry(entry *log.Entry, deferred bool, leader string) string {
 	dur := entry.EndedAt.AsTime().Sub(entry.StartedAt.AsTime())
 
 	return doIndent(fmt.Sprintf(
-		"%s:%s [%s:%s]%s%s%s %s %s (%s):\n%s\n",
+		"%s:%s [%s:%s]%s%s%s %s %s (%s):\n%s%s\n",
 		entry.StartedAt.AsTime().Format(time.RFC3339Nano),
 		dur.String(),
 		entry.GetSpanID(),
@@ -129,6 +129,7 @@ func formatEntry(entry *log.Entry, deferred bool, leader string) string {
 		entry.GetStatus(),
 		entry.GetName(),
 		entry.GetReason(),
+		formatModules(entry.GetImpacted()),
 		stack), leader)
 }
 
@@ -193,23 +194,21 @@ func formatNormalEvent(event *log.Event, leader string) string {
 
 	if event.GetTick() < 0 {
 		return doIndent(fmt.Sprintf(
-			"%s       : [%s] (%s) %s\n%s%s\n",
+			"%s       : [%s] (%s) %s\n%s\n",
 			event.At.AsTime().Format(time.RFC3339Nano),
 			severityFlag(event.GetSeverity()),
 			event.GetName(),
 			event.GetText(),
-			formatModules(event.Impacted),
 			stack), leader)
 	}
 
 	return doIndent(fmt.Sprintf(
-		"%s  @%4d: [%s] (%s) %s\n%s%s\n",
+		"%s  @%4d: [%s] (%s) %s\n%s\n",
 		event.At.AsTime().Format(time.RFC3339Nano),
 		event.GetTick(),
 		severityFlag(event.GetSeverity()),
 		event.GetName(),
 		event.GetText(),
-		formatModules(event.Impacted),
 		stack), leader)
 }
 
@@ -281,15 +280,18 @@ func processImpacts(attrs interface{}) []*log.Module {
 	values := attrs.([]string)
 
 	for _, value := range values {
-		tags := strings.Split(value, ":")
-
-		modules = append(modules, &log.Module{
-			Impact: decodeImpact(tags[0]),
-			Name:   tags[1],
-		})
+		modules = append(modules, processOneImpact(value))
 	}
 
 	return modules
+}
+
+func processOneImpact(value string) *log.Module {
+	tags := strings.Split(value, ":")
+	return &log.Module{
+		Impact: decodeImpact(tags[0]),
+		Name:   tags[1],
+	}
 }
 
 func decodeImpact(tag string) log.Impact {

--- a/simulation/internal/tracing/exporters/common.go
+++ b/simulation/internal/tracing/exporters/common.go
@@ -58,7 +58,7 @@ func extractEntry(_ context.Context, data *trace.SpanData) *log.Entry {
 			}
 
 		case tracing.ImpactKey:
-			entry.Impacted = processImpacts(attr.Value.AsArray())
+			entry.Impacted = append(entry.Impacted, processImpact(attr.Value.AsString()))
 
 		case tracing.SpanNameKey:
 			entry.Name = attr.Value.AsString()
@@ -100,7 +100,7 @@ func extractEntry(_ context.Context, data *trace.SpanData) *log.Entry {
 
 		switch item.EventAction {
 		case log.Action_AddImpact:
-			entry.Impacted = append(entry.Impacted, processOneImpact(item.Text))
+			entry.Impacted = append(entry.Impacted, processImpact(item.Text))
 
 		default:
 			entry.Event = append(entry.Event, &item)
@@ -223,7 +223,6 @@ func doIndent(s string, indent string) string {
 func severityFlag(severity log.Severity) string {
 	var severityToText = map[log.Severity]string{
 		log.Severity_Debug:   "D",
-		log.Severity_Reason:  "R",
 		log.Severity_Info:    "I",
 		log.Severity_Warning: "W",
 		log.Severity_Error:   "E",
@@ -275,18 +274,7 @@ func formatModules(modules []*log.Module) string {
 	return res
 }
 
-func processImpacts(attrs interface{}) []*log.Module {
-	var modules []*log.Module
-	values := attrs.([]string)
-
-	for _, value := range values {
-		modules = append(modules, processOneImpact(value))
-	}
-
-	return modules
-}
-
-func processOneImpact(value string) *log.Module {
+func processImpact(value string) *log.Module {
 	tags := strings.Split(value, ":")
 	return &log.Module{
 		Impact: decodeImpact(tags[0]),

--- a/simulation/internal/tracing/exporters/io_spans_test.go
+++ b/simulation/internal/tracing/exporters/io_spans_test.go
@@ -21,7 +21,6 @@ func (ts *ioSpanTestSuite) newTraceEvent(i int, tick int64, s log.Severity) *log
 		Name:        fmt.Sprintf("test%d", i),
 		Text:        fmt.Sprintf("text%d", i),
 		StackTrace:  fmt.Sprintf("stack%d", i),
-		Impacted:    nil,
 		EventAction: log.Action_Trace,
 		SpanId:      "",
 		LinkId:      "",
@@ -35,7 +34,6 @@ func (ts *ioSpanTestSuite) newSpanStartEvent(i int, tick int64, spanId string) *
 		Name:        fmt.Sprintf("test%d", i),
 		Text:        fmt.Sprintf("text%d", i),
 		StackTrace:  fmt.Sprintf("stack%d", i),
-		Impacted:    nil,
 		EventAction: log.Action_SpanStart,
 		SpanId:      spanId,
 		LinkId:      "",
@@ -61,6 +59,7 @@ func (ts *ioSpanTestSuite) TestSingleRoot() {
 			ts.newTraceEvent(2, 1, 0),
 		},
 		Infrastructure: false,
+		Impacted:    nil,
 	}
 
 	s.add(entry, &io)

--- a/simulation/internal/tracing/spanEx.go
+++ b/simulation/internal/tracing/spanEx.go
@@ -93,9 +93,9 @@ func (cfg *startSpanConfig) toKvPairs() []kv.KeyValue {
 type StartSpanOption func(*startSpanConfig)
 
 // WithName adds the supplied value as the name of the span under creation
-func WithName(name string) StartSpanOption {
+func WithName(f string, a ...interface{}) StartSpanOption {
 	return func(cfg *startSpanConfig) {
-		cfg.name = name
+		cfg.name = fmt.Sprintf(f, a...)
 	}
 }
 

--- a/simulation/pkg/protos/log/entry.Validate.go
+++ b/simulation/pkg/protos/log/entry.Validate.go
@@ -87,7 +87,7 @@ func (x *Event) Validate(prefix string) error {
 	}
 
 	switch x.EventAction {
-	case Action_Trace, Action_UpdateSpanName, Action_UpdateReason:
+	case Action_Trace:
 		textLen := int64(len(x.Text))
 		if textLen == 0 {
 			return &errors2.ErrMinLenString{

--- a/simulation/pkg/protos/log/entry.Validate.go
+++ b/simulation/pkg/protos/log/entry.Validate.go
@@ -72,7 +72,6 @@ func (x *Entry) Validate(prefix string) error {
 func (x *Event) Validate(prefix string) error {
 	switch x.Severity {
 	case Severity_Debug,
-		Severity_Reason,
 		Severity_Info,
 		Severity_Warning,
 		Severity_Error,


### PR DESCRIPTION
Impact claims added to inventory state machine operations
Impact is moved to the span
uplift from child spans is supported in the text output
reason and span name updates are now done via setting attributes to the span
tsx form of the log entries are updated.  ts_ref is updated from generated code to track the change.