### PR TITLE
Add mocked controller structure, with dataflow highlight

### DIFF
--- a/clients/observer/src/MainPage/Main.tsx
+++ b/clients/observer/src/MainPage/Main.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import {CommandBar} from "../CommandBar"
-import {Paper} from "@material-ui/core"
-import ControllerDetails from "../ControllerDetails"
-import {SimulatedInventory} from "../SimulatedInventory/SimulatedInventory"
-import {LogDisplay} from "../Log/LogDisplay"
-import {StatusBar} from "../StatusBar"
-import {makeStyles} from "@material-ui/core/styles"
-import {Container, Item} from "../common/Cells"
+import { CommandBar } from "../CommandBar"
+import { Paper } from "@material-ui/core"
+import { SimulatedController } from '../SimulatedController/SimulatedController';
+import { SimulatedInventory } from "../SimulatedInventory/SimulatedInventory"
+import { LogDisplay } from "../Log/LogDisplay"
+import { StatusBar } from "../StatusBar"
+import { makeStyles } from "@material-ui/core/styles"
+import { Container, Item } from "../common/Cells"
 
 const useStyles = makeStyles(() => ({
     root: {
@@ -22,28 +22,28 @@ export function MainPage(props: {
     return <div className={classes.root}>
         <Container>
             <Item xs={12}>
-                <CommandBar onLogout={props.onLogout}/>
+                <CommandBar onLogout={props.onLogout} />
             </Item>
             <Item xs={9}>
                 <Container id="left-pane" direction="column">
                     <Item xs={12}>
-                        <Paper variant="outlined" style={{maxHeight: 150, minHeight: 150, overflow: "auto"}}>
-                            <ControllerDetails/>
+                        <Paper variant="outlined" style={{ minHeight: 150, overflow: "auto" }}>
+                            <SimulatedController />
                         </Paper>
                     </Item>
                     <Item xs={12}>
-                        <Paper variant="outlined" style={{minHeight: 250, overflow: "auto"}}>
-                            <SimulatedInventory/>
+                        <Paper variant="outlined" style={{ minHeight: 250, overflow: "auto" }}>
+                            <SimulatedInventory />
                         </Paper>
                     </Item>
                 </Container>
             </Item>
             <Item xs={3}>
-                <LogDisplay matchId="left-pane"/>
+                <LogDisplay matchId="left-pane" />
             </Item>
             <Item xs={12}>
                 <Paper variant="outlined">
-                    <StatusBar/>
+                    <StatusBar />
                 </Paper>
             </Item>
         </Container>

--- a/clients/observer/src/SimulatedController/Constants.tsx
+++ b/clients/observer/src/SimulatedController/Constants.tsx
@@ -1,0 +1,96 @@
+// This module contains temporary definitions for the impact claims on the
+// controller components.  Once the simulated controller components have been
+// implemented and operating these definitions will be superseded or fully
+// replaced.
+
+import { Theme } from "@material-ui/core/styles"
+
+export enum Impact {
+    ImpactNone = 0,
+    ImpactRead = 1,
+    ImpactWrite = 2,
+    ImpactSelected = 3
+}
+
+// Impacts defines the impact statement for each controller element.
+export interface Impacts {
+    WorkloadGoal: Impact,
+    InventoryGoal: Impact,
+
+    RollingUpgrade: Impact,
+    PhasedUpdate: Impact,
+    AutoScaler: Impact,
+
+    AddInventory: Impact,
+    RetireInventory: Impact,
+    BurnIn: Impact,
+
+    WorkloadTargetPartial: Impact,
+    InventoryTargetPartial: Impact,
+
+    Scheduler: Impact,
+
+    WorkloadTargetFull: Impact,
+    InventoryTargetFull: Impact,
+
+    WorkloadRepairManager: Impact,
+    InventoryRepairManager: Impact,
+
+    Observed: Impact,
+    WorkloadActions: Impact,
+    InventoryActions: Impact,
+
+    Monitor: Impact,
+    Effector: Impact
+}
+
+// NoImpacts acts as the 'quick reset' for the impact statements.  It is used
+// to set the initial state, and to set the default values on all impact claims.
+export const NoImpacts : Impacts = {
+    WorkloadGoal: Impact.ImpactNone,
+    InventoryGoal: Impact.ImpactNone,
+
+    RollingUpgrade: Impact.ImpactNone,
+    PhasedUpdate: Impact.ImpactNone,
+    AutoScaler: Impact.ImpactNone,
+
+    AddInventory: Impact.ImpactNone,
+    RetireInventory: Impact.ImpactNone,
+    BurnIn: Impact.ImpactNone,
+
+    WorkloadTargetPartial: Impact.ImpactNone,
+    InventoryTargetPartial: Impact.ImpactNone,
+
+    Scheduler: Impact.ImpactNone,
+
+    WorkloadTargetFull: Impact.ImpactNone,
+    InventoryTargetFull: Impact.ImpactNone,
+
+    WorkloadRepairManager: Impact.ImpactNone,
+    InventoryRepairManager: Impact.ImpactNone,
+
+    Observed: Impact.ImpactNone,
+    WorkloadActions: Impact.ImpactNone,
+    InventoryActions: Impact.ImpactNone,
+
+    Monitor: Impact.ImpactNone,
+    Effector: Impact.ImpactNone
+}
+
+// impactToColor converts an impact claim into a background color.  This is used
+// temporarily to highlight expected data flows in the controller.
+export function impactToColor(impact: Impact, theme: Theme): string {
+    switch (impact) {
+        case Impact.ImpactSelected:
+            return theme.palette.background.default
+
+        case Impact.ImpactNone:
+            return theme.palette.action.disabledBackground
+
+        case Impact.ImpactRead:
+            return "yellow"
+
+        case Impact.ImpactWrite:
+            return "red"
+    }
+}

--- a/clients/observer/src/SimulatedController/LogicElement.tsx
+++ b/clients/observer/src/SimulatedController/LogicElement.tsx
@@ -1,0 +1,60 @@
+// This module provides the common look and feel for logic subsystems in the
+// controller.
+
+import { Avatar, Chip } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import React from "react";
+import { LogicIcon } from '../common/Icons';
+import { impactsSlice, useAppDispatch } from '../store/Store';
+import { Impact, Impacts, impactToColor } from './Constants';
+
+interface styleProps {
+    impact: Impact
+}
+
+const useStyles = makeStyles((theme) => ({
+    card: (props: styleProps) => ({
+        display: 'flex',
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+        pb: theme.spacing(2),
+        backgroundColor: impactToColor(props.impact, theme),
+        '& > *': {
+            margin: theme.spacing(0.5),
+        },
+    }),
+}))
+
+// Display a logic element in the simulated controller.  Much of the internals
+// of this function are temporary, and serve only to provide a trial framing
+// for the controller structure.
+export function LogicElement(props: {
+    title: string,
+    impact: Impact,
+    selectedImpacts: Impacts
+}) {
+    const dispatch = useAppDispatch()
+
+    const clickEvent = (ev: React.MouseEvent<HTMLDivElement, MouseEvent>): void => {
+        if (props.impact === Impact.ImpactNone) {
+            dispatch(impactsSlice.actions.update(props.selectedImpacts))
+        } else {
+            dispatch(impactsSlice.actions.clear())
+        }
+    }
+
+    const classes = useStyles({ impact: props.impact })
+
+    return <Chip
+        className={classes.card}
+        variant="outlined"
+        color="primary"
+        label={props.title}
+        onClick={clickEvent}
+        avatar = {
+        <Avatar>
+            <LogicIcon />
+        </Avatar>
+        }
+    />
+}

--- a/clients/observer/src/SimulatedController/SimulatedController.tsx
+++ b/clients/observer/src/SimulatedController/SimulatedController.tsx
@@ -1,0 +1,202 @@
+import { Grid } from '@material-ui/core';
+import { createStyles, makeStyles } from '@material-ui/core/styles';
+import { Container } from '../common/Cells';
+import { impactsSelector, useAppSelector } from '../store/Store';
+import { Impact, NoImpacts } from './Constants';
+import { LogicElement } from './LogicElement';
+import { StorageElement } from './StorageElement';
+
+const useStyles = makeStyles((theme) =>
+    createStyles({
+        layer: {
+            paddingBottom: theme.spacing(2)
+        }
+    }),
+)
+
+function Layer(props: any) {
+    const classes = useStyles()
+
+    return <Grid container XS={12} className={classes.layer} {...props} />
+}
+
+// Display the simulated controller's components and stores in a logical
+// structure.  Emphasis is on showing the layered relationship between the
+// stores and logic components.
+//
+// Note that logic elements are active, in that they can be clicked to show
+// what storage elements they read, and which ones they modify.
+export function SimulatedController() {
+    const impacts = useAppSelector(impactsSelector)
+
+    return (
+        <Container xs={12}>
+            <Layer justify="space-around">
+                <StorageElement
+                    impact={impacts.controllerImpacts.WorkloadGoal}
+                    title="Workload Goal State" />
+
+                <StorageElement
+                    impact={impacts.controllerImpacts.InventoryGoal}
+                    title="Inventory Goal State" />
+            </Layer>
+
+            <Layer xs={6} justify="space-evenly">
+                <LogicElement
+                    impact={impacts.controllerImpacts.RollingUpgrade}
+                    selectedImpacts={{
+                        ...NoImpacts,
+                        WorkloadGoal: Impact.ImpactRead,
+                        WorkloadTargetPartial: Impact.ImpactWrite,
+                        RollingUpgrade: Impact.ImpactSelected,
+                    }}
+                    title="Rolling Update" />
+
+                <LogicElement
+                    impact={impacts.controllerImpacts.PhasedUpdate}
+                    selectedImpacts={{
+                        ...NoImpacts,
+                        WorkloadGoal: Impact.ImpactRead,
+                        WorkloadTargetPartial: Impact.ImpactWrite,
+                        PhasedUpdate: Impact.ImpactSelected,
+                    }}
+                    title="Phased Update" />
+
+                <LogicElement
+                    impact={impacts.controllerImpacts.AutoScaler}
+                    selectedImpacts={{
+                        ...NoImpacts,
+                        WorkloadGoal: Impact.ImpactRead,
+                        WorkloadTargetPartial: Impact.ImpactWrite,
+                        AutoScaler: Impact.ImpactSelected,
+                    }}
+                    title="Auto-Scaler" />
+            </Layer>
+
+            <Layer xs={6} justify="space-evenly">
+                <LogicElement
+                    impact={impacts.controllerImpacts.AddInventory}
+                    selectedImpacts={{
+                        ...NoImpacts,
+                        InventoryGoal: Impact.ImpactRead,
+                        InventoryTargetPartial: Impact.ImpactWrite,
+                        AddInventory: Impact.ImpactSelected,
+                    }}
+                    title="Add Inventory" />
+
+                <LogicElement
+                    impact={impacts.controllerImpacts.RetireInventory}
+                    selectedImpacts={{
+                        ...NoImpacts,
+                        InventoryGoal: Impact.ImpactRead,
+                        InventoryTargetPartial: Impact.ImpactWrite,
+                        RetireInventory: Impact.ImpactSelected,
+                    }}
+                    title="Retire Inventory" />
+
+                <LogicElement
+                    impact={impacts.controllerImpacts.BurnIn}
+                    selectedImpacts={{
+                        ...NoImpacts,
+                        InventoryGoal: Impact.ImpactRead,
+                        InventoryTargetPartial: Impact.ImpactWrite,
+                        BurnIn: Impact.ImpactSelected,
+                    }}
+                    title="Burn-In" />
+            </Layer>
+
+            <Layer justify="space-around">
+                <StorageElement
+                    impact={impacts.controllerImpacts.WorkloadTargetPartial}
+                    title="Workload Target State (partial)" />
+
+                <StorageElement
+                    impact={impacts.controllerImpacts.InventoryTargetPartial}
+                    title="Inventory Target State (partial)" />
+            </Layer>
+
+            <Layer justify="center">
+                <LogicElement
+                    impact={impacts.controllerImpacts.Scheduler}
+                    selectedImpacts={{
+                        ...NoImpacts,
+                        WorkloadTargetPartial: Impact.ImpactRead,
+                        WorkloadTargetFull: Impact.ImpactWrite,
+                        InventoryTargetPartial: Impact.ImpactRead,
+                        InventoryTargetFull: Impact.ImpactWrite,
+                        Scheduler: Impact.ImpactSelected,
+                    }}
+                    title="Scheduler" />
+            </Layer>
+
+            <Layer justify="space-around">
+                <StorageElement
+                    impact={impacts.controllerImpacts.WorkloadTargetFull}
+                    title="Workload Target State" />
+
+                <StorageElement
+                    impact={impacts.controllerImpacts.InventoryTargetFull}
+                    title="Inventory Target State" />
+            </Layer>
+
+            <Layer justify="space-around">
+                <LogicElement
+                    impact={impacts.controllerImpacts.WorkloadRepairManager}
+                    selectedImpacts={{
+                        ...NoImpacts,
+                        WorkloadTargetFull: Impact.ImpactRead,
+                        Observed: Impact.ImpactRead,
+                        WorkloadActions: Impact.ImpactWrite,
+                        WorkloadRepairManager: Impact.ImpactSelected,
+                    }}
+                    title="Workload Repair Manager" />
+
+                <LogicElement
+                    impact={impacts.controllerImpacts.InventoryRepairManager}
+                    selectedImpacts={{
+                        ...NoImpacts,
+                        InventoryTargetFull: Impact.ImpactRead,
+                        Observed: Impact.ImpactRead,
+                        InventoryActions: Impact.ImpactWrite,
+                        InventoryRepairManager: Impact.ImpactSelected,
+                    }}
+                    title="Inventory Repair Manager" />
+            </Layer>
+
+            <Layer justify="space-around">
+                <StorageElement
+                    impact={impacts.controllerImpacts.Observed}
+                    title="Observed State" />
+
+                <StorageElement
+                    impact={impacts.controllerImpacts.WorkloadActions}
+                    title="Workload Actions" />
+
+                <StorageElement
+                    impact={impacts.controllerImpacts.InventoryActions}
+                    title="Inventory Actions" />
+            </Layer>
+
+            <Layer justify="space-around">
+                <LogicElement
+                    impact={impacts.controllerImpacts.Monitor}
+                    selectedImpacts={{
+                        ...NoImpacts,
+                        Observed: Impact.ImpactWrite,
+                        Monitor: Impact.ImpactSelected
+                    }}
+                    title="Monitor" />
+
+                <LogicElement
+                    impact={impacts.controllerImpacts.Effector}
+                    selectedImpacts={{
+                        ...NoImpacts,
+                        InventoryActions: Impact.ImpactRead,
+                        WorkloadActions: Impact.ImpactRead,
+                        Effector: Impact.ImpactSelected,
+                    }}
+                    title="Effector" />
+            </Layer>
+        </Container>
+    )
+}

--- a/clients/observer/src/SimulatedController/StorageElement.tsx
+++ b/clients/observer/src/SimulatedController/StorageElement.tsx
@@ -1,0 +1,45 @@
+// This module provides the common look and feel for stores in the controller.
+
+import { Avatar, Chip } from "@material-ui/core";
+import { makeStyles } from '@material-ui/core/styles';
+import { StorageIcon } from "../common/Icons";
+import { Impact, impactToColor } from "./Constants";
+
+interface styleProps {
+    impact: Impact
+}
+
+const useStyles = makeStyles((theme) => ({
+    card: (props: styleProps) => ({
+        display: 'flex',
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+        pb: theme.spacing(2),
+        backgroundColor: impactToColor(props.impact, theme),
+        '& > *': {
+            margin: theme.spacing(0.5),
+        },
+    }),
+}))
+
+// Display a storage element in the simulated controller.  Much of the internals
+// of this function are temporary, and serve only to provide a trial framing
+// for the controller structure.
+export function StorageElement(props: {
+    title: string,
+    impact: Impact
+}) {
+    const classes = useStyles({impact: props.impact})
+
+    return <Chip
+        className={classes.card}
+        variant="outlined"
+        color="default"
+        avatar={
+                <Avatar>
+                    <StorageIcon />
+                </Avatar>
+            }
+            label={props.title}
+        />
+}

--- a/clients/observer/src/SimulatedInventory/SimulatedInventory.tsx
+++ b/clients/observer/src/SimulatedInventory/SimulatedInventory.tsx
@@ -1,9 +1,9 @@
-import React, {useEffect, useState} from 'react'
-import {green, grey, red, yellow} from "@material-ui/core/colors"
+import React, { useEffect, useState } from 'react'
+import { green, grey, red, yellow } from "@material-ui/core/colors"
 
-import {ClusterDetails, getCluster, getRackDetails, RackDetails} from "../proxies/InventoryProxy"
-import {Cluster} from "./Cluster"
-import {ErrorSnackbar, MessageMode, SnackData, SuccessSnackbar} from "../common/Snackbar"
+import { ClusterDetails, getCluster, getRackDetails, RackDetails } from "../proxies/InventoryProxy"
+import { Cluster } from "./Cluster"
+import { ErrorSnackbar, MessageMode, SnackData, SuccessSnackbar } from "../common/Snackbar"
 
 
 // This is the palette of colors used by the various parts of the
@@ -53,7 +53,7 @@ export function SimulatedInventory() {
                 zone.racks.forEach((rack, name) => {
                     getRackDetails(rack)
                         .then(res => {
-                            let newZone = {...zone}
+                            let newZone = { ...zone }
                             newZone.racks.set(name, res)
 
                             let done = true
@@ -72,7 +72,7 @@ export function SimulatedInventory() {
                 })
             })
             .catch((err: Error) => {
-                setSnackData({message: err.message, mode: MessageMode.Error})
+                setSnackData({ message: err.message, mode: MessageMode.Error })
             })
     }, [])
 
@@ -86,20 +86,20 @@ export function SimulatedInventory() {
         runningColor: green[300]
     }
 
-    return <React.Fragment>
-        <Cluster cluster={cluster} palette={palette}/>
+    return <>
+        <Cluster cluster={cluster} palette={palette} />
 
         <SuccessSnackbar
             open={snackData.mode === MessageMode.Success}
-            onClose={() => setSnackData({message: "", mode: MessageMode.None})}
+            onClose={() => setSnackData({ message: "", mode: MessageMode.None })}
             autoHideDuration={3000}
-            message={snackData.message}/>
+            message={snackData.message} />
 
         <ErrorSnackbar
             open={snackData.mode === MessageMode.Error}
-            onClose={() => setSnackData({message: "", mode: MessageMode.None})}
+            onClose={() => setSnackData({ message: "", mode: MessageMode.None })}
             autoHideDuration={4000}
-            message={snackData.message}/>
+            message={snackData.message} />
 
-    </React.Fragment>
+    </>
 }

--- a/clients/observer/src/common/Icons.tsx
+++ b/clients/observer/src/common/Icons.tsx
@@ -1,6 +1,6 @@
 // This module contains custom icons used by the Observer display
 
-import {SvgIcon} from "@material-ui/core"
+import { SvgIcon } from "@material-ui/core"
 import React from "react"
 
 export function TorIcon(props: {
@@ -8,7 +8,7 @@ export function TorIcon(props: {
     y?: number,
     width?: number,
     height?: number
-} = {x: 0, y: 0, width: 24, height: 24}) {
+} = { x: 0, y: 0, width: 24, height: 24 }) {
     return <SvgIcon
         x={props.x}
         y={props.y}
@@ -16,7 +16,7 @@ export function TorIcon(props: {
         height={props.height}
         viewBox="0 0 24 24">
         <path fill="currentColor"
-              d="M17,3A2,2 0 0,1 19,5V15A2,2 0 0,1 17,17H13V19H14A1,1 0 0,1 15,20H22V22H15A1,1 0 0,1 14,23H10A1,1 0 0,1 9,22H2V20H9A1,1 0 0,1 10,19H11V17H7C5.89,17 5,16.1 5,15V5A2,2 0 0,1 7,3H17Z"/>
+            d="M17,3A2,2 0 0,1 19,5V15A2,2 0 0,1 17,17H13V19H14A1,1 0 0,1 15,20H22V22H15A1,1 0 0,1 14,23H10A1,1 0 0,1 9,22H2V20H9A1,1 0 0,1 10,19H11V17H7C5.89,17 5,16.1 5,15V5A2,2 0 0,1 7,3H17Z" />
     </SvgIcon>
 }
 
@@ -25,7 +25,7 @@ export function NetworkOnIcon(props: {
     y?: number,
     width?: number,
     height?: number
-} = {x: 0, y: 0, width: 24, height: 24}) {
+} = { x: 0, y: 0, width: 24, height: 24 }) {
     return <SvgIcon
         x={props.x}
         y={props.y}
@@ -34,7 +34,7 @@ export function NetworkOnIcon(props: {
         viewBox="0 0 24 24">
         <path
             fill="currentColor"
-            d="M15,20A1,1 0 0,0 14,19H13V17H17A2,2 0 0,0 19,15V5A2,2 0 0,0 17,3H7A2,2 0 0,0 5,5V15A2,2 0 0,0 7,17H11V19H10A1,1 0 0,0 9,20H2V22H9A1,1 0 0,0 10,23H14A1,1 0 0,0 15,22H22V20H15M7,15V5H17V15H7Z"/>
+            d="M15,20A1,1 0 0,0 14,19H13V17H17A2,2 0 0,0 19,15V5A2,2 0 0,0 17,3H7A2,2 0 0,0 5,5V15A2,2 0 0,0 7,17H11V19H10A1,1 0 0,0 9,20H2V22H9A1,1 0 0,0 10,23H14A1,1 0 0,0 15,22H22V20H15M7,15V5H17V15H7Z" />
     </SvgIcon>
 }
 
@@ -43,7 +43,7 @@ export function NetworkOffIcon(props: {
     y?: number,
     width?: number,
     height?: number
-} = {x: 0, y: 0, width: 24, height: 24}) {
+} = { x: 0, y: 0, width: 24, height: 24 }) {
     return <SvgIcon
         x={props.x}
         y={props.y}
@@ -52,7 +52,7 @@ export function NetworkOffIcon(props: {
         viewBox="0 0 24 24">
         <path
             fill="currentColor"
-            d="M1.04,5.27L5,9.23V15A2,2 0 0,0 7,17H11V19H10A1,1 0 0,0 9,20H2V22H9A1,1 0 0,0 10,23H14A1,1 0 0,0 15,22H17.77L19.77,24L21.04,22.72L2.32,4L1.04,5.27M7,11.23L10.77,15H7V11.23M15,20A1,1 0 0,0 14,19H13V17.23L15.77,20H15M22,20V21.14L20.86,20H22M7,6.14L5.14,4.28C5.43,3.53 6.16,3 7,3H17A2,2 0 0,1 19,5V15C19,15.85 18.47,16.57 17.72,16.86L15.86,15H17V5H7V6.14Z"/>
+            d="M1.04,5.27L5,9.23V15A2,2 0 0,0 7,17H11V19H10A1,1 0 0,0 9,20H2V22H9A1,1 0 0,0 10,23H14A1,1 0 0,0 15,22H17.77L19.77,24L21.04,22.72L2.32,4L1.04,5.27M7,11.23L10.77,15H7V11.23M15,20A1,1 0 0,0 14,19H13V17.23L15.77,20H15M22,20V21.14L20.86,20H22M7,6.14L5.14,4.28C5.43,3.53 6.16,3 7,3H17A2,2 0 0,1 19,5V15C19,15.85 18.47,16.57 17.72,16.86L15.86,15H17V5H7V6.14Z" />
     </SvgIcon>
 }
 
@@ -61,7 +61,7 @@ export function PowerOnIcon(props: {
     y?: number,
     width?: number,
     height?: number
-} = {x: 0, y: 0, width: 24, height: 24}) {
+} = { x: 0, y: 0, width: 24, height: 24 }) {
     return <SvgIcon
         x={props.x}
         y={props.y}
@@ -79,7 +79,7 @@ export function PowerOffIcon(props: {
     y?: number,
     width?: number,
     height?: number
-} = {x: 0, y: 0, width: 24, height: 24}) {
+} = { x: 0, y: 0, width: 24, height: 24 }) {
     return <SvgIcon
         x={props.x}
         y={props.y}
@@ -90,4 +90,38 @@ export function PowerOffIcon(props: {
             fill="currentColor"
             d="M22.11 21.46L2.39 1.73L1.11 3L6.25 8.14C6.1 8.41 6 8.7 6 9V14.5L9.5 18V21H14.5V18L15.31 17.2L20.84 22.73L22.11 21.46M13.09 16.59L12.67 17H11.33L10.92 16.59L8 13.67V9.89L13.89 15.78L13.09 16.59M12.2 9L10.2 7H14V3H16V7C17 7 18 8 18 9V14.5L17.85 14.65L16 12.8V9.09C16 9.06 15.95 9 15.92 9H12.2M10 6.8L8 4.8V3H10V6.8Z" />
     </SvgIcon>
+}
+
+export function LogicIcon(props: {
+    x?: number,
+    y?: number,
+    width?: number,
+    height?: number
+} = { x: 0, y: 0, width: 24, height: 24 }) {
+    return <SvgIcon
+        x={props.x}
+        y={props.y}
+        width={props.width}
+        height={props.height}
+        viewBox="0 0 24 24">
+        <   path
+            fill="currentColor"
+            d="M6.91 5.5L9.21 7.79L7.79 9.21L5.5 6.91L3.21 9.21L1.79 7.79L4.09 5.5L1.79 3.21L3.21 1.79L5.5 4.09L7.79 1.79L9.21 3.21M22.21 16.21L20.79 14.79L18.5 17.09L16.21 14.79L14.79 16.21L17.09 18.5L14.79 20.79L16.21 22.21L18.5 19.91L20.79 22.21L22.21 20.79L19.91 18.5M20.4 6.83L17.18 11L15.6 9.73L16.77 8.23A9.08 9.08 0 0 0 10.11 13.85A4.5 4.5 0 1 1 7.5 13A4 4 0 0 1 8.28 13.08A11.27 11.27 0 0 1 16.43 6.26L15 5.18L16.27 3.6M10 17.5A2.5 2.5 0 1 0 7.5 20A2.5 2.5 0 0 0 10 17.5Z" />
+    </SvgIcon>
+}
+
+export function StorageIcon(props: {
+    x?: number,
+    y?: number,
+    width?: number,
+    height?: number
+} = { x: 0, y: 0, width: 24, height: 24 }) {
+    return <SvgIcon
+        x={props.x}
+        y={props.y}
+        width={props.width}
+        height={props.height}
+        viewBox="0 0 24 24">
+<path fill="currentColor" d="M12,3C7.58,3 4,4.79 4,7C4,9.21 7.58,11 12,11C16.42,11 20,9.21 20,7C20,4.79 16.42,3 12,3M4,9V12C4,14.21 7.58,16 12,16C16.42,16 20,14.21 20,12V9C20,11.21 16.42,13 12,13C7.58,13 4,11.21 4,9M4,14V17C4,19.21 7.58,21 12,21C16.42,21 20,19.21 20,17V14C20,16.21 16.42,18 12,18C7.58,18 4,16.21 4,14Z" />
+</SvgIcon>
 }

--- a/clients/observer/src/store/Store.tsx
+++ b/clients/observer/src/store/Store.tsx
@@ -1,19 +1,22 @@
 // This module contains the redux store definitions and access functions.
 
-import {combineReducers, configureStore, createSlice, PayloadAction} from '@reduxjs/toolkit'
+import { combineReducers, configureStore, createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux"
+import { Organizer } from "../Log/Organizer"
+import { LogEntry } from "../proxies/LogProxy"
+import { CreateSessionUser, SessionUser } from "../proxies/Session"
+import { StepperMode, TimeContext } from "../proxies/StepperProxy"
+import { SettingsState } from "../Settings"
+import { Impacts, NoImpacts } from '../SimulatedController/Constants'
 
-import {StepperMode, TimeContext} from "../proxies/StepperProxy"
-import {TypedUseSelectorHook, useDispatch, useSelector} from "react-redux"
-import {SettingsState} from "../Settings"
-import {CreateSessionUser, SessionUser} from "../proxies/Session"
-import {LogEntry} from "../proxies/LogProxy"
-import {Organizer} from "../Log/Organizer"
 
 // The store consists of slices associated with:
 //   - simulated time (stepper),
 //   - the current server session (logon),
 //   - the display settings (settings),
-//   - the error alert bar (snackbar)
+//   - the error alert bar (snackbar),
+//   - the event log and display,
+//   - the controller element impact map,
 //
 // Each section has the definition for the slice, and the retrieval functions
 // used to select specific information from that slice.
@@ -231,12 +234,42 @@ export const logSelector = (state: StoreSchema) => state.log
 
 // --- Simulation log tracking slice
 
+// +++ Controller impacts slice
+
+export const impactsSlice = createSlice({
+    name: "impacts",
+    initialState: {
+        controllerImpacts: NoImpacts
+    },
+    reducers: {
+        // replace the impact claims with the newly provided ones
+        update: {
+            reducer: (state, action: PayloadAction<Impacts>) => {
+                state.controllerImpacts = action.payload
+            },
+            prepare: (impacts: Impacts) => {
+                return { payload: impacts }
+            }
+        },
+
+        // clear all impact claims
+        clear: (state) => {
+            state.controllerImpacts = NoImpacts
+        }
+    }
+})
+
+export const impactsSelector = (state: StoreSchema) => state.impacts
+
+// --- controller impacts slice
+
 const rootReducer = combineReducers({
     cur: stepperSlice.reducer,
     settings: settingsSlice.reducer,
     snackText: snackbarSlice.reducer,
     session: logonSlice.reducer,
-    log: logSlice.reducer
+    log: logSlice.reducer,
+    impacts: impactsSlice.reducer
 })
 
 export const store = configureStore({


### PR DESCRIPTION
This change provides a skeleton structure for the simulated controller.  It currently just uses a standard Chip element for each controller component.  Each logic element is 'live', in the sense that clicking on it will show read / write relationships to the storage elements.  This is done by modifying the background color.

There is no connection to anything on the server at this point.  This is only to help determine the overall controller pane shape, and what relationships we will want to display in it.  Most of the content here is transitional, and will be radically enhanced / replaced when the actual simulated controller comes online.